### PR TITLE
fix(cdconc): fix identification of missing attributes

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
@@ -4,12 +4,18 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 
 public class ConcretizationCompleter implements ICompletionStrategy {
 
+  private final String mapping;
+
+  public ConcretizationCompleter(String mapping) {
+    this.mapping = mapping;
+  }
+
   @Override
   public ASTCDCompilationUnit complete(ASTCDCompilationUnit rcd, ASTCDCompilationUnit ccd)
       throws CompletionException {
 
-    DefaultTypeIncCompleter typeCompleter = new DefaultTypeIncCompleter(ccd, rcd, "ref");
-    DefaultAssocIncCompleter assocCompleter = new DefaultAssocIncCompleter(ccd, rcd, "ref");
+    DefaultTypeIncCompleter typeCompleter = new DefaultTypeIncCompleter(ccd, rcd, mapping);
+    DefaultAssocIncCompleter assocCompleter = new DefaultAssocIncCompleter(ccd, rcd, mapping);
 
     typeCompleter.completeIncarnations();
     assocCompleter.completeIncarnations();

--- a/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationHelper.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationHelper.java
@@ -3,14 +3,14 @@ package de.monticore.cdconcretization;
 import de.monticore.cdassociation._ast.ASTCDAssocSide;
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdassociation._symboltable.CDRoleSymbol;
-import de.monticore.cdbasis._ast.ASTCDClass;
-import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
-import de.monticore.cdbasis._ast.ASTCDDefinition;
-import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdbasis._ast.*;
 import de.monticore.cdbasis._symboltable.CDTypeSymbol;
 import de.monticore.cdconformance.inc.association.CompAssocIncStrategy;
 import de.monticore.cdconformance.inc.type.CompTypeIncStrategy;
 import de.monticore.cddiff.CDDiffUtil;
+import de.monticore.cdinterfaceandenum._ast.ASTCDEnum;
+import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -224,10 +224,23 @@ public class ConcretizationHelper {
   }
 
   public static void reorderElements(ASTCDDefinition cdDefinition) {
-    List<ASTCDClass> classList = new ArrayList<>(cdDefinition.getCDClassesList());
-    List<ASTCDAssociation> assocList = new ArrayList<>(cdDefinition.getCDAssociationsList());
-    cdDefinition.getCDElementList().clear();
-    cdDefinition.addAllCDElements(classList);
-    cdDefinition.addAllCDElements(assocList);
+    List<ASTCDElement> elements = new ArrayList<>(cdDefinition.getCDElementList());
+    elements.sort(Comparator.comparingInt((element) -> {
+      if (element instanceof ASTCDClass) {
+        return 0;
+      } else if (element instanceof ASTCDInterface) {
+        return 1;
+      } else if (element instanceof ASTCDEnum) {
+        return 2;
+      } else if (element instanceof ASTCDAssociation) {
+        return 3;
+      } else if (element instanceof ASTCDPackage) {
+        return 4;
+      } else {
+        // all other elements at the end
+        return 5;
+      }
+    }));
+    cdDefinition.setCDElementList(elements);
   }
 }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultTypeIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultTypeIncCompleter.java
@@ -142,15 +142,7 @@ public class DefaultTypeIncCompleter implements IIncarnationCompleter<ASTCDType>
             .collect(Collectors.toSet());
 
     for (ASTCDAttribute rAttribute : rAttributeSet) {
-      if (typeInCCD.getCDAttributeList().stream()
-          .noneMatch(
-              cAttribute ->
-                  cAttribute
-                      .getSymbol()
-                      .getFullName()
-                      .equals(rAttribute.getSymbol().getFullName()))) {
-        buildAttributeIncarnation(rAttribute, typeInCCD);
-      }
+      buildAttributeIncarnation(rAttribute, typeInCCD);
     }
   }
 

--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultTypeIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultTypeIncCompleter.java
@@ -1,5 +1,6 @@
 package de.monticore.cdconcretization;
 
+import de.monticore.cd._symboltable.CDSymbolTables;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDClass;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -127,18 +128,19 @@ public class DefaultTypeIncCompleter implements IIncarnationCompleter<ASTCDType>
     enumInCCD.setCDEnumConstantList(processed);
   }
 
