### PR TITLE
refactor(cdconc): refactor DefaultAssocIncCompleter & add more test cases

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
@@ -172,7 +172,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       }
     }
 
-    completeAssociation(cAssoc, rAssoc, match);
+    completeAssociation(cAssoc, rAssoc, match ? AssocMatchDirection.SAME_DIRECTION : AssocMatchDirection.REVERSE_DIRECTION);
   }
 
   /***
@@ -180,27 +180,29 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
    *
    * @param cAssoc The concrete association to complete
    * @param rAssoc The reference association to use for completion
-   * @param matchInSameDirection A boolean indicating whether the associations match in the same
-   *                             direction (left-left, right-right) or reverse (left-right,
-   *                             right-left).
+   * @param matchDirection indicating whether the associations match in the same direction
+   *                       (left-left, right-right) or reverse (left-right, right-left).
    * @throws CompletionException
    */
-  private void completeAssociation(ASTCDAssociation cAssoc, ASTCDAssociation rAssoc, boolean matchInSameDirection) throws CompletionException {
+  private void completeAssociation(ASTCDAssociation cAssoc, ASTCDAssociation rAssoc, AssocMatchDirection matchDirection) throws CompletionException {
     completeAssociationName(cAssoc, rAssoc);
 
-    if (matchInSameDirection) {
-      completeAssocNavigability(cAssoc, rAssoc);
-      completeAssocCardinality(cAssoc.getLeft(), rAssoc.getLeft());
-      completeAssocCardinality(cAssoc.getRight(), rAssoc.getRight());
-      completeAssociationRoleNames(cAssoc.getLeft(), rAssoc.getLeft());
-      completeAssociationRoleNames(cAssoc.getRight(), rAssoc.getRight());
-    } else {
-      // If the match is in reverse, complete the association properties for alternating sides.
-      completeAssocNavigabilityReverse(cAssoc, rAssoc);
-      completeAssocCardinality(cAssoc.getLeft(), rAssoc.getRight());
-      completeAssocCardinality(cAssoc.getRight(), rAssoc.getLeft());
-      completeAssociationRoleNames(cAssoc.getLeft(), rAssoc.getRight());
-      completeAssociationRoleNames(cAssoc.getRight(), rAssoc.getLeft());
+    switch (matchDirection) {
+      case SAME_DIRECTION:
+        completeAssocNavigability(cAssoc, rAssoc);
+        completeAssocCardinality(cAssoc.getLeft(), rAssoc.getLeft());
+        completeAssocCardinality(cAssoc.getRight(), rAssoc.getRight());
+        completeAssociationRoleNames(cAssoc.getLeft(), rAssoc.getLeft());
+        completeAssociationRoleNames(cAssoc.getRight(), rAssoc.getRight());
+        break;
+      case REVERSE_DIRECTION:
+        // If the match is in reverse, complete the association properties for alternating sides.
+        completeAssocNavigabilityReverse(cAssoc, rAssoc);
+        completeAssocCardinality(cAssoc.getLeft(), rAssoc.getRight());
+        completeAssocCardinality(cAssoc.getRight(), rAssoc.getLeft());
+        completeAssociationRoleNames(cAssoc.getLeft(), rAssoc.getRight());
+        completeAssociationRoleNames(cAssoc.getRight(), rAssoc.getLeft());
+        break;
     }
 
     // Handle potential role name conflicts in a post-processing step
@@ -438,7 +440,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
           assocIncarnations,
           assocGreedyMatches,
           ccd.getCDDefinition(),
-          rAssoc);
+          rAssoc, true);
 
       // Then, process right-type incarnations against left-type incarnations
       processTypeIncarnations(
@@ -448,7 +450,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
           assocIncarnations,
           assocGreedyMatches,
           ccd.getCDDefinition(),
-          rAssoc);
+          rAssoc, false);
 
       CDDiffUtil.refreshSymbolTable(ccd);
 
@@ -477,6 +479,8 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
    * @param assocGreedyMatches greedy matches for the reference association to process
    * @param cd the CONCRETE class diagram
    * @param rAssoc the reference association to process
+   * @param leftToRight indicates if we process left types against right types (true) or vice versa (false).
+   *                    This indicates whether the 'typeInc2Process' set contains left or right type incarnations.
    * @throws CompletionException
    */
   private void processTypeIncarnations(
@@ -486,7 +490,8 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       Set<ASTCDAssociation> assocIncarnations,
       Set<ASTCDAssociation> assocGreedyMatches,
       ASTCDDefinition cd,
-      ASTCDAssociation rAssoc)
+      ASTCDAssociation rAssoc,
+      boolean leftToRight)
       throws CompletionException {
 
     // Iterate over each type incarnation in rTypeIncarnation
@@ -495,8 +500,8 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       Set<ASTCDType> superTypes = CDDiffUtil.getAllSuperTypes(typeInc, cd);
 
       // First, attempt to find a match among the specific association incarnations
-      Optional<ASTCDAssociation> match =
-          findAssociationToAnyOppositeTypeInc(superTypes, rOppositeTypeIncarnations, assocIncarnations, cd);
+      Optional<AssociationMatch> match =
+          findAssociationToAnyOppositeTypeInc(superTypes, rOppositeTypeIncarnations, assocIncarnations, cd, leftToRight);
 
       // If a match is found, remove the current type incarnation from the set to be processed and
       // continue
@@ -505,13 +510,13 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
         // NOTE: we do not call "handleAssociation" here, because we already processed the match in the step before
         Log.debug("Found normal match for type inc: " + typeInc.getName(), LOG_NAME);
         Log.debug("reference assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
-        Log.debug("concrete assoc: " + CD4CodeMill.prettyPrint(match.get(), false), LOG_NAME);
+        Log.debug("concrete assoc: " + CD4CodeMill.prettyPrint(match.get().getAssociation(), false), LOG_NAME);
         continue;
       }
 
       if (greedyMatcherEnabled) {
         // If no match is found in specific incarnations, try matching against the greedy matches
-        match = findAssociationToAnyOppositeTypeInc(superTypes, rOppositeTypeIncarnations, assocGreedyMatches, cd);
+        match = findAssociationToAnyOppositeTypeInc(superTypes, rOppositeTypeIncarnations, assocGreedyMatches, cd, leftToRight);
 
         // If a match is found among the greedy matches, remove the current type incarnation from the
         // set to be processed
@@ -520,9 +525,11 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
           typeInc2Process.remove(typeInc);
           Log.debug("Found GREEDY match for type inc: " + typeInc.getName(), LOG_NAME);
           Log.debug("reference assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
-          Log.debug("concrete assoc: " + CD4CodeMill.prettyPrint(match.get(), false), LOG_NAME);
+          Log.debug("concrete assoc: " + CD4CodeMill.prettyPrint(match.get().getAssociation(), false), LOG_NAME);
           Log.debug("completing greedy match", LOG_NAME);
-          handleAssociation(match.get(), rAssoc);
+          // instead of handleAssociation(...) we call completeAssociation(...) here because we already
+          // know in what direction the match is
+          completeAssociation(match.get().getAssociation(), rAssoc, match.get().getMatchDirection());
         }
       }
     }
@@ -536,15 +543,17 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
    * @param oppositeTypeIncarnations all incarnations of the type on the "other side" of the association
    * @param associations the set of concrete associations to check for a match
    * @param cd the concrete CD
+   * @param leftToRight indicates if we process left types against right types (true) or vice versa (false).
    * @return an association from the given set that connect one of the superTypes with one of the
    * oppositeTypeIncarnations.
    * @throws CompletionException
    */
-  private Optional<ASTCDAssociation> findAssociationToAnyOppositeTypeInc(
+  private Optional<AssociationMatch> findAssociationToAnyOppositeTypeInc(
       Set<ASTCDType> superTypes,
       Set<ASTCDType> oppositeTypeIncarnations,
       Set<ASTCDAssociation> associations,
-      ASTCDDefinition cd)
+      ASTCDDefinition cd,
+      boolean leftToRight)
       throws CompletionException {
 
     // For each type in the oppositeTypeIncarnations set we also check the super types
@@ -554,8 +563,10 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
 
     for (ASTCDAssociation assoc : associations) {
       // Check if the association "assoc" relates any of the superTypes with any of the oppositeTypeIncarnations (or its super types) (??)
-      if (checkAssociationMatchesTypes(superTypes, oppositeTypeIncarnationSuperTypes, assoc)) {
-        return Optional.of(assoc); // Match found, return the association
+      Optional<AssocMatchDirection> matchDirection = checkAssociationMatchesTypes(superTypes, oppositeTypeIncarnationSuperTypes, assoc, leftToRight);
+      if (matchDirection.isPresent()) {
+        // Match found, return the association
+        return Optional.of(new AssociationMatch(assoc, matchDirection.get()));
       }
     }
     return Optional.empty(); // No match found, return empty
@@ -627,13 +638,16 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
    * @param typesSideA the set (A) of types to check for on one side of the association
    * @param typesSideB the set (B) of types to check for on the other side of the association
    * @param assoc the CONCRETE association to check for a match
-   * @return true if the association relates any of the types from set A with any of the types from
+   * @param leftToRight indicates if we process left types against right types (true) or vice versa (false).
+   * @return if the association relates any of the types from set A with any of the types from set
+   *     B, return the direction of the match (same or reverse), otherwise return empty.
    * @throws CompletionException
    */
-  private boolean checkAssociationMatchesTypes(
+  private Optional<AssocMatchDirection> checkAssociationMatchesTypes(
       Set<ASTCDType> typesSideA,
       Set<ASTCDType> typesSideB,
-      ASTCDAssociation assoc)
+      ASTCDAssociation assoc,
+      boolean leftToRight)
       throws CompletionException {
 
     boolean fail = false;
@@ -659,7 +673,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
                       .getSymbol()
                       .getInternalQualifiedName()
                       .contains(assoc.getRightQualifiedName().getQName()))) { // TODO why contains?? - if because CD names can differ -> remove first part
-        return true;
+        return Optional.of(leftToRight ? AssocMatchDirection.SAME_DIRECTION : AssocMatchDirection.REVERSE_DIRECTION);
       }
       fail = true; // TODO analyze what this fail means!
     }
@@ -685,7 +699,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
                       .getSymbol()
                       .getInternalQualifiedName()
                       .contains(assoc.getLeftQualifiedName().getQName()))) {
-        return true;
+        return Optional.of(leftToRight ? AssocMatchDirection.REVERSE_DIRECTION : AssocMatchDirection.SAME_DIRECTION);
       }
       fail = true;
     }
@@ -693,6 +707,38 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       throw new CompletionException(
           "Something went wrong when identifying missing association incarnations.");
     }
-    return false;
+    return Optional.empty();
+  }
+
+  enum AssocMatchDirection {
+    /**
+     * The association matches in the same direction as the reference association.
+     * i.e. left-left, right-right
+     */
+    SAME_DIRECTION,
+
+    /**
+     * The association matches in the reverse direction as the reference association.
+     * i.e. left-right, right-left
+     */
+    REVERSE_DIRECTION;
+  }
+
+  static class AssociationMatch {
+    private final ASTCDAssociation association;
+    private final AssocMatchDirection matchDirection;
+
+    public AssociationMatch(ASTCDAssociation association, AssocMatchDirection matchDirection) {
+      this.association = association;
+      this.matchDirection = matchDirection;
+    }
+
+    public ASTCDAssociation getAssociation() {
+      return association;
+    }
+
+    public AssocMatchDirection getMatchDirection() {
+      return matchDirection;
+    }
   }
 }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
@@ -458,11 +458,10 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
 
       // Finally, process any remaining type incarnations that still need to be handled
       // Process the remaining left-type incarnations against right-type incarnations
-      processTypeInc2Process(leftTypeInc2Process, rRightTypeIncarnations, rAssoc, true);
+      addAssociationIncarnations(leftTypeInc2Process, rRightTypeIncarnations, rAssoc);
 
       // Process the remaining right-type incarnations against left-type incarnations
-      // TODO Can't we just pass right and left lists in the same order and get rid of the boolean?
-      processTypeInc2Process(rightTypeInc2Process, rLeftTypeIncarnations, rAssoc, false);
+      addAssociationIncarnations(rLeftTypeIncarnations, rightTypeInc2Process, rAssoc);
       Log.debug("=== DONE processing assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
     }
   }
@@ -563,103 +562,56 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
   }
 
   /**
-   * Creates missing incarnations for the given type incarnations and the reference association.
-   * For each pair of typeInc2Process and otherTypeIncs, a new association is created based on the
-   * reference association.
+   * Creates incarnations if a reference association for the given sets of left and right type
+   * incarnations.
+   * For each pair of left and right type incarnations, a new association is created.
    *
-   * @param typeInc2Process the type incarnations for which we want to create missing incarnations
-   * @param otherTypeIncs the types to which we want to create missing incarnations
-   * @param rAssoc the reference association for which we want to create missing incarnations
-   * @param isLeftToRight If true, the left type of the new association is the type from
-   *                      'typeInc2Process' and the right type is from otherTypeIncs. If false, it is
-   *                      the other way around.
+   * @param leftTypesIncs the left type incarnations missing an association
+   * @param rightTypeIncs the right type incarnations missing an association
+   * @param referenceAssociation the reference association for which we want to create missing incarnations
    */
+  private void addAssociationIncarnations(
+      Set<ASTCDType> leftTypesIncs,
+      Set<ASTCDType> rightTypeIncs,
+      ASTCDAssociation referenceAssociation) {
 
-  private void processTypeInc2Process(
-      Set<ASTCDType> typeInc2Process,
-      Set<ASTCDType> otherTypeIncs,
-      ASTCDAssociation rAssoc,
-      boolean isLeftToRight) {
+    for (ASTCDType leftTypeInc : leftTypesIncs) {
+      for (ASTCDType rightTypeInc : rightTypeIncs) {
+        ASTCDAssociation association = referenceAssociation.deepClone();
 
-    // Iterate over each type incarnation in typeInc2Process
-    for (ASTCDType typeInc : typeInc2Process) {
-      // For each type incarnation in typeInc2Process, iterate over each type incarnation in
-      // otherTypeIncs
-      for (ASTCDType otherTypeInc : otherTypeIncs) {
-        ASTCDAssociation association = rAssoc.deepClone();
+        // Set the left and right types of the association based on the type incarnations
+        association.getLeft().setMCQualifiedType(
+                CD4CodeMill.mCQualifiedTypeBuilder()
+                        .setMCQualifiedName(MCQualifiedNameFacade.createQualifiedName(
+                                leftTypeInc.getSymbol().getInternalQualifiedName()))
+                        .build());
+        association.getRight().setMCQualifiedType(
+                CD4CodeMill.mCQualifiedTypeBuilder()
+                        .setMCQualifiedName(MCQualifiedNameFacade.createQualifiedName(
+                                rightTypeInc.getSymbol().getInternalQualifiedName()))
+                        .build());
 
-        // Set the qualified names for the association's left and right types based on the direction
-        if (isLeftToRight) {
-          // Set the left type to the current type incarnation and the right type to the other type
-          // incarnation
+        // If the right type does not have a role name, it is implicitly the type incarnation's
+        // name (first character lowercase) anyway.
+        if (association.getRight().isPresentCDRole()) {
+          // If a role name is already present, append the type incarnation's name to it
           association
-              .getLeft()
-              .setMCQualifiedType(
-                  CD4CodeMill.mCQualifiedTypeBuilder()
-                      .setMCQualifiedName(
-                          MCQualifiedNameFacade.createQualifiedName(
-                              typeInc.getSymbol().getInternalQualifiedName()))
-                      .build());
+                  .getRight()
+                  .getCDRole()
+                  .setName(
+                          association.getRight().getCDRole().getName() + "_" + rightTypeInc.getName());
+        }
+        if (association.getLeft().isPresentCDRole()) {
           association
-              .getRight()
-              .setMCQualifiedType(
-                  CD4CodeMill.mCQualifiedTypeBuilder()
-                      .setMCQualifiedName(
-                          MCQualifiedNameFacade.createQualifiedName(
-                              otherTypeInc.getSymbol().getInternalQualifiedName()))
-                      .build());
-
-          // If the right type does not have a role name, set it to the type incarnation's name
-          if (association.getRight().isPresentCDRole()) {
-            // If a role name is already present, append the type incarnation's name to it
-            association
-                .getRight()
-                .getCDRole()
-                .setName(
-                    association.getRight().getCDRole().getName() + "_" + otherTypeInc.getName());
-          }
-          if (association.getLeft().isPresentCDRole()) {
-            association
-                .getLeft()
-                .getCDRole()
-                .setName(association.getLeft().getCDRole().getName() + "_" + typeInc.getName());
-          }
-
-        } else {
-          // Set the left type to the other type incarnation and the right type to the current type
-          // incarnation
-          association
-              .getLeft()
-              .setMCQualifiedType(
-                  CD4CodeMill.mCQualifiedTypeBuilder()
-                      .setMCQualifiedName(
-                          MCQualifiedNameFacade.createQualifiedName(
-                              otherTypeInc.getSymbol().getInternalQualifiedName()))
-                      .build());
-          association
-              .getRight()
-              .setMCQualifiedType(
-                  CD4CodeMill.mCQualifiedTypeBuilder()
-                      .setMCQualifiedName(
-                          MCQualifiedNameFacade.createQualifiedName(
-                              typeInc.getSymbol().getInternalQualifiedName()))
-                      .build());
-
-          if (association.getLeft().isPresentCDRole()) {
-            association
-                .getLeft()
-                .getCDRole()
-                .setName(
-                    association.getLeft().getCDRole().getName() + "_" + otherTypeInc.getName());
-          }
-          if (association.getRight().isPresentCDRole()) {
-            association
-                .getRight()
-                .getCDRole()
-                .setName(association.getRight().getCDRole().getName() + "_" + typeInc.getName());
-          }
+                  .getLeft()
+                  .getCDRole()
+                  .setName(association.getLeft().getCDRole().getName() + "_" + leftTypeInc.getName());
         }
 
+        // Only add it if it is not already present. This can happen if the same type incarnation
+        // occurs in the "leftType2Process" set while processing "left types" missing an association
+        // and after that in the "allLeftTypeIncs" set while processing the "right types" missing
+        // an association.
         if (ccd.getCDDefinition().getCDAssociationsList().stream()
             .noneMatch(a -> a.deepEquals(association))) {
           ccd.getCDDefinition().addCDElement(association);

--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
@@ -710,6 +710,10 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     return Optional.empty();
   }
 
+  public CompAssocIncStrategy getCompAssocIncStrategy() {
+    return compAssocIncStrategy;
+  }
+
   enum AssocMatchDirection {
     /**
      * The association matches in the same direction as the reference association.

--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
@@ -467,14 +467,13 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
   }
 
   /**
-   * GUESS: Process the type incarnations to find and handle matching associations.
+   * Process the type incarnations to find and handle matching associations.
    *    -> so we still try to find more matches than we found in the step before.
    *
    * @param rTypeIncarnation all incarnation of the one side of the association
    * @param rOppositeTypeIncarnations all incarnation of the other side of the association
    * @param typeInc2Process Subset of 'rTypeIncarnation' (?) that still needs an incarnation of the reference association (??)
    * @param assocIncarnations "normal" matches from the association matching strategy -> NOTE: these were processed before in step 4 by handleAssociation(...)
-   *                          Although handleAssociations can abort the processing, so we could match them again ??
    * @param assocGreedyMatches greedy matches for the reference association to process
    * @param cd the CONCRETE class diagram
    * @param rAssoc the reference association to process
@@ -497,7 +496,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
 
       // First, attempt to find a match among the specific association incarnations
       Optional<ASTCDAssociation> match =
-          processAssociations(superTypes, rOppositeTypeIncarnations, assocIncarnations, cd);
+          findAssociationToAnyOppositeTypeInc(superTypes, rOppositeTypeIncarnations, assocIncarnations, cd);
 
       // If a match is found, remove the current type incarnation from the set to be processed and
       // continue
@@ -512,7 +511,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
 
       if (greedyMatcherEnabled) {
         // If no match is found in specific incarnations, try matching against the greedy matches
-        match = processAssociations(superTypes, rOppositeTypeIncarnations, assocGreedyMatches, cd);
+        match = findAssociationToAnyOppositeTypeInc(superTypes, rOppositeTypeIncarnations, assocGreedyMatches, cd);
 
         // If a match is found among the greedy matches, remove the current type incarnation from the
         // set to be processed
@@ -530,31 +529,32 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
   }
 
   /**
-   * GUESS: Finds any association in the given set that "associates" one of the superTypes with
-   *        one if the "oppositeTypeIncarnations".
+   * Finds any association in the given set that "associates" one of the superTypes with one if the
+   * "oppositeTypeIncarnations".
    *
    * @param superTypes all concrete super types of the "one side" of the association
    * @param oppositeTypeIncarnations all incarnations of the type on the "other side" of the association
    * @param associations the set of concrete associations to check for a match
    * @param cd the concrete CD
-   * @return
+   * @return an association from the given set that connect one of the superTypes with one of the
+   * oppositeTypeIncarnations.
    * @throws CompletionException
    */
-  // TODO name change proposal: findMatchingConcreteAssociationInSuperTypes
-  private Optional<ASTCDAssociation> processAssociations(
+  private Optional<ASTCDAssociation> findAssociationToAnyOppositeTypeInc(
       Set<ASTCDType> superTypes,
       Set<ASTCDType> oppositeTypeIncarnations,
       Set<ASTCDAssociation> associations,
       ASTCDDefinition cd)
       throws CompletionException {
+
+    // For each type in the oppositeTypeIncarnations set we also check the super types
+    Set<ASTCDType> oppositeTypeIncarnationSuperTypes = oppositeTypeIncarnations.stream()
+            .flatMap(oType -> CDDiffUtil.getAllSuperTypes(oType, cd).stream())
+            .collect(Collectors.toSet());
+
     for (ASTCDAssociation assoc : associations) {
-      // Check if there is a match with the left side of the association
-      // TODO NOTE: (??? doesn't the method check both sides??)
-      /*
-       * MY description would be:
-       * check if the association "assoc" relates any of the superTypes with any of the oppositeTypeIncarnations (or its super types) (??)
-       */
-      if (checkAssociationMatch(superTypes, oppositeTypeIncarnations, assoc, cd)) {
+      // Check if the association "assoc" relates any of the superTypes with any of the oppositeTypeIncarnations (or its super types) (??)
+      if (checkAssociationMatchesTypes(superTypes, oppositeTypeIncarnationSuperTypes, assoc)) {
         return Optional.of(assoc); // Match found, return the association
       }
     }
@@ -562,7 +562,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
   }
 
   /**
-   * Creates incarnations if a reference association for the given sets of left and right type
+   * Creates incarnations of a reference association for the given sets of left and right type
    * incarnations.
    * For each pair of left and right type incarnations, a new association is created.
    *
@@ -621,25 +621,24 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
   }
 
   /**
-   * Checks if the association "assoc" relates any of the superTypes with any of the oppositeTypeIncarnations (or its super types)
+   * Checks if the given concrete association relates any of the types from set A with any of the
+   * types from set B.
    *
-   * @param superTypes
-   * @param oppositeTypeIncarnations
+   * @param typesSideA the set (A) of types to check for on one side of the association
+   * @param typesSideB the set (B) of types to check for on the other side of the association
    * @param assoc the CONCRETE association to check for a match
-   * @param cd the concrete CD
-   * @return
+   * @return true if the association relates any of the types from set A with any of the types from
    * @throws CompletionException
    */
-  private boolean checkAssociationMatch(
-      Set<ASTCDType> superTypes,
-      Set<ASTCDType> oppositeTypeIncarnations,
-      ASTCDAssociation assoc,
-      ASTCDDefinition cd)
+  private boolean checkAssociationMatchesTypes(
+      Set<ASTCDType> typesSideA,
+      Set<ASTCDType> typesSideB,
+      ASTCDAssociation assoc)
       throws CompletionException {
 
     boolean fail = false;
 
-    if (superTypes.stream()
+    if (typesSideA.stream()
         .anyMatch(
             superType ->
                 // Compare the qualified name of the supertype with the qualified name of the
@@ -651,9 +650,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     // additionally, check if any supertype of the opposite types matches the right side of
     // the association
     ) {
-      if (oppositeTypeIncarnations.stream()
-          // For each type in the oppositeTypeIncarnations set, get all its supertypes
-          .flatMap(oType -> CDDiffUtil.getAllSuperTypes(oType, cd).stream())
+      if (typesSideB.stream()
           .anyMatch(
               oSuperType ->
                   // Compare the qualified name of the supertype with the qualified name of the
@@ -667,7 +664,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       fail = true; // TODO analyze what this fail means!
     }
     // Same logic, but this time we check from right to left
-    if (superTypes.stream()
+    if (typesSideA.stream()
         .anyMatch(
             superType ->
                 // Compare the qualified name of the supertype with the qualified name of the
@@ -679,9 +676,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     // Additionally, check if any supertype of the opposite types matches the left side of the
     // association
     ) {
-      if (oppositeTypeIncarnations.stream()
-          // For each type in the oppositeTypeIncarnations set, get all its supertypes
-          .flatMap(oType -> CDDiffUtil.getAllSuperTypes(oType, cd).stream())
+      if (typesSideB.stream()
           .anyMatch(
               oSuperType ->
                   // Compare the qualified name of the supertype with the qualified name of the

--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
@@ -16,8 +16,11 @@ import de.monticore.cdconformance.inc.type.EqTypeIncStrategy;
 import de.monticore.cdconformance.inc.type.STTypeIncStrategy;
 import de.monticore.cddiff.CDDiffUtil;
 import de.monticore.cdmatcher.MatchCDAssocsGreedy;
+import de.monticore.cdmatcher.MatchCDTypesToSubTypes;
 import de.monticore.cdmatcher.MatchingStrategy;
 import de.monticore.tf.odrulegeneration._ast.ASTAssociation;
+import de.se_rwth.commons.logging.Log;
+
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -25,14 +28,19 @@ import java.util.stream.Collectors;
 
 public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssociation> {
 
+  private static final String LOG_NAME = DefaultAssocIncCompleter.class.getName();
+
   protected ASTCDCompilationUnit rcd;
   protected ASTCDCompilationUnit ccd;
 
   protected String mapping;
   protected CompAssocIncStrategy compAssocIncStrategy;
   protected CompTypeIncStrategy compTypeIncStrategy;
+  protected CompTypeIncStrategy typeIncStrategyMatchingSubTypes;
   protected ConcretizationHelper helper;
   protected boolean intersectCardinality = false;
+
+  private boolean greedyMatcherEnabled = true; // TODO remove! only for testing
 
   public DefaultAssocIncCompleter(
       ASTCDCompilationUnit conCD, ASTCDCompilationUnit refCD, String mapping) {
@@ -40,17 +48,23 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     this.ccd = conCD;
     this.mapping = mapping;
 
+    // TODO use same config params as for conformance checker
+
     compTypeIncStrategy = new CompTypeIncStrategy(refCD, mapping);
     compTypeIncStrategy.addIncStrategy(new STTypeIncStrategy(refCD, mapping));
     compTypeIncStrategy.addIncStrategy(new EqTypeIncStrategy(refCD, mapping));
+
+    typeIncStrategyMatchingSubTypes = new CompTypeIncStrategy(refCD, mapping);
+    typeIncStrategyMatchingSubTypes.addIncStrategy(compTypeIncStrategy);
+    typeIncStrategyMatchingSubTypes.addIncStrategy(new MatchCDTypesToSubTypes(compTypeIncStrategy, conCD, refCD));
 
     compAssocIncStrategy = new CompAssocIncStrategy(refCD, mapping);
     compAssocIncStrategy.addIncStrategy(new STNamedAssocIncStrategy(refCD, mapping));
     compAssocIncStrategy.addIncStrategy(new EqNameAssocIncStrategy(refCD, mapping));
     compAssocIncStrategy.addIncStrategy(
-        new RolePrefixInNavDirIncStrategy(compTypeIncStrategy, conCD, refCD));
+        new RolePrefixInNavDirIncStrategy(typeIncStrategyMatchingSubTypes, conCD, refCD));
     compAssocIncStrategy.addIncStrategy(
-        new RolePrefixIfPresentIncStrategy(compTypeIncStrategy, conCD, refCD));
+        new RolePrefixIfPresentIncStrategy(typeIncStrategyMatchingSubTypes, conCD, refCD));
 
     this.helper = new ConcretizationHelper(ccd, rcd, compTypeIncStrategy, compAssocIncStrategy);
   }
@@ -60,15 +74,18 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     // First: complete the incarnations, so add stuff to the underspecified incarnation
     // or do nothing to the over-specified incarnation
 
+    Log.debug("=== START completing existing associations ===", LOG_NAME);
     // Iterate through all concrete associations
     for (ASTCDAssociation cAssoc : ccd.getCDDefinition().getCDAssociationsList()) {
       for (ASTCDAssociation rAssoc : rcd.getCDDefinition().getCDAssociationsList()) {
         // Check if the concrete association is an incarnation of the reference association
         if (compAssocIncStrategy.isMatched(cAssoc, rAssoc)) {
+          Log.debug("Found match for assoc: " + CD4CodeMill.prettyPrint(cAssoc, false), LOG_NAME);
           handleAssociation(cAssoc, rAssoc);
         }
       }
     }
+    Log.debug("=== DONE completing existing associations ===", LOG_NAME);
 
     // Second:
     identifyAndAddMissingAssociations();
@@ -109,29 +126,26 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     // A match occurs if the left types match and the right types match, considering supertypes as
     // well.
     boolean match =
-        (compTypeIncStrategy.isMatched(cLeftType, rLeftType)
+        (typeIncStrategyMatchingSubTypes.isMatched(cLeftType, rLeftType)
                 || cLeftSuperTypes.stream()
-                    .anyMatch(sLeftType -> compTypeIncStrategy.isMatched(sLeftType, rLeftType)))
-            && (compTypeIncStrategy.isMatched(cRightType, rRightType)
+                    .anyMatch(sLeftType -> typeIncStrategyMatchingSubTypes.isMatched(sLeftType, rLeftType)))
+            && (typeIncStrategyMatchingSubTypes.isMatched(cRightType, rRightType)
                 || cRightSuperTypes.stream()
-                    .anyMatch(sRightType -> compTypeIncStrategy.isMatched(sRightType, rRightType)));
+                    .anyMatch(sRightType -> typeIncStrategyMatchingSubTypes.isMatched(sRightType, rRightType)));
 
     // Determine if the concrete association matches the reference association in the reverse
     // direction.
     // A match in reverse occurs if the left type of the concrete association matches the right type
     // of the reference, and vice versa.
     boolean matchInReverse =
-        (compTypeIncStrategy.isMatched(cLeftType, rRightType)
+        (typeIncStrategyMatchingSubTypes.isMatched(cLeftType, rRightType)
                 || cLeftSuperTypes.stream()
-                    .anyMatch(sLeftType -> compTypeIncStrategy.isMatched(sLeftType, rRightType)))
-            && (compTypeIncStrategy.isMatched(cRightType, rLeftType)
+                    .anyMatch(sLeftType -> typeIncStrategyMatchingSubTypes.isMatched(sLeftType, rRightType)))
+            && (typeIncStrategyMatchingSubTypes.isMatched(cRightType, rLeftType)
                 || cRightSuperTypes.stream()
-                    .anyMatch(sRightType -> compTypeIncStrategy.isMatched(sRightType, rLeftType)));
+                    .anyMatch(sRightType -> typeIncStrategyMatchingSubTypes.isMatched(sRightType, rLeftType)));
 
-    // If a match is found in either direction, proceed to complete the association names.
-    if (match || matchInReverse) {
-      completeAssociationNames(cAssoc, rAssoc);
-    } else {
+    if (!match && !matchInReverse) {
       // If no match is found, throw an exception as the associations could not be completed.
       throw new CompletionException("Associations could not be completed.");
     }
@@ -158,9 +172,23 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       }
     }
 
-    // If the match is still valid, complete the association properties for the same sides.
-    if (match) {
-      // Complete association
+    completeAssociation(cAssoc, rAssoc, match);
+  }
+
+  /***
+   * Completes the properties of the concrete association based on the reference association.
+   *
+   * @param cAssoc The concrete association to complete
+   * @param rAssoc The reference association to use for completion
+   * @param matchInSameDirection A boolean indicating whether the associations match in the same
+   *                             direction (left-left, right-right) or reverse (left-right,
+   *                             right-left).
+   * @throws CompletionException
+   */
+  private void completeAssociation(ASTCDAssociation cAssoc, ASTCDAssociation rAssoc, boolean matchInSameDirection) throws CompletionException {
+    completeAssociationName(cAssoc, rAssoc);
+
+    if (matchInSameDirection) {
       completeAssocNavigability(cAssoc, rAssoc);
       completeAssocCardinality(cAssoc.getLeft(), rAssoc.getLeft());
       completeAssocCardinality(cAssoc.getRight(), rAssoc.getRight());
@@ -175,7 +203,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       completeAssociationRoleNames(cAssoc.getRight(), rAssoc.getLeft());
     }
 
-    // Handle potential role name conflicts in a post-processing step.
+    // Handle potential role name conflicts in a post-processing step
     renameRoleIfConflicting(cAssoc);
   }
 
@@ -328,7 +356,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     }
   }
 
-  private void completeAssociationNames(ASTCDAssociation cAssoc, ASTCDAssociation rAssoc) {
+  private void completeAssociationName(ASTCDAssociation cAssoc, ASTCDAssociation rAssoc) {
     // Check and complete association name
     if (!cAssoc.isPresentName() && rAssoc.isPresentName()) {
       if (ccd.getCDDefinition().getCDAssociationsList().stream()
@@ -340,18 +368,25 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
   }
 
   public void identifyAndAddMissingAssociations() throws CompletionException {
+    Log.debug("=== START finding missing associations ===", LOG_NAME);
     CDDiffUtil.refreshSymbolTable(ccd);
 
     // Iterate over all associations in the reference class diagram
     for (ASTCDAssociation rAssoc : rcd.getCDDefinition().getCDAssociationsList()) {
+      Log.debug("Finding matches for assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
+
       MatchingStrategy<ASTCDAssociation> greedyMatching =
-          new MatchCDAssocsGreedy(compTypeIncStrategy, ccd, rcd);
+          new MatchCDAssocsGreedy(typeIncStrategyMatchingSubTypes, ccd, rcd);
 
       // Find all associations in the concrete class diagram that match the reference association
       Set<ASTCDAssociation> assocIncarnations =
           ccd.getCDDefinition().getCDAssociationsList().stream()
               .filter(cAssoc -> compAssocIncStrategy.isMatched(cAssoc, rAssoc))
               .collect(Collectors.toSet());
+
+      Log.debug("Found normal matches: " + assocIncarnations.stream()
+              .map(a -> CD4CodeMill.prettyPrint(a, false))
+              .collect(Collectors.toList()), LOG_NAME);
 
       // Find associations that match greedily , but ensure that they don't match more than one
       // element
@@ -362,6 +397,10 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
                       greedyMatching.isMatched(cAssoc, rAssoc)
                           && greedyMatching.getMatchedElements(cAssoc).size() < 2)
               .collect(Collectors.toSet());
+
+      Log.debug("Found greedy matches: " + assocGreedyMatches.stream()
+              .map(a -> CD4CodeMill.prettyPrint(a, false))
+              .collect(Collectors.toList()), LOG_NAME);
 
       // Resolve the left and right types of the reference association in the reference class
       // diagram
@@ -407,12 +446,17 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
 
       CDDiffUtil.refreshSymbolTable(ccd);
 
+      Log.debug("DONE finding matches for assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
+      Log.debug("remaining left type incarnations: " + leftTypeInc2Process.stream().map(ASTCDType::getName).collect(Collectors.toList()), LOG_NAME);
+      Log.debug("remaining right type incarnations: " + rightTypeInc2Process.stream().map(ASTCDType::getName).collect(Collectors.toList()), LOG_NAME);
+
       // Finally, process any remaining type incarnations that still need to be handled
       // Process the remaining left-type incarnations against right-type incarnations
       processTypeInc2Process(leftTypeInc2Process, rRightTypeIncarnations, rAssoc, true);
 
       // Process the remaining right-type incarnations against left-type incarnations
       processTypeInc2Process(rightTypeInc2Process, rLeftTypeIncarnations, rAssoc, false);
+      Log.debug("=== DONE processing assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
     }
   }
 
@@ -439,18 +483,27 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       // continue
       if (match.isPresent()) {
         typeInc2Process.remove(typeInc);
+        Log.debug("Found normal match for type inc: " + typeInc.getName(), LOG_NAME);
+        Log.debug("reference assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
+        Log.debug("concrete assoc: " + CD4CodeMill.prettyPrint(match.get(), false), LOG_NAME);
         continue;
       }
 
-      // If no match is found in specific incarnations, try matching against the greedy matches
-      match = processAssociations(superTypes, rOppositeTypeIncarnations, assocGreedyMatches, cd);
+      if (greedyMatcherEnabled) {
+        // If no match is found in specific incarnations, try matching against the greedy matches
+        match = processAssociations(superTypes, rOppositeTypeIncarnations, assocGreedyMatches, cd);
 
-      // If a match is found among the greedy matches, remove the current type incarnation from the
-      // set to be processed
-      // and handle the association accordingly
-      if (match.isPresent()) {
-        typeInc2Process.remove(typeInc);
-        handleAssociation(match.get(), rAssoc);
+        // If a match is found among the greedy matches, remove the current type incarnation from the
+        // set to be processed
+        // and handle the association accordingly
+        if (match.isPresent()) {
+          typeInc2Process.remove(typeInc);
+          Log.debug("Found GREEDY match for type inc: " + typeInc.getName(), LOG_NAME);
+          Log.debug("reference assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
+          Log.debug("concrete assoc: " + CD4CodeMill.prettyPrint(match.get(), false), LOG_NAME);
+          Log.debug("completing greedy match", LOG_NAME);
+          handleAssociation(match.get(), rAssoc);
+        }
       }
     }
   }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
@@ -54,6 +54,26 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     compTypeIncStrategy.addIncStrategy(new STTypeIncStrategy(refCD, mapping));
     compTypeIncStrategy.addIncStrategy(new EqTypeIncStrategy(refCD, mapping));
 
+    // 'typeIncStrategyMatchingSubTypes' matches types which are an incarnation of a reference type
+    // themselves or have a subclass which is an incarnation of the reference type.
+    // This strategy is only used when matching associations. If we want to allow the concrete CD to
+    // define associations in superclasses of the actual type incarnation, we have to pass this type
+    // matching strategy to the association matching strategies. This allows supertypes to 'act' as
+    // incarnation of the reference type in context of a specific association.
+    // For example in the following concrete CD, A is a valid incarnation of A in the reference CD
+    // because A is a subclass of X, which has an association towards B.
+    //
+    // classdiagram Concrete {
+    //   class X;
+    //   class A extends X;
+    //   X -> B;
+    // }
+    //
+    // classdiagram Reference {
+    //   class A;
+    //   class B;
+    //   A -> B;
+    // }
     typeIncStrategyMatchingSubTypes = new CompTypeIncStrategy(refCD, mapping);
     typeIncStrategyMatchingSubTypes.addIncStrategy(compTypeIncStrategy);
     typeIncStrategyMatchingSubTypes.addIncStrategy(new MatchCDTypesToSubTypes(compTypeIncStrategy, conCD, refCD));
@@ -81,7 +101,8 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
         // Check if the concrete association is an incarnation of the reference association
         if (compAssocIncStrategy.isMatched(cAssoc, rAssoc)) {
           Log.debug("Found match for assoc: " + CD4CodeMill.prettyPrint(cAssoc, false), LOG_NAME);
-          handleAssociation(cAssoc, rAssoc);
+          AssocMatchDirection matchDirection = determineMatchDirection(cAssoc, rAssoc);
+          completeAssociation(cAssoc, rAssoc, matchDirection);
         }
       }
     }
@@ -105,7 +126,16 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     }
   }
 
-  private void handleAssociation(ASTCDAssociation cAssoc, ASTCDAssociation rAssoc)
+  /**
+   * Checks in what direction the concrete association matches the reference association.
+   * If the direction cannot be determined, an exception is thrown.
+   *
+   * @param cAssoc the concrete association
+   * @param rAssoc the reference association
+   * @return
+   * @throws CompletionException if the match direction cannot be determined.
+   */
+  private AssocMatchDirection determineMatchDirection(ASTCDAssociation cAssoc, ASTCDAssociation rAssoc)
       throws CompletionException {
 
     // Extract the left and right types of the concrete association
@@ -172,7 +202,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       }
     }
 
-    completeAssociation(cAssoc, rAssoc, match ? AssocMatchDirection.SAME_DIRECTION : AssocMatchDirection.REVERSE_DIRECTION);
+    return match ? AssocMatchDirection.SAME_DIRECTION : AssocMatchDirection.REVERSE_DIRECTION;
   }
 
   /***
@@ -714,6 +744,19 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     return compAssocIncStrategy;
   }
 
+  /**
+   * A matching direction indicates whether two association match in the same direction or in the
+   * reverse direction.
+   * This is required as associations in CD4A are defined in a textual syntax where the same
+   * association between two classes 'A' and 'B' can be defined in two different ways:
+   * <ul>
+   *   <li>either: <code>A -> B</code></li>
+   *   <li>or: <code>B <- A</code></li>
+   * </ul>
+   * Although, both have the same semantic meaning, they are represented in different ways in the AST.
+   * In the first case, 'A' is on the left side and 'B' is on the right side of the association. In
+   * the second case, 'B' is on the left side and 'A' is on the right side of the association.
+   */
   enum AssocMatchDirection {
     /**
      * The association matches in the same direction as the reference association.
@@ -728,8 +771,17 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     REVERSE_DIRECTION;
   }
 
+  /**
+   * Represents an association that matches another association in a certain direction.
+   * This is useful when we want to keep the information about the direction of the match for later
+   * processing.
+   */
   static class AssociationMatch {
+
+    /** The matching association. */
     private final ASTCDAssociation association;
+
+    /** The direction of the match. */
     private final AssocMatchDirection matchDirection;
 
     public AssociationMatch(ASTCDAssociation association, AssocMatchDirection matchDirection) {

--- a/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/DefaultAssocIncCompleter.java
@@ -367,6 +367,12 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     }
   }
 
+  /**
+   * Adds missing associations to the concrete class diagram based on the associations in the
+   * reference class diagram.
+   *
+   * @throws CompletionException
+   */
   public void identifyAndAddMissingAssociations() throws CompletionException {
     Log.debug("=== START finding missing associations ===", LOG_NAME);
     CDDiffUtil.refreshSymbolTable(ccd);
@@ -455,11 +461,26 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       processTypeInc2Process(leftTypeInc2Process, rRightTypeIncarnations, rAssoc, true);
 
       // Process the remaining right-type incarnations against left-type incarnations
+      // TODO Can't we just pass right and left lists in the same order and get rid of the boolean?
       processTypeInc2Process(rightTypeInc2Process, rLeftTypeIncarnations, rAssoc, false);
       Log.debug("=== DONE processing assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
     }
   }
 
+  /**
+   * GUESS: Process the type incarnations to find and handle matching associations.
+   *    -> so we still try to find more matches than we found in the step before.
+   *
+   * @param rTypeIncarnation all incarnation of the one side of the association
+   * @param rOppositeTypeIncarnations all incarnation of the other side of the association
+   * @param typeInc2Process Subset of 'rTypeIncarnation' (?) that still needs an incarnation of the reference association (??)
+   * @param assocIncarnations "normal" matches from the association matching strategy -> NOTE: these were processed before in step 4 by handleAssociation(...)
+   *                          Although handleAssociations can abort the processing, so we could match them again ??
+   * @param assocGreedyMatches greedy matches for the reference association to process
+   * @param cd the CONCRETE class diagram
+   * @param rAssoc the reference association to process
+   * @throws CompletionException
+   */
   private void processTypeIncarnations(
       Set<ASTCDType> rTypeIncarnation,
       Set<ASTCDType> rOppositeTypeIncarnations,
@@ -483,6 +504,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       // continue
       if (match.isPresent()) {
         typeInc2Process.remove(typeInc);
+        // NOTE: we do not call "handleAssociation" here, because we already processed the match in the step before
         Log.debug("Found normal match for type inc: " + typeInc.getName(), LOG_NAME);
         Log.debug("reference assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
         Log.debug("concrete assoc: " + CD4CodeMill.prettyPrint(match.get(), false), LOG_NAME);
@@ -508,6 +530,18 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     }
   }
 
+  /**
+   * GUESS: Finds any association in the given set that "associates" one of the superTypes with
+   *        one if the "oppositeTypeIncarnations".
+   *
+   * @param superTypes all concrete super types of the "one side" of the association
+   * @param oppositeTypeIncarnations all incarnations of the type on the "other side" of the association
+   * @param associations the set of concrete associations to check for a match
+   * @param cd the concrete CD
+   * @return
+   * @throws CompletionException
+   */
+  // TODO name change proposal: findMatchingConcreteAssociationInSuperTypes
   private Optional<ASTCDAssociation> processAssociations(
       Set<ASTCDType> superTypes,
       Set<ASTCDType> oppositeTypeIncarnations,
@@ -516,12 +550,30 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
       throws CompletionException {
     for (ASTCDAssociation assoc : associations) {
       // Check if there is a match with the left side of the association
+      // TODO NOTE: (??? doesn't the method check both sides??)
+      /*
+       * MY description would be:
+       * check if the association "assoc" relates any of the superTypes with any of the oppositeTypeIncarnations (or its super types) (??)
+       */
       if (checkAssociationMatch(superTypes, oppositeTypeIncarnations, assoc, cd)) {
         return Optional.of(assoc); // Match found, return the association
       }
     }
     return Optional.empty(); // No match found, return empty
   }
+
+  /**
+   * Creates missing incarnations for the given type incarnations and the reference association.
+   * For each pair of typeInc2Process and otherTypeIncs, a new association is created based on the
+   * reference association.
+   *
+   * @param typeInc2Process the type incarnations for which we want to create missing incarnations
+   * @param otherTypeIncs the types to which we want to create missing incarnations
+   * @param rAssoc the reference association for which we want to create missing incarnations
+   * @param isLeftToRight If true, the left type of the new association is the type from
+   *                      'typeInc2Process' and the right type is from otherTypeIncs. If false, it is
+   *                      the other way around.
+   */
 
   private void processTypeInc2Process(
       Set<ASTCDType> typeInc2Process,
@@ -616,6 +668,16 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
     }
   }
 
+  /**
+   * Checks if the association "assoc" relates any of the superTypes with any of the oppositeTypeIncarnations (or its super types)
+   *
+   * @param superTypes
+   * @param oppositeTypeIncarnations
+   * @param assoc the CONCRETE association to check for a match
+   * @param cd the concrete CD
+   * @return
+   * @throws CompletionException
+   */
   private boolean checkAssociationMatch(
       Set<ASTCDType> superTypes,
       Set<ASTCDType> oppositeTypeIncarnations,
@@ -633,7 +695,7 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
                 superType
                     .getSymbol()
                     .getInternalQualifiedName()
-                    .contains(assoc.getLeftQualifiedName().getQName()))
+                    .contains(assoc.getLeftQualifiedName().getQName())) // TODO why contains?? - if because CD names can differ -> remove first part
     // additionally, check if any supertype of the opposite types matches the right side of
     // the association
     ) {
@@ -647,10 +709,10 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
                   oSuperType
                       .getSymbol()
                       .getInternalQualifiedName()
-                      .contains(assoc.getRightQualifiedName().getQName()))) {
+                      .contains(assoc.getRightQualifiedName().getQName()))) { // TODO why contains?? - if because CD names can differ -> remove first part
         return true;
       }
-      fail = true;
+      fail = true; // TODO analyze what this fail means!
     }
     // Same logic, but this time we check from right to left
     if (superTypes.stream()
@@ -685,17 +747,5 @@ public class DefaultAssocIncCompleter implements IIncarnationCompleter<ASTAssoci
           "Something went wrong when identifying missing association incarnations.");
     }
     return false;
-  }
-
-  protected void setIntersectCardinality(Boolean b) {
-    this.intersectCardinality = b;
-  }
-
-  protected Boolean getIntersectCardinality() {
-    return intersectCardinality;
-  }
-
-  public CompAssocIncStrategy getCompAssocIncStrategy() {
-    return this.compAssocIncStrategy;
   }
 }

--- a/cddiff/src/main/java/de/monticore/cdmatcher/MatchCDTypesToSubTypes.java
+++ b/cddiff/src/main/java/de/monticore/cdmatcher/MatchCDTypesToSubTypes.java
@@ -4,6 +4,10 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._ast.ASTCDType;
 import de.monticore.cddiff.CDDiffUtil;
 
+/**
+ * A special type matching strategy that matches the reference type if any strict subtype of a
+ * concrete type is an incarnation of the reference type.
+ */
 public class MatchCDTypesToSubTypes extends MatchCDTypeInHierarchy {
 
   public MatchCDTypesToSubTypes(

--- a/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
@@ -272,6 +272,37 @@ public class ConcretizationCompleterTest {
   }
 
   @Test
+  void testAssocInSuperType() {
+    testConcretizedConformsToRefAndExpectedOut(
+        "associations/AssociationInSuperTypeConc.cd",
+        "associations/AssociationInSuperTypeRef.cd",
+        "associations/AssociationInSuperTypeOut.cd");
+  }
+
+  @Test
+  void testAssocSuperMatchingTest() {
+    testConcretizedConformsToRef(
+        "associations/AssociationSuperMatchingConc.cd",
+        "associations/AssociationSuperMatchingRef.cd");
+  }
+
+  @Test
+  void testAssocSuperMatchingConformanceTest() {
+    parseModels(
+        "associations/AssociationSuperMatchingOut.cd",
+        "associations/AssociationSuperMatchingRef.cd");
+    assertTrue(
+            new CDConformanceChecker(
+                    Set.of(
+                            STEREOTYPE_MAPPING,
+                            NAME_MAPPING,
+                            SRC_TARGET_ASSOC_MAPPING,
+                            INHERITANCE,
+                            ALLOW_CARD_RESTRICTION))
+                    .checkConformance(conCD, refCD, Set.of("ref")));
+  }
+
+  @Test
   void testAssociationReverseMatch() {
     testConcretizedConformsToRefAndExpectedOut(
         "associations/AssociationReverseMatchConc.cd",

--- a/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
@@ -177,6 +177,18 @@ public class ConcretizationCompleterTest {
   }
 
   @Test
+  void testAssocBothSidesMIOneAssocExistsPerTypeIncarnation() {
+    /*
+     * The tool only adds associations between each pair of type incarnations if the concrete CD
+     * does not already contain an association for each SINGLE type incarnation!
+     */
+    testConcretizedConformsToRefAndExpectedOut(
+        "multipleIncarnation/BothAssocSidesMIOneAssocExistsConc.cd",
+        "multipleIncarnation/BothAssocSidesMIRef.cd",
+            "multipleIncarnation/BothAssocSidesMIOneAssocExistsOut.cd");
+  }
+
+  @Test
   void testMIUnequalCardinalities() {
     try {
       parseAndConcretize(
@@ -281,9 +293,10 @@ public class ConcretizationCompleterTest {
 
   @Test
   void testAssocSuperMatchingTest() {
-    testConcretizedConformsToRef(
+    testConcretizedConformsToRefAndExpectedOut(
         "associations/AssociationSuperMatchingConc.cd",
-        "associations/AssociationSuperMatchingRef.cd");
+        "associations/AssociationSuperMatchingRef.cd",
+        "associations/AssociationSuperMatchingOut.cd");
   }
 
   @Test
@@ -313,9 +326,9 @@ public class ConcretizationCompleterTest {
   @Test
   void testTypeMIOneAssocExists() {
     testConcretizedConformsToRefAndExpectedOut(
-        "associations/TypeMIOneAssocExistsConc.cd",
-        "associations/TypeMIOneAssocExistsRef.cd",
-        "associations/TypeMIOneAssocExistsOut.cd");
+            "associations/TypeMIOneAssocExistsConc.cd",
+            "associations/TypeMIOneAssocExistsRef.cd",
+            "associations/TypeMIOneAssocExistsOut.cd");
   }
 
   @Test

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationInSuperTypeConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationInSuperTypeConc.cd
@@ -1,0 +1,11 @@
+classdiagram AssociationInSuperTypeConc {
+
+  abstract class AccountTop;
+
+  class Account extends AccountTop;
+
+  class Person ;
+
+  association AccountTop -> Person[1];
+  association Person     -> Account[*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationInSuperTypeOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationInSuperTypeOut.cd
@@ -1,0 +1,12 @@
+classdiagram AssociationInSuperTypeConc {
+
+  abstract class AccountTop;
+
+  class Account extends AccountTop;
+
+  class Person ;
+
+  association AccountTop -> Person[1];
+  association Person     -> Account[*];
+  // there is no association missing to be conform to reference CD. So the tool should not add any association
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationInSuperTypeRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationInSuperTypeRef.cd
@@ -1,0 +1,8 @@
+classdiagram AssociationInSuperTypeRef {
+  class Account;
+
+  class Person ;
+
+  association Account -> Person[1];
+  association Person  -> Account[*] ;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationSuperMatchingConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationSuperMatchingConc.cd
@@ -1,0 +1,22 @@
+classdiagram AssociationSuperMatchingConc {
+
+  class ASuperSuper1;
+  class ASuperSuper2;
+  class ASuper1 extends ASuperSuper1;
+  class ASuper2 extends ASuperSuper2;
+  class ASuper3;
+
+  <<ref="A">> class A1 extends ASuper1;
+  <<ref="A">> class A2 extends ASuper2;
+  <<ref="A">> class A3 extends ASuper3; // this one is missing associations
+
+  abstract class BSuperSuper1;
+  abstract class BSuperSuper2;
+  abstract class BSuper1 extends BSuperSuper1, BSuperSuper2;
+
+  <<ref="B">> class B1 extends BSuper1;
+  <<ref="B">> class B2 extends BSuperSuper2; // this one is missing associations
+
+  association ASuperSuper1 -> BSuperSuper1 [*];
+  association ASuperSuper2 -> BSuperSuper1 [*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationSuperMatchingOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationSuperMatchingOut.cd
@@ -6,7 +6,7 @@ classdiagram AssociationSuperMatchingConc {
   class ASuper2 extends ASuperSuper2;
   class ASuper3;
 
-  <<ref="A">> class A1 extends ASuper1, ASuper2;
+  <<ref="A">> class A1 extends ASuper1;
   <<ref="A">> class A2 extends ASuper2;
   <<ref="A">> class A3 extends ASuper3; // this one is missing associations
 

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationSuperMatchingOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationSuperMatchingOut.cd
@@ -1,0 +1,27 @@
+classdiagram AssociationSuperMatchingConc {
+
+  class ASuperSuper1;
+  class ASuperSuper2;
+  class ASuper1 extends ASuperSuper1;
+  class ASuper2 extends ASuperSuper2;
+  class ASuper3;
+
+  <<ref="A">> class A1 extends ASuper1, ASuper2;
+  <<ref="A">> class A2 extends ASuper2;
+  <<ref="A">> class A3 extends ASuper3; // this one is missing associations
+
+  abstract class BSuperSuper1;
+  abstract class BSuperSuper2;
+  abstract class BSuper1 extends BSuperSuper1, BSuperSuper2;
+
+  <<ref="B">> class B1 extends BSuper1;
+  <<ref="B">> class B2 extends BSuperSuper2; // this one is missing associations
+
+  association ASuperSuper1 -> BSuperSuper1 [*];
+  association ASuperSuper2 -> BSuperSuper1 [*];
+
+  association A3 -> B1 [*];
+  association A3 -> B2 [*];
+  association A1 -> B2 [*];
+  association A2 -> B2 [*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationSuperMatchingRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationSuperMatchingRef.cd
@@ -1,0 +1,6 @@
+classdiagram AssociationSuperMatchingRef {
+  class A;
+  class B;
+
+  association A -> B [*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/multipleIncarnation/BothAssocSidesMIOneAssocExistsConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/multipleIncarnation/BothAssocSidesMIOneAssocExistsConc.cd
@@ -1,0 +1,18 @@
+classdiagram BothAssocSidesMIConc {
+
+  <<ref="SuperTeacher">> class SuperTeacher1 {
+  }
+  <<ref="SuperTeacher">> class SuperTeacher2 {
+  }
+  <<ref="Teacher">> class Teacher1 {
+  }
+  <<ref="Teacher">> class Teacher2 {
+  }
+  <<ref="Department">> class Department1 {
+  }
+  <<ref="Department">> class Department2 {
+  }
+
+  association Teacher1 (hasTeacher) -- (teachesIn) Department1;
+  association Teacher2 (hasTeacher) -- (teachesIn) Department2;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/multipleIncarnation/BothAssocSidesMIOneAssocExistsOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/multipleIncarnation/BothAssocSidesMIOneAssocExistsOut.cd
@@ -1,0 +1,25 @@
+classdiagram BothAssocSidesMIConc {
+    <<ref="SuperTeacher">>class SuperTeacher1 {
+
+    }
+    <<ref="SuperTeacher">>class SuperTeacher2 {
+
+    }
+    <<ref="Teacher">>class Teacher1 extends SuperTeacher2,SuperTeacher1 {
+
+    }
+    <<ref="Teacher">>class Teacher2 extends SuperTeacher2,SuperTeacher1 {
+
+    }
+    <<ref="Department">>class Department1 {
+
+    }
+    <<ref="Department">>class Department2 {
+
+    }
+
+    association Teacher1(hasTeacher)--(teachesIn)Department1;
+    association Teacher2(hasTeacher)--(teachesIn)Department2;
+    // no more associations are added here because each type incarnation already has one association
+}
+


### PR DESCRIPTION
## What?
- introduce `AssocMatchDirection` & `AssociacionMatch` so we can remember the matching direction and don't have to compute it twice
- extract `completeAssociation` which does the actual completion of association properties
- more test cases to make sure we don't change behavior when doing more refactoring

## Why?
Before decomposing association completion logic into the new architecture, I had to fully understood what the code did. Since the method are sometimes not named well and hard to understand, I added documentation and simplified the code at some.