-  public void identifyAndAddMissingAttributeIncarnations(
-      ASTCDType typeInCCD, ASTCDType referenceType) {
+  public void identifyAndAddMissingAttributeIncarnations(ASTCDType typeInCCD, ASTCDType referenceType) {
     CompAttributeChecker compAttributeChecker = initAttributeChecker(typeInCCD, referenceType);
+    List<ASTCDAttribute> allConcreteAttributesInHierarchy = CDSymbolTables.getAttributesInHierarchy(typeInCCD);
+
     // Set of all the reference type attributes that have no match with the attributes of the
-    // concrete type
+    // concrete type or any of its superclasses
     Set<ASTCDAttribute> rAttributeSet =
         referenceType.getCDAttributeList().stream()
             .filter(
                 rAttribute ->
-                    typeInCCD.getCDAttributeList().stream()
-                        .noneMatch(
-                            cAttribute -> compAttributeChecker.isMatched(cAttribute, rAttribute)))
+                  allConcreteAttributesInHierarchy.stream()
+                    .noneMatch(
+                      cAttribute -> compAttributeChecker.isMatched(cAttribute, rAttribute)))
             .collect(Collectors.toSet());
 
     for (ASTCDAttribute rAttribute : rAttributeSet) {

--- a/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
@@ -34,43 +34,9 @@ public class ConcretizationCompleterTest {
     BuiltInTypes.addBuiltInTypes(CD4CodeMill.globalScope());
   }
 
-  public void parseModels(String concrete, String ref) {
-    try {
-      Optional<ASTCDCompilationUnit> conCD =
-          CD4CodeMill.parser().parseCDCompilationUnit(dir + concrete);
-      Optional<ASTCDCompilationUnit> refCD = CD4CodeMill.parser().parseCDCompilationUnit(dir + ref);
-      if (conCD.isPresent() && refCD.isPresent()) {
-        CD4CodeMill.scopesGenitorDelegator().createFromAST(conCD.get());
-        CD4CodeMill.scopesGenitorDelegator().createFromAST(refCD.get());
-        conCD.get().accept(new CD4CodeSymbolTableCompleter(conCD.get()).getTraverser());
-        refCD.get().accept(new CD4CodeSymbolTableCompleter(refCD.get()).getTraverser());
-        this.refCD = refCD.get();
-        this.conCD = conCD.get();
-      } else {
-        fail("Could not parse CDs.");
-      }
-
-    } catch (IOException e) {
-      fail(e.getMessage());
-    }
-  }
-
   @Test
-  public void testEvaluation() throws CompletionException {
-    parseModels("ConcEvaluation.cd", "RefEvaluation.cd");
-
-    ConcretizationCompleter completer = new ConcretizationCompleter();
-    completer.complete(refCD, conCD);
-
-    assertTrue(
-        new CDConformanceChecker(
-                Set.of(
-                    STEREOTYPE_MAPPING,
-                    NAME_MAPPING,
-                    SRC_TARGET_ASSOC_MAPPING,
-                    INHERITANCE,
-                    ALLOW_CARD_RESTRICTION))
-            .checkConformance(conCD, refCD, Set.of("ref")));
+  public void testEvaluation() {
+    testConcretizedConformsToRef("ConcEvaluation.cd", "RefEvaluation.cd");
   }
 
   /**
@@ -79,32 +45,14 @@ public class ConcretizationCompleterTest {
    */
   @Test
   @Disabled
-  public void testTypeMissing() throws CompletionException {
-    parseModels("types/valid/ConcTypeMissing.cd", "types/valid/RefTypeMissing.cd");
-    DefaultTypeIncCompleter incarnationCompleter = new DefaultTypeIncCompleter(conCD, refCD, "ref");
-    incarnationCompleter.completeIncarnations();
-    // conCD.getCDDefinition().setName("RefTypeMissing");
-    // System.out.println(CD4CodeMill.prettyPrint(conCD, false));
-    assertTrue(
-        new CDConformanceChecker(
-                Set.of(
-                    STEREOTYPE_MAPPING,
-                    NAME_MAPPING,
-                    SRC_TARGET_ASSOC_MAPPING,
-                    INHERITANCE,
-                    ALLOW_CARD_RESTRICTION))
-            .checkConformance(conCD, refCD, Set.of("ref")));
+  public void testTypeMissing() {
+    testConcretizedConformsToRef("types/valid/ConcTypeMissing.cd", "types/valid/RefTypeMissing.cd");
   }
 
   /** Test that checks if completeInheritance works correctly (after adding the types) */
   @Test
-  public void testTypeMissingInheritance() throws CompletionException {
-    parseModels("inheritance/ConcMissingInheritance.cd", "inheritance/RefMissingInheritance.cd");
-    DefaultTypeIncCompleter incarnationCompleter =
-        new DefaultTypeIncCompleter(conCD, refCD, "incarnates");
-    incarnationCompleter.completeIncarnations();
-    conCD.getCDDefinition().setName("RefMissingInheritance");
-    assertTrue(conCD.deepEquals(refCD, false));
+  public void testTypeMissingInheritance() {
+    testConcretizedEqualsRef("inheritance/ConcMissingInheritance.cd", "inheritance/RefMissingInheritance.cd");
   }
 
   /**
@@ -112,105 +60,45 @@ public class ConcretizationCompleterTest {
    * are added based on predefined CDs.
    */
   @Test
-  public void testMissingAttributes() throws CompletionException {
-    parseModels(
-        "attributes/valid/ConcAttributesMissing.cd", "attributes/valid/RefAttributesMissing.cd");
-    DefaultTypeIncCompleter incarnationCompleter =
-        new DefaultTypeIncCompleter(conCD, refCD, "incarnates");
-
-    conCD.getCDDefinition().setName("RefAttributesMissing");
-    incarnationCompleter.completeIncarnations();
-    assertTrue(conCD.deepEquals(refCD));
+  public void testMissingAttributes() {
+    testConcretizedEqualsRef(
+      "attributes/valid/ConcAttributesMissing.cd",
+      "attributes/valid/RefAttributesMissing.cd");
   }
 
   @Test
-  public void testTwoMissingAttributes() throws CompletionException {
+  public void testTwoMissingAttributes() {
     testConcretizedEqualsRef(
       "attributes/valid/ConcTwoAttributesMissing.cd",
       "attributes/valid/RefTwoAttributesMissing.cd");
   }
 
   @Test
-  public void testTwoMissingAttributesOneMatch() throws CompletionException {
+  public void testTwoMissingAttributesOneMatch() {
     testConcretizedEqualsRef(
       "attributes/valid/ConcTwoAttributesMissingOneMatch.cd",
       "attributes/valid/RefTwoAttributesMissingOneMatch.cd");
   }
 
-  /***
-   * Parses the two models and checks if the concretized CD equals the reference CD.
-   * <br>
-   * Use this to test if basic completion of model elements works, without any application of
-   * explicit incarnation mappings.
-   *
-   * @param conc the path to the concrete CD
-   * @param ref the path to the reference CD
-   * @throws CompletionException
-   */
-  private void testConcretizedEqualsRef(String conc, String ref) throws CompletionException {
-    parseModels(conc, ref);
-    DefaultTypeIncCompleter incarnationCompleter = new DefaultTypeIncCompleter(conCD, refCD, "ref");
-    incarnationCompleter.completeIncarnations();
-    // to use deep equals, both CDs need to have the same name
-    conCD.getCDDefinition().setName(refCD.getCDDefinition().getName());
-    assertTrue(conCD.deepEquals(refCD, false));
+  @Test
+  public void testMissingEnumMember() {
+    testConcretizedConformsToRef(
+      "types/enums/ConcEnumMemberMissing.cd",
+      "types/enums/RefEnumMemberMissing.cd");
   }
 
   @Test
-  public void testMissingEnumMember() throws CompletionException {
-    parseModels("types/enums/ConcEnumMemberMissing.cd", "types/enums/RefEnumMemberMissing.cd");
-    DefaultTypeIncCompleter incarnationCompleter =
-        new DefaultTypeIncCompleter(conCD, refCD, "incarnates");
-    incarnationCompleter.completeIncarnations();
-    conCD.getCDDefinition().setName("RefEnumMemberMissing");
-    // System.out.println(CD4CodeMill.prettyPrint(conCD, false));
-    assertTrue(
-        new CDConformanceChecker(
-                Set.of(
-                    STEREOTYPE_MAPPING,
-                    NAME_MAPPING,
-                    SRC_TARGET_ASSOC_MAPPING,
-                    INHERITANCE,
-                    ALLOW_CARD_RESTRICTION))
-            .checkConformance(conCD, refCD, Set.of("ref")));
+  public void testMultipleIncarnation() {
+    testConcretizedConformsToRef(
+      "multipleIncarnation/ConcMultipleIncarnation.cd",
+      "multipleIncarnation/RefMultipleIncarnation.cd");
   }
 
   @Test
-  public void testMultipleIncarnation() throws CompletionException {
-    parseModels(
-        "multipleIncarnation/ConcMultipleIncarnation.cd",
-        "multipleIncarnation/RefMultipleIncarnation.cd");
-    DefaultTypeIncCompleter incarnationCompleter = new DefaultTypeIncCompleter(conCD, refCD, "ref");
-    incarnationCompleter.completeIncarnations();
-    // System.out.println(CD4CodeMill.prettyPrint(conCD, false));
-
-    assertTrue(
-        new CDConformanceChecker(
-                Set.of(
-                    STEREOTYPE_MAPPING,
-                    NAME_MAPPING,
-                    SRC_TARGET_ASSOC_MAPPING,
-                    INHERITANCE,
-                    ALLOW_CARD_RESTRICTION))
-            .checkConformance(conCD, refCD, Set.of("ref")));
-  }
-
-  @Test
-  public void testMIBothSides() throws CompletionException {
-    parseModels("multipleIncarnation/ConcMIBothSides.cd", "multipleIncarnation/RefMIBothSides.cd");
-
-    ConcretizationCompleter completer = new ConcretizationCompleter();
-    completer.complete(refCD, conCD);
-
-    assertTrue(
-        new CDConformanceChecker(
-                Set.of(
-                    STEREOTYPE_MAPPING,
-                    NAME_MAPPING,
-                    SRC_TARGET_ASSOC_MAPPING,
-                    INHERITANCE,
-                    ALLOW_CARD_RESTRICTION))
-            .checkConformance(conCD, refCD, Set.of("ref")));
+  public void testMIBothSides() {
+    testConcretizedConformsToRef(
+      "multipleIncarnation/ConcMIBothSides.cd",
+      "multipleIncarnation/RefMIBothSides.cd");
   }
 
   @Test
@@ -220,23 +108,9 @@ public class ConcretizationCompleterTest {
 
   /** Test that checks if attributes are inherited in the correct way with a valid example. */
   @Test
-  public void testInheritanceValid() throws CompletionException {
-    parseModels(
-        "inheritance/ConcAttributeInheritance.cd", "inheritance/RefAttributeInheritance.cd");
-    DefaultTypeIncCompleter incarnationCompleter =
-        new DefaultTypeIncCompleter(conCD, refCD, "incarnates");
-    incarnationCompleter.completeIncarnations();
-
-    // System.out.println(CD4CodeMill.prettyPrint(conCD, false));
-    assertTrue(
-        new CDConformanceChecker(
-                Set.of(
-                    STEREOTYPE_MAPPING,
-                    NAME_MAPPING,
-                    SRC_TARGET_ASSOC_MAPPING,
-                    INHERITANCE,
-                    ALLOW_CARD_RESTRICTION))
-            .checkConformance(conCD, refCD, Set.of("ref")));
+  public void testInheritanceValid() {
+    testConcretizedConformsToRef(
+      "inheritance/ConcAttributeInheritance.cd", "inheritance/RefAttributeInheritance.cd");
   }
 
   @Test
@@ -283,141 +157,49 @@ public class ConcretizationCompleterTest {
         "associations/ConcAssociationMissingCardinality.cd",
         "associations/RefAssociationMissingCardinality.cd");
 
-    DefaultAssocIncCompleter incarnationCompleter =
-        new DefaultAssocIncCompleter(conCD, refCD, "incarnates");
-    try {
-      incarnationCompleter.completeIncarnations();
-      conCD.getCDDefinition().setName("RefAssociationMissingCardinality");
-      assertTrue(conCD.deepEquals(refCD, false));
-    } catch (CompletionException e) {
-      fail(e.getMessage());
-    }
+    testConcretizedEqualsRef(
+      "associations/ConcAssociationMissingCardinality.cd",
+      "associations/RefAssociationMissingCardinality.cd");
   }
 
   @Test
   public void testAssocMissingRolename() {
-    parseModels(
-        "associations/ConcAssociationMissingRolename.cd",
-        "associations/RefAssociationMissingRolename.cd");
-
-    DefaultAssocIncCompleter incarnationCompleter =
-        new DefaultAssocIncCompleter(conCD, refCD, "incarnates");
-    try {
-      incarnationCompleter.completeIncarnations();
-      conCD.getCDDefinition().setName("RefAssociationMissingRolename");
-      assertTrue(conCD.deepEquals(refCD));
-    } catch (CompletionException e) {
-      fail(e.getMessage());
-    }
+    testConcretizedEqualsRef(
+      "associations/ConcAssociationMissingRolename.cd",
+      "associations/RefAssociationMissingRolename.cd");
   }
 
   @Test
   public void testAssocMissingFinal() {
-    parseModels(
-        "associations/ConcAssociationMissingFinal.cd",
-        "associations/RefAssociationMissingFinal.cd");
-
-    DefaultAssocIncCompleter incarnationCompleter =
-        new DefaultAssocIncCompleter(conCD, refCD, "incarnates");
-    try {
-      incarnationCompleter.completeIncarnations();
-      // System.out.println(CD4CodeMill.prettyPrint(conCD, false));
-
-      assertTrue(
-          new CDConformanceChecker(
-                  Set.of(
-                      STEREOTYPE_MAPPING,
-                      NAME_MAPPING,
-                      SRC_TARGET_ASSOC_MAPPING,
-                      INHERITANCE,
-                      ALLOW_CARD_RESTRICTION))
-              .checkConformance(conCD, refCD, Set.of("ref")));
-
-    } catch (CompletionException e) {
-      fail(e.getMessage());
-    }
+    testConcretizedConformsToRef(
+      "associations/ConcAssociationMissingFinal.cd",
+      "associations/RefAssociationMissingFinal.cd");
   }
 
   @Test
   public void testAssocMultipleTypeIncarnation() {
-    parseModels(
-        "associations/ConcAssocMultipleTypeIncarnation.cd",
-        "associations/RefAssocMultipleTypeIncarnation.cd");
-
-    DefaultAssocIncCompleter incarnationCompleter =
-        new DefaultAssocIncCompleter(conCD, refCD, "ref");
-    try {
-      incarnationCompleter.completeIncarnations();
-      // System.out.println(CD4CodeMill.prettyPrint(conCD, false));
-
-      assertTrue(
-          new CDConformanceChecker(
-                  Set.of(
-                      STEREOTYPE_MAPPING,
-                      NAME_MAPPING,
-                      SRC_TARGET_ASSOC_MAPPING,
-                      INHERITANCE,
-                      ALLOW_CARD_RESTRICTION))
-              .checkConformance(conCD, refCD, Set.of("ref")));
-
-    } catch (CompletionException e) {
-      fail(e.getMessage());
-    }
+    testConcretizedConformsToRef(
+      "associations/ConcAssocMultipleTypeIncarnation.cd",
+      "associations/RefAssocMultipleTypeIncarnation.cd");
   }
 
   @Test
   public void testAssociationReverseMatch() {
-    parseModels(
-        "associations/ConcAssociationReverseMatch.cd",
-        "associations/RefAssociationReverseMatch.cd");
-
-    DefaultAssocIncCompleter incarnationCompleter =
-        new DefaultAssocIncCompleter(conCD, refCD, "ref");
-    try {
-      incarnationCompleter.completeIncarnations();
-
-      assertTrue(
-          new CDConformanceChecker(
-                  Set.of(
-                      STEREOTYPE_MAPPING,
-                      NAME_MAPPING,
-                      SRC_TARGET_ASSOC_MAPPING,
-                      INHERITANCE,
-                      ALLOW_CARD_RESTRICTION))
-              .checkConformance(conCD, refCD, Set.of("ref")));
-
-    } catch (CompletionException e) {
-      fail(e.getMessage());
-    }
+    testConcretizedConformsToRef(
+      "associations/ConcAssociationReverseMatch.cd",
+      "associations/RefAssociationReverseMatch.cd");
   }
 
   @Test
   public void testAssocRename() {
-    parseModels("associations/ConcAssocRename.cd", "associations/RefAssocRename.cd");
-
-    DefaultAssocIncCompleter incarnationCompleter =
-        new DefaultAssocIncCompleter(conCD, refCD, "ref");
-    try {
-      incarnationCompleter.completeIncarnations();
-
-      assertTrue(
-          new CDConformanceChecker(
-                  Set.of(
-                      STEREOTYPE_MAPPING,
-                      NAME_MAPPING,
-                      SRC_TARGET_ASSOC_MAPPING,
-                      INHERITANCE,
-                      ALLOW_CARD_RESTRICTION))
-              .checkConformance(conCD, refCD, Set.of("ref")));
-
-    } catch (CompletionException e) {
-      fail(e.getMessage());
-    }
+    testConcretizedConformsToRef(
+      "associations/ConcAssocRename.cd",
+      "associations/RefAssocRename.cd");
   }
 
   // ConcretizationHelper tests
   @Test
-  public void testCDHelperMappings() throws CompletionException {
+  public void testCDHelperMappings() throws CompletionException{
     parseModels("helper/ConcHelper.cd", "helper/RefHelper.cd");
 
     DefaultTypeIncCompleter defaultTypeIncCompleter =
@@ -495,5 +277,81 @@ public class ConcretizationCompleterTest {
     assertEquals(actualMapTemp3, expectedMap3);
 
      */
+  }
+
+  /***
+   * Parses the two models and checks if the concretized CD equals the reference CD.
+   * <br>
+   * Use this to test if basic completion of model elements works, without any application of
+   * explicit incarnation mappings.
+   *
+   * @param conc the path to the concrete CD
+   * @param ref the path to the reference CD
+   */
+  private void testConcretizedEqualsRef(String conc, String ref) {
+    try {
+      parseAndConcretize(conc, ref);
+    } catch (CompletionException e) {
+      fail("CompletionException", e);
+    }
+
+    // to use deep equals, both CDs need to have the same name
+    conCD.getCDDefinition().setName(refCD.getCDDefinition().getName());
+    assertTrue(conCD.deepEquals(refCD, false));
+  }
+
+  /**
+   * Parses the two models and checks if the concretized CD conforms to the reference CD.
+   * <br>
+   * Use this for all non-trivial test cases where the concretization is no longer expected to equal
+   * to the reference CD.
+   *
+   * @param conc the path to the concrete CC
+   * @param ref the path to the reference CD
+   */
+  private void testConcretizedConformsToRef(String conc, String ref) {
+    try {
+      parseAndConcretize(conc, ref);
+    } catch (CompletionException e) {
+      fail("CompletionException", e);
+    }
+    assertTrue(
+      new CDConformanceChecker(
+        Set.of(
+          STEREOTYPE_MAPPING,
+          NAME_MAPPING,
+          SRC_TARGET_ASSOC_MAPPING,
+          INHERITANCE,
+          ALLOW_CARD_RESTRICTION))
+        .checkConformance(conCD, refCD, Set.of("ref")));
+  }
+
+  private void parseAndConcretize(String conc, String ref) throws CompletionException {
+    parseModels(conc, ref);
+    ConcretizationCompleter completer = new ConcretizationCompleter("ref");
+    completer.complete(refCD, conCD);
+    System.out.println("Concretized CD:");
+    System.out.println(CD4CodeMill.prettyPrint(conCD, false));
+  }
+
+  private void parseModels(String concrete, String ref) {
+    try {
+      Optional<ASTCDCompilationUnit> conCD =
+        CD4CodeMill.parser().parseCDCompilationUnit(dir + concrete);
+      Optional<ASTCDCompilationUnit> refCD = CD4CodeMill.parser().parseCDCompilationUnit(dir + ref);
+      if (conCD.isPresent() && refCD.isPresent()) {
+        CD4CodeMill.scopesGenitorDelegator().createFromAST(conCD.get());
+        CD4CodeMill.scopesGenitorDelegator().createFromAST(refCD.get());
+        conCD.get().accept(new CD4CodeSymbolTableCompleter(conCD.get()).getTraverser());
+        refCD.get().accept(new CD4CodeSymbolTableCompleter(refCD.get()).getTraverser());
+        this.refCD = refCD.get();
+        this.conCD = conCD.get();
+      } else {
+        fail("Could not parse CDs.");
+      }
+
+    } catch (IOException e) {
+      fail(e);
+    }
   }
 }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
@@ -124,6 +124,39 @@ public class ConcretizationCompleterTest {
   }
 
   @Test
+  public void testTwoMissingAttributes() throws CompletionException {
+    testConcretizedEqualsRef(
+      "attributes/valid/ConcTwoAttributesMissing.cd",
+      "attributes/valid/RefTwoAttributesMissing.cd");
+  }
+
+  @Test
+  public void testTwoMissingAttributesOneMatch() throws CompletionException {
+    testConcretizedEqualsRef(
+      "attributes/valid/ConcTwoAttributesMissingOneMatch.cd",
+      "attributes/valid/RefTwoAttributesMissingOneMatch.cd");
+  }
+
+  /***
+   * Parses the two models and checks if the concretized CD equals the reference CD.
+   * <br>
+   * Use this to test if basic completion of model elements works, without any application of
+   * explicit incarnation mappings.
+   *
+   * @param conc the path to the concrete CD
+   * @param ref the path to the reference CD
+   * @throws CompletionException
+   */
+  private void testConcretizedEqualsRef(String conc, String ref) throws CompletionException {
+    parseModels(conc, ref);
+    DefaultTypeIncCompleter incarnationCompleter = new DefaultTypeIncCompleter(conCD, refCD, "ref");
+    incarnationCompleter.completeIncarnations();
+    // to use deep equals, both CDs need to have the same name
+    conCD.getCDDefinition().setName(refCD.getCDDefinition().getName());
+    assertTrue(conCD.deepEquals(refCD, false));
+  }
+
+  @Test
   public void testMissingEnumMember() throws CompletionException {
     parseModels("types/enums/ConcEnumMemberMissing.cd", "types/enums/RefEnumMemberMissing.cd");
     DefaultTypeIncCompleter incarnationCompleter =

--- a/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
@@ -7,6 +7,7 @@ import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._symboltable.CD4CodeSymbolTableCompleter;
 import de.monticore.cdassociation._symboltable.CDRoleSymbol;
+import de.monticore.cdbasis._ast.ASTCDClass;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._symboltable.CDTypeSymbol;
 import de.monticore.cdconformance.CDConformanceChecker;
@@ -78,6 +79,56 @@ public class ConcretizationCompleterTest {
     testConcretizedEqualsRef(
       "attributes/valid/ConcTwoAttributesMissingOneMatch.cd",
       "attributes/valid/RefTwoAttributesMissingOneMatch.cd");
+  }
+
+  /**
+   * The attributes expected by the reference class are already present in the direct superclass of
+   * 'Employee'. The concretization should not add them again.
+   */
+  @Test
+  public void testAttributeExistsInConcreteSuperclass() {
+    testConcretizedConformsToRef(
+      "attributes/valid/ConcAttributeInSuperClass.cd",
+      "attributes/valid/RefAttributeInSuperClass.cd");
+
+    // The conformance check is not enough here. The tool must not add attributes to the concrete class if they
+    // are already inherited from a superclass.
+    List<String> attributesInSuperclass = Arrays.asList("firstName", "lastName");
+
+    ASTCDClass employeeClass = conCD.getCDDefinition().getCDClassesList().stream()
+      .filter(cdClass -> cdClass.getName().equals("Employee"))
+      .findFirst().orElseThrow();
+    employeeClass.getCDAttributeList().stream()
+      .filter(cdAttribute -> attributesInSuperclass.contains(cdAttribute.getName()))
+      .findAny().ifPresent(cdAttribute -> {
+        fail("Attribute " + cdAttribute + " should not be added to the concrete class 'Employee' as it is already " +
+          "inherited from the superclass 'Person'");
+    });
+  }
+
+  /**
+   * The attributes expected by the reference class are already present "deep" in the class hierarchy of
+   * 'Employee'. The concretization should not add them again.
+   */
+  @Test
+  public void testAttributeExistsInConcreteDeepSuperclass() {
+    testConcretizedConformsToRef(
+      "attributes/valid/ConcAttributeInDeepSuperClass.cd",
+      "attributes/valid/RefAttributeInDeepSuperClass.cd");
+
+    // The conformance check is not enough here. The tool must not add attributes to the concrete class if they
+    // are already inherited from a superclass.
+    List<String> attributesInSuperclass = Arrays.asList("firstName", "lastName");
+
+    ASTCDClass employeeClass = conCD.getCDDefinition().getCDClassesList().stream()
+      .filter(cdClass -> cdClass.getName().equals("Employee"))
+      .findFirst().orElseThrow();
+    employeeClass.getCDAttributeList().stream()
+      .filter(cdAttribute -> attributesInSuperclass.contains(cdAttribute.getName()))
+      .findAny().ifPresent(cdAttribute -> {
+        fail("Attribute " + cdAttribute + " should not be added to the concrete class 'Employee' as it is already " +
+          "inherited from the superclass 'Person'");
+      });
   }
 
   @Test

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/ConcAttributeInDeepSuperClass.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/ConcAttributeInDeepSuperClass.cd
@@ -1,0 +1,16 @@
+import java.lang.String;
+
+classdiagram ConcAttributeInSuperClass {
+  class Person {
+    String firstName;
+    String lastName;
+  }
+
+  class AbstractEmployee extends Person {
+    String someOtherProperty;
+  }
+
+  class Employee extends AbstractEmployee {
+    int number;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/ConcAttributeInSuperClass.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/ConcAttributeInSuperClass.cd
@@ -1,0 +1,12 @@
+import java.lang.String;
+
+classdiagram ConcAttributeInSuperClass {
+  class Person {
+    String firstName;
+    String lastName;
+  }
+
+  class Employee extends Person {
+    int number;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/ConcTwoAttributesMissing.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/ConcTwoAttributesMissing.cd
@@ -1,0 +1,4 @@
+classdiagram ConcTwoAttributesMissing {
+  class Employee {
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/ConcTwoAttributesMissingOneMatch.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/ConcTwoAttributesMissingOneMatch.cd
@@ -1,0 +1,5 @@
+classdiagram ConcTwoAttributesMissingOneMatch {
+  class Employee {
+    int number;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/RefAttributeInDeepSuperClass.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/RefAttributeInDeepSuperClass.cd
@@ -1,0 +1,10 @@
+import java.lang.String;
+
+classdiagram RefAttributesMissing {
+  class Employee {
+    String firstName;
+    String lastName;
+    int number;
+    int salary;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/RefAttributeInSuperClass.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/RefAttributeInSuperClass.cd
@@ -1,0 +1,10 @@
+import java.lang.String;
+
+classdiagram RefAttributesMissing {
+  class Employee {
+    String firstName;
+    String lastName;
+    int number;
+    int salary;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/RefTwoAttributesMissing.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/RefTwoAttributesMissing.cd
@@ -1,0 +1,6 @@
+classdiagram RefTwoAttributesMissing {
+  class Employee {
+    int number;
+    int salary;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/RefTwoAttributesMissingOneMatch.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/valid/RefTwoAttributesMissingOneMatch.cd
@@ -1,0 +1,7 @@
+classdiagram RefTwoAttributesMissingOneMatch {
+  class Employee {
+    int number;
+    int anotherNumber;
+    int salary;
+  }
+}


### PR DESCRIPTION
## What?
- Remove buggy comparison of attribute symbol names when adding missing attributes to concrete CD.
- Fixed `identifyAndAddMissingAttributeIncarnations(...)` to consider attribiutes in superclass as well
- fixed `Concretizationhelper.reorderElements(...)` to really reorder. Previously, enums, interfaces and package definitions were dropped completely!
- Cleanup of test cases:
  - remove duplicated code
  - all test cases now execute the "full concretization" using `ConcretizationCompleter.complete(ref, conc)` so we have a more uniform setup

## Why?
- Concretization tools fails with MontiCore error exit if reference and concrete class differ in more than one attribute (see simple examples in PR)
- `cAttribute.getSymbol().getFullName()` fails because in second iteration the previously added attribute is checked for a match. The new AST instance has no symbol information generated yet.
- Comparision by full symbol name makes no sense in the first place. The reference and concrete CD could have different names which results in all attribute, class symbols etc. being different. Also, we use the `MatchingStrategy` abstraction before to find all attributes that need to be added.
- test cases were 

## Test
- Added two basic test cases covering more than one attribute difference
- Added two test cases for attributes existing in superclasses