### PR TITLE
Migrate tests to Junit 5

### DIFF
--- a/cd2smt/src/test/java/de/monticore/cd2smt/AssocStrategiesTest.java
+++ b/cd2smt/src/test/java/de/monticore/cd2smt/AssocStrategiesTest.java
@@ -14,9 +14,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AssocStrategiesTest extends CD2SMTAbstractTest {
 
@@ -62,6 +63,6 @@ public class AssocStrategiesTest extends CD2SMTAbstractTest {
     Solver solver =
         cd2SMTGenerator.makeSolver(
             List.of(IdentifiableBoolExpr.buildIdentifiable(two, null, Optional.of("Two_Motor"))));
-    Assertions.assertEquals(Status.UNSATISFIABLE, solver.check());
+    assertEquals(Status.UNSATISFIABLE, solver.check());
   }
 }

--- a/cd2smt/src/test/java/de/monticore/cd2smt/CD2SMTAbstractTest.java
+++ b/cd2smt/src/test/java/de/monticore/cd2smt/CD2SMTAbstractTest.java
@@ -14,8 +14,10 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CD2SMTAbstractTest {
   protected final String RELATIVE_MODEL_PATH = "src/test/resources/de/monticore/cd2smt";
@@ -30,7 +32,7 @@ public class CD2SMTAbstractTest {
           outputFile.toFile(), OD4ReportMill.prettyPrint(od, true), Charset.defaultCharset());
     } catch (Exception e) {
       e.printStackTrace();
-      Assertions.fail();
+      fail();
     }
   }
 
@@ -40,12 +42,12 @@ public class CD2SMTAbstractTest {
     Optional<ASTCDCompilationUnit> optAutomaton;
     try {
       optAutomaton = parser.parseCDCompilationUnit(model.toString());
-      Assertions.assertTrue(optAutomaton.isPresent());
+      assertTrue(optAutomaton.isPresent());
       (new CD4CodeAfterParseTrafo()).transform(optAutomaton.get());
       return optAutomaton.get();
     } catch (Exception e) {
       e.printStackTrace();
-      Assertions.fail(
+      fail(
           "There was an exception when parsing the model " + modelFile + ": " + e.getMessage());
     }
 

--- a/cd2smt/src/test/java/de/monticore/cd2smt/CD2SMTGeneratorTest.java
+++ b/cd2smt/src/test/java/de/monticore/cd2smt/CD2SMTGeneratorTest.java
@@ -20,10 +20,12 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CD2SMTGeneratorTest {
   protected final String RELATIVE_MODEL_PATH = "src/test/resources/de/monticore/cd2smt";
@@ -31,7 +33,7 @@ public class CD2SMTGeneratorTest {
   CD2SMTGenerator cd2SMTGenerator;
   Context context;
 
-  @Before
+  @BeforeEach
   public void init() {
     Log.init();
     Log.enableFailQuick(false);
@@ -50,11 +52,11 @@ public class CD2SMTGeneratorTest {
     try {
       Optional<ASTCDCompilationUnit> optCD =
           CD4CodeMill.parser().parse(Paths.get(RELATIVE_MODEL_PATH, fileName).toString());
-      Assert.assertTrue(optCD.isPresent());
+      assertTrue(optCD.isPresent());
       astCD = optCD.get();
       (new CD4CodeAfterParseTrafo()).transform(astCD);
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
     CD2SMTMill.initDefault();
     cd2SMTGenerator = CD2SMTMill.cd2SMTGenerator();
@@ -65,7 +67,7 @@ public class CD2SMTGeneratorTest {
   public void testDeclare_empty_class() {
     setup("car1.cd");
     Sort sort = cd2SMTGenerator.getSort(astCD.getCDDefinition().getCDClassesList().get(0));
-    Assert.assertNotNull(sort);
+    assertNotNull(sort);
   }
 
   @Test
@@ -75,19 +77,19 @@ public class CD2SMTGeneratorTest {
     Expr<? extends Sort> obj = context.mkConst("myObj", cd2SMTGenerator.getSort(Class));
     for (ASTCDAttribute attribute : Class.getCDAttributeList()) {
       Expr<? extends Sort> attr = cd2SMTGenerator.getAttribute(Class, attribute.getName(), obj);
-      Assert.assertNotNull(attr);
+      assertNotNull(attr);
       switch (attribute.getName()) {
         case "price":
-          Assert.assertEquals(attr.getSort(), context.mkFPSortDouble());
+          assertEquals(attr.getSort(), context.mkFPSortDouble());
           break;
         case "manufacturer":
-          Assert.assertEquals(attr.getSort(), context.mkStringSort());
+          assertEquals(attr.getSort(), context.mkStringSort());
           break;
         case "numberOfWheel":
-          Assert.assertEquals(attr.getSort(), context.mkIntSort());
+          assertEquals(attr.getSort(), context.mkIntSort());
           break;
         case "isExpensive":
-          Assert.assertEquals(attr.getSort(), context.mkBoolSort());
+          assertEquals(attr.getSort(), context.mkBoolSort());
           break;
       }
     }
@@ -97,13 +99,13 @@ public class CD2SMTGeneratorTest {
   public void EnumerationTest() {
     setup("car21.cd");
     ASTCDEnum astcdEnum = (ASTCDEnum) CDHelper.getASTCDType("Color", astCD.getCDDefinition());
-    Assert.assertNotNull(astcdEnum);
+    assertNotNull(astcdEnum);
     Expr<? extends Sort> enumConstant =
         cd2SMTGenerator.getEnumConstant(astcdEnum, astcdEnum.getCDEnumConstant(0));
-    Assert.assertEquals("RED", enumConstant.toString());
+    assertEquals("RED", enumConstant.toString());
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     if (context != null) {
       context.close();

--- a/cd2smt/src/test/java/de/monticore/cd2smt/CDHelperTest.java
+++ b/cd2smt/src/test/java/de/monticore/cd2smt/CDHelperTest.java
@@ -6,10 +6,12 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._ast.ASTCDType;
 import de.se_rwth.commons.logging.Log;
 import java.util.*;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CDHelperTest extends CD2SMTAbstractTest {
   @BeforeEach
@@ -35,16 +37,16 @@ public class CDHelperTest extends CD2SMTAbstractTest {
     ASTCDCompilationUnit ast = parseModel("car3.cd");
 
     ASTCDType astcdType = CDHelper.getASTCDType(type, ast.getCDDefinition());
-    Assertions.assertNotNull(astcdType);
+    assertNotNull(astcdType);
     Set<ASTCDType> superTypeList = CDHelper.getSuperTypeAllDeep(astcdType, ast.getCDDefinition());
-    Assertions.assertEquals(superTypeList.size(), number);
+    assertEquals(superTypeList.size(), number);
   }
 
   public void checkSubTypes(String type, int number) {
     ASTCDCompilationUnit ast = parseModel("car3.cd");
     ASTCDType astcdType = CDHelper.getASTCDType(type, ast.getCDDefinition());
-    Assertions.assertNotNull(astcdType);
+    assertNotNull(astcdType);
     Set<ASTCDType> subTypeAllDeep = CDHelper.getSubTypeAllDeep(astcdType, ast);
-    Assertions.assertEquals(subTypeAllDeep.size(), number);
+    assertEquals(subTypeAllDeep.size(), number);
   }
 }

--- a/cd2smt/src/test/java/de/monticore/cd2smt/CheckODValidityTest.java
+++ b/cd2smt/src/test/java/de/monticore/cd2smt/CheckODValidityTest.java
@@ -1,6 +1,8 @@
 package de.monticore.cd2smt;
 
 import static de.monticore.cd2smt.cd2smtGenerator.inhrStrategies.InheritanceData.Strategy.SE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microsoft.z3.*;
 import de.monticore.cd._symboltable.BuiltInTypes;
@@ -23,7 +25,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -242,14 +243,14 @@ public class CheckODValidityTest extends CD2SMTAbstractTest {
 
     Solver solver = cd2SMTGenerator.makeSolver(constraints);
 
-    Assertions.assertEquals(Status.SATISFIABLE, solver.check());
+    assertEquals(Status.SATISFIABLE, solver.check());
 
     Model model = solver.getModel();
     Optional<ASTODArtifact> optOd = cd2SMTGenerator.smt2od(model, false, odName);
-    Assertions.assertTrue(optOd.isPresent());
+    assertTrue(optOd.isPresent());
 
     printOD(optOd.get(), targetName);
-    Assertions.assertTrue(
+    assertTrue(
         matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, optOd.get(), ast));
   }
 

--- a/cd2smt/src/test/java/de/monticore/cd2smt/DataWrapperTest/AssocInhertianceTest.java
+++ b/cd2smt/src/test/java/de/monticore/cd2smt/DataWrapperTest/AssocInhertianceTest.java
@@ -19,12 +19,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssocInhertianceTest extends CD2SMTAbstractTest {
 
@@ -43,7 +44,6 @@ public class AssocInhertianceTest extends CD2SMTAbstractTest {
     ASTCDCompilationUnit ast =
         parseModel(Paths.get("DataWrapper/inheritance/association/AssocInheritance.cd").toString());
     CD2SMTMill.initDefault();
-    ;
     cd2SMTGenerator = CD2SMTMill.cd2SMTGenerator();
     cd2SMTGenerator.cd2smt(ast, new Context(cfg));
     ctx = cd2SMTGenerator.getContext();
@@ -59,10 +59,10 @@ public class AssocInhertianceTest extends CD2SMTAbstractTest {
 
     Optional<Expr<? extends Sort>> link1 =
         Optional.ofNullable(cd2SMTGenerator.evaluateLink(association, type1, type2, obj1, obj2));
-    Assertions.assertTrue(link1.isPresent());
+    assertTrue(link1.isPresent());
     Optional<Expr<? extends Sort>> link2 =
         Optional.ofNullable(cd2SMTGenerator.evaluateLink(association, type2, type1, obj2, obj1));
-    Assertions.assertTrue(link2.isPresent());
+    assertTrue(link2.isPresent());
   }
 
   @ParameterizedTest

--- a/cd2smt/src/test/java/de/monticore/cd2smt/DataWrapperTest/AttrInheritanceTest.java
+++ b/cd2smt/src/test/java/de/monticore/cd2smt/DataWrapperTest/AttrInheritanceTest.java
@@ -17,9 +17,10 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AttrInheritanceTest extends CD2SMTAbstractTest {
   protected CD2SMTGenerator cd2SMTGenerator;
@@ -46,7 +47,7 @@ public class AttrInheritanceTest extends CD2SMTAbstractTest {
   public void checkAttribute(ASTCDClass Class, String attrname, Expr<? extends Sort> obj) {
     Optional<Expr<? extends Sort>> attribute =
         Optional.ofNullable(cd2SMTGenerator.getAttribute(Class, attrname, obj));
-    Assertions.assertTrue(attribute.isPresent());
+    assertTrue(attribute.isPresent());
   }
 
   @Test

--- a/cd2smt/src/test/java/de/monticore/cd2smt/SingleSortTest.java
+++ b/cd2smt/src/test/java/de/monticore/cd2smt/SingleSortTest.java
@@ -3,6 +3,7 @@ package de.monticore.cd2smt;
 import static de.monticore.cd2smt.cd2smtGenerator.assocStrategies.AssociationStrategy.Strategy.DEFAULT;
 import static de.monticore.cd2smt.cd2smtGenerator.classStrategies.ClassStrategy.Strategy.SSCOMB;
 import static de.monticore.cd2smt.cd2smtGenerator.inhrStrategies.InheritanceData.Strategy.SE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.microsoft.z3.*;
 import de.monticore.cd2smt.Helper.IdentifiableBoolExpr;
@@ -11,7 +12,6 @@ import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.se_rwth.commons.logging.Log;
 import java.util.*;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -62,7 +62,7 @@ public class SingleSortTest extends CD2SMTAbstractTest {
     }
     for (IdentifiableBoolExpr UNSATConstr : UNSATConstrList) {
       Solver solver = cd2SMTGenerator.makeSolver(List.of(UNSATConstr));
-      Assertions.assertEquals(solver.check(), Status.UNSATISFIABLE);
+      assertEquals(Status.UNSATISFIABLE, solver.check());
     }
   }
 }

--- a/cddiff/src/test/java/de/monticore/cddiff/CDDiffTestBasis.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/CDDiffTestBasis.java
@@ -1,9 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4analysis._cocos.CD4AnalysisCoCoChecker;
 import de.monticore.cd4analysis._parser.CD4AnalysisParser;
@@ -19,12 +16,15 @@ import de.se_rwth.commons.logging.LogStub;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Provides some helpers for tests. */
 public abstract class CDDiffTestBasis {
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
     Log.enableFailQuick(false);

--- a/cddiff/src/test/java/de/monticore/cddiff/JoinLinksTrafoTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/JoinLinksTrafoTest.java
@@ -7,9 +7,12 @@ import de.monticore.od4report._parser.OD4ReportParser;
 import de.monticore.odbasis._ast.ASTODArtifact;
 import de.monticore.odlink._ast.ASTODLink;
 import de.se_rwth.commons.logging.Log;
+
+import java.util.Optional;
 import java.util.stream.Collectors;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JoinLinksTrafoTest extends CDDiffTestBasis {
 
@@ -18,21 +21,22 @@ public class JoinLinksTrafoTest extends CDDiffTestBasis {
     try {
       ASTCDCompilationUnit cd =
           parseModel("src/test/resources/de/monticore/cddiff/Employees" + "/Employees2.cd");
-      ASTODArtifact od =
+      Optional<ASTODArtifact> od =
           new OD4ReportParser()
-              .parse("src/test/resources/de/monticore/cddiff/JoinLinksTrafo/EmployeesInstance.od")
-              .get();
-      new JoinLinksTrafo(cd).transform(od);
-      Assert.assertEquals(
+              .parse("src/test/resources/de/monticore/cddiff/JoinLinksTrafo/EmployeesInstance.od");
+      
+      assertTrue(od.isPresent());
+      new JoinLinksTrafo(cd).transform(od.get());
+      assertEquals(
           3,
-          od.getObjectDiagram().getODElementList().stream()
+          od.get().getObjectDiagram().getODElementList().stream()
               .filter(element -> element instanceof ASTODLink)
               .collect(Collectors.toSet())
               .size());
-      Log.print(System.lineSeparator() + OD4ReportMill.prettyPrint(od, true));
+      Log.print(System.lineSeparator() + OD4ReportMill.prettyPrint(od.get(), true));
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
   }
 }

--- a/cddiff/src/test/java/de/monticore/cddiff/alloy2od/WitnessTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/alloy2od/WitnessTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.alloy2od;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.alloycddiff.AlloyCDDiff;
@@ -10,9 +8,12 @@ import de.monticore.cddiff.alloycddiff.CDSemantics;
 import de.monticore.cddiff.alloycddiff.alloyRunner.AlloyDiffSolution;
 import de.monticore.odbasis._ast.ASTODArtifact;
 import de.monticore.odvalidity.OD2CDMatcher;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /** Test if diff-witnesses match first class diagram and not second */
 public class WitnessTest extends CDDiffTestBasis {

--- a/cddiff/src/test/java/de/monticore/cddiff/alloycddiff/AlloyDiffTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/alloycddiff/AlloyDiffTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.alloycddiff;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.alloycddiff.alloyRunner.AlloyDiffSolution;
@@ -15,7 +13,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /** Test classes to test the generation of different alloy modules for cddiff */
 public class AlloyDiffTest extends CDDiffTestBasis {

--- a/cddiff/src/test/java/de/monticore/cddiff/alloycddiff/AssociationChainTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/alloycddiff/AssociationChainTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.alloycddiff;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.alloycddiff.alloyRunner.AlloyDiffSolution;
@@ -15,7 +13,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /** Test classes to test the generation of different alloy modules for cddiff */
 public class AssociationChainTest extends CDDiffTestBasis {
@@ -88,7 +88,7 @@ public class AssociationChainTest extends CDDiffTestBasis {
                 + astV2.getCDDefinition().getName());
 
     // Assertion that no difference should be found in this scope
-    assertTrue(optS1.isPresent() && optS1.get().generateODs().size() == 0);
+    assertTrue(optS1.isPresent() && optS1.get().generateODs().isEmpty());
     // Generate outputs
     optS1.get().generateSolutionsToPath(outputDirectoryS1);
 
@@ -125,7 +125,7 @@ public class AssociationChainTest extends CDDiffTestBasis {
                 + "_"
                 + astV1.getCDDefinition().getName());
     // Assertion that no difference should be found in this scope
-    assertTrue(optS2.isPresent() && optS2.get().generateODs().size() == 0);
+    assertTrue(optS2.isPresent() && optS2.get().generateODs().isEmpty());
     // Generate outputs
     optS2.get().generateSolutionsToPath(outputDirectoryS2);
   }

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/AlloyGeneratorTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/AlloyGeneratorTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy;
 
-import static org.junit.Assert.assertNotNull;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.alloycddiff.CDSemantics;
@@ -12,7 +10,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** This is an integration test that e.g. checks that generated files exist as expected. */
 public class AlloyGeneratorTest extends CDDiffTestBasis {

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/OpenWorldGeneratorTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/OpenWorldGeneratorTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy;
 
-import static org.junit.Assert.assertNotNull;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.OpenWorldGenerator;
@@ -10,7 +8,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class OpenWorldGeneratorTest extends CDDiffTestBasis {
 

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ParserTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ParserTest.java
@@ -1,11 +1,11 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy;
 
-import static org.junit.Assert.assertNotNull;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** Testing that the models can be parsed. */
 public class ParserTest extends CDDiffTestBasis {

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/cocos/IllegalAttributeModifierTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/cocos/IllegalAttributeModifierTest.java
@@ -11,7 +11,7 @@ import de.se_rwth.commons.logging.Finding;
 import de.se_rwth.commons.logging.Log;
 import java.util.Collection;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests to detect currently not supported modifiers. */
 public class IllegalAttributeModifierTest extends CDDiffTestBasis {

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/cocos/IllegalSymbolsTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/cocos/IllegalSymbolsTest.java
@@ -11,7 +11,7 @@ import de.se_rwth.commons.logging.Finding;
 import de.se_rwth.commons.logging.Log;
 import java.util.Arrays;
 import java.util.Collection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for the detection of illegal symbols */
 public class IllegalSymbolsTest extends CDDiffTestBasis {

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A1RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A1RuleTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class A1RuleTest extends CDDiffTestBasis {
@@ -24,7 +24,7 @@ public class A1RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A2RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A2RuleTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class A2RuleTest extends CDDiffTestBasis {
@@ -18,7 +18,7 @@ public class A2RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit mvAst =
       parseModel("src/test/resources/de/monticore/cddiff/VehicleManagement/cd1.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
   }

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A3RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A3RuleTest.java
@@ -1,15 +1,15 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class A3RuleTest extends CDDiffTestBasis {
@@ -17,7 +17,7 @@ public class A3RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit mvAst =
       parseModel("src/test/resources/de/monticore/cddiff/VehicleManagement/cd1.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
   }

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A4RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A4RuleTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class A4RuleTest extends CDDiffTestBasis {
@@ -18,7 +18,7 @@ public class A4RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit mvAst =
       parseModel("src/test/resources/de/monticore/cddiff/VehicleManagement/cd1.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
   }

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A5RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A5RuleTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class A5RuleTest extends CDDiffTestBasis {
@@ -18,7 +18,7 @@ public class A5RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit mvAst =
       parseModel("src/test/resources/de/monticore/cddiff/VehicleManagement/cd1.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
   }

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A6RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/A6RuleTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class A6RuleTest extends CDDiffTestBasis {
@@ -18,7 +18,7 @@ public class A6RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit mvAst =
       parseModel("src/test/resources/de/monticore/cddiff/VehicleManagement/cd1.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
   }

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/F1RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/F1RuleTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
@@ -10,8 +10,8 @@ import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class F1RuleTest extends CDDiffTestBasis {
@@ -25,7 +25,7 @@ public class F1RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/F2RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/F2RuleTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
@@ -10,8 +10,8 @@ import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class F2RuleTest extends CDDiffTestBasis {
@@ -25,7 +25,7 @@ public class F2RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/F3RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/F3RuleTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
@@ -11,8 +11,8 @@ import de.se_rwth.commons.logging.Log;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class F3RuleTest extends CDDiffTestBasis {
@@ -26,7 +26,7 @@ public class F3RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/F4RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/F4RuleTest.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
@@ -10,8 +10,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class F4RuleTest extends CDDiffTestBasis {
@@ -25,7 +25,7 @@ public class F4RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/P1RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/P1RuleTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Tests the P1 rule using the examples from the technical report */
 public class P1RuleTest extends CDDiffTestBasis {
@@ -24,7 +24,7 @@ public class P1RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/P2RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/P2RuleTest.java
@@ -1,14 +1,14 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Tests the P2 rule using the examples from the technical report */
 public class P2RuleTest extends CDDiffTestBasis {
@@ -22,7 +22,7 @@ public class P2RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/P3RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/P3RuleTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Tests the P3 rule using the examples from the technical report */
 public class P3RuleTest extends CDDiffTestBasis {
@@ -24,7 +24,7 @@ public class P3RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/P4RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/P4RuleTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
@@ -10,8 +10,8 @@ import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Tests the P4 rule using the examples from the technical report */
 public class P4RuleTest extends CDDiffTestBasis {
@@ -25,7 +25,7 @@ public class P4RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/U1RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/U1RuleTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class U1RuleTest extends CDDiffTestBasis {
@@ -24,7 +24,7 @@ public class U1RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/U2RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/U2RuleTest.java
@@ -1,15 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertTrue;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class U2RuleTest extends CDDiffTestBasis {
@@ -23,7 +24,7 @@ public class U2RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/U3RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/U3RuleTest.java
@@ -1,16 +1,17 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class U3RuleTest extends CDDiffTestBasis {
@@ -24,7 +25,7 @@ public class U3RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/U4RuleTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/cd2alloy/ruletest/U4RuleTest.java
@@ -1,16 +1,17 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.cd2alloy.ruletest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.cd2alloy.generator.CD2AlloyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Unit test for the U1 rule for the generation of common class names */
 public class U4RuleTest extends CDDiffTestBasis {
@@ -24,7 +25,7 @@ public class U4RuleTest extends CDDiffTestBasis {
   protected ASTCDCompilationUnit m2Ast =
       parseModel("src/test/resources/de/monticore/cddiff/Employees/Employees2.cd");
 
-  @Before
+  @BeforeEach
   public void prepareASTs() {
     prepareAST(mvAst);
     prepareAST(m1Ast);

--- a/cddiff/src/test/java/de/monticore/cddiff/ow2cw/CDAssociationHelperTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/ow2cw/CDAssociationHelperTest.java
@@ -8,16 +8,18 @@ import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.CDDiffUtil;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CDAssociationHelperTest extends CDDiffTestBasis {
   protected final ASTCDCompilationUnit conflictCD =
       parseModel("src/test/resources/de/monticore/cddiff/Conflict/ConflictEmployees.cd");
   protected ICD4CodeArtifactScope scope;
 
-  @Before
+  @BeforeEach
   public void buildSymbolTable() {
     CDDiffUtil.refreshSymbolTable(conflictCD);
     scope = (ICD4CodeArtifactScope) conflictCD.getEnclosingScope();
@@ -29,10 +31,10 @@ public class CDAssociationHelperTest extends CDDiffTestBasis {
         new ArrayList<>(conflictCD.getCDDefinition().getCDAssociationsList());
     for (ASTCDAssociation src : conflictCD.getCDDefinition().getCDAssociationsList()) {
       assocList.remove(src);
-      Assert.assertTrue(
+      assertTrue(
           assocList.stream()
               .anyMatch(target -> CDAssociationHelper.inConflict(src, target, scope)));
-      Assert.assertFalse(
+      assertFalse(
           assocList.stream()
               .allMatch(target -> CDAssociationHelper.inConflict(src, target, scope)));
       assocList.add(src);
@@ -45,7 +47,7 @@ public class CDAssociationHelperTest extends CDDiffTestBasis {
         new ArrayList<>(conflictCD.getCDDefinition().getCDAssociationsList());
     for (ASTCDAssociation src : conflictCD.getCDDefinition().getCDAssociationsList()) {
       assocList.remove(src);
-      Assert.assertTrue(
+      assertTrue(
           assocList.stream().noneMatch(target -> CDAssociationHelper.sameAssociation(src, target)));
       assocList.add(src);
     }
@@ -57,7 +59,7 @@ public class CDAssociationHelperTest extends CDDiffTestBasis {
         new ArrayList<>(conflictCD.getCDDefinition().getCDAssociationsList());
     for (ASTCDAssociation src : conflictCD.getCDDefinition().getCDAssociationsList()) {
       assocList.remove(src);
-      Assert.assertTrue(
+      assertTrue(
           assocList.stream()
               .anyMatch(
                   target ->
@@ -65,7 +67,7 @@ public class CDAssociationHelperTest extends CDDiffTestBasis {
                           || CDAssociationHelper.isSuperAssociationInReverse(src, target, scope)
                           || CDAssociationHelper.isSuperAssociation(target, src, scope)
                           || CDAssociationHelper.isSuperAssociationInReverse(target, src, scope)));
-      Assert.assertFalse(
+      assertFalse(
           assocList.stream()
               .allMatch(
                   target ->

--- a/cddiff/src/test/java/de/monticore/cddiff/ow2cw/CDInheritanceHelperTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/ow2cw/CDInheritanceHelperTest.java
@@ -12,8 +12,10 @@ import de.monticore.cddiff.CDDiffUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CDInheritanceHelperTest extends CDDiffTestBasis {
 
@@ -28,7 +30,7 @@ public class CDInheritanceHelperTest extends CDDiffTestBasis {
 
     opt.ifPresent(
         cdTypeSymbol ->
-            Assert.assertTrue(
+            assertTrue(
                 CDInheritanceHelper.isAttributInSuper(
                     CDAttributeFacade.getInstance()
                         .createAttribute(
@@ -56,7 +58,7 @@ public class CDInheritanceHelperTest extends CDDiffTestBasis {
 
     if (opt.isPresent()) {
       for (ASTCDType superType : CDInheritanceHelper.getAllSuper(opt.get().getAstNode(), scope1)) {
-        Assert.assertTrue(superList.stream().anyMatch(name -> name.equals(superType.getName())));
+        assertTrue(superList.stream().anyMatch(name -> name.equals(superType.getName())));
       }
     }
   }
@@ -72,7 +74,7 @@ public class CDInheritanceHelperTest extends CDDiffTestBasis {
         .resolveCDType("Manager")
         .ifPresent(
             src ->
-                Assert.assertEquals(
+                assertEquals(
                     "ins.Employee",
                     CDInheritanceHelper.resolveClosestType(
                             src.getAstNode(), "Employee", employees8.getEnclosingScope())

--- a/cddiff/src/test/java/de/monticore/cddiff/ow2cw/FullExpanderTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/ow2cw/FullExpanderTest.java
@@ -15,8 +15,9 @@ import de.monticore.cddiff.ow2cw.expander.FullExpander;
 import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FullExpanderTest extends CDDiffTestBasis {
 
@@ -44,7 +45,7 @@ public class FullExpanderTest extends CDDiffTestBasis {
     machines = parseModel("src/test/resources/de/monticore/cddiff/Machines/Machines3.cd");
     machines.getCDDefinition().setName("Machines2");
 
-    Assert.assertEquals(result, CD4CodeMill.prettyPrint(machines, false));
+    assertEquals(result, CD4CodeMill.prettyPrint(machines, false));
   }
 
   @Test
@@ -82,7 +83,7 @@ public class FullExpanderTest extends CDDiffTestBasis {
     machines.getCDDefinition().setName("Machines1");
     CD4CodeMill.scopesGenitorDelegator().createFromAST(machines);
 
-    Assert.assertEquals(result, CD4CodeMill.prettyPrint(machines, false));
+    assertEquals(result, CD4CodeMill.prettyPrint(machines, false));
   }
 
   @Test
@@ -110,7 +111,7 @@ public class FullExpanderTest extends CDDiffTestBasis {
 
     machines5.getCDDefinition().setName("Machines4");
 
-    Assert.assertEquals(result, CD4CodeMill.prettyPrint(machines5, false));
+    assertEquals(result, CD4CodeMill.prettyPrint(machines5, false));
   }
 
   @Test
@@ -136,7 +137,7 @@ public class FullExpanderTest extends CDDiffTestBasis {
 
     machines4.getCDDefinition().setName("Machines3");
 
-    Assert.assertEquals(result, CD4CodeMill.prettyPrint(machines4, false));
+    assertEquals(result, CD4CodeMill.prettyPrint(machines4, false));
   }
 
   @Test
@@ -161,7 +162,7 @@ public class FullExpanderTest extends CDDiffTestBasis {
     lecture4.getCDDefinition().setName("Lecture5");
     CDDiffUtil.refreshSymbolTable(lecture4);
 
-    Assert.assertEquals(result, CD4CodeMill.prettyPrint(lecture4, false));
+    assertEquals(result, CD4CodeMill.prettyPrint(lecture4, false));
   }
 
   @Test
@@ -184,7 +185,7 @@ public class FullExpanderTest extends CDDiffTestBasis {
 
     enumComp2.getCDDefinition().setName("enumCompV1");
 
-    Assert.assertEquals(result, CD4CodeMill.prettyPrint(enumComp2, false));
+    assertEquals(result, CD4CodeMill.prettyPrint(enumComp2, false));
   }
 
   @Test
@@ -212,7 +213,7 @@ public class FullExpanderTest extends CDDiffTestBasis {
     lecture = parseModel("src/test/resources/de/monticore/cddiff/Lecture/Lecture3.cd");
     lecture.getCDDefinition().setName("Lecture2");
 
-    Assert.assertEquals(result, CD4CodeMill.prettyPrint(lecture, false));
+    assertEquals(result, CD4CodeMill.prettyPrint(lecture, false));
   }
 
   @Test
@@ -226,7 +227,7 @@ public class FullExpanderTest extends CDDiffTestBasis {
         .resolveCDTypeDown("ins.Employee")
         .ifPresent(
             type ->
-                Assert.assertEquals("ins", fullExpander.determinePackageName(type.getAstNode())));
+                assertEquals("ins", fullExpander.determinePackageName(type.getAstNode())));
   }
 
   @Test
@@ -242,15 +243,15 @@ public class FullExpanderTest extends CDDiffTestBasis {
 
     fullExpander.updateDir2Match(lecture1.getCDDefinition().getCDAssociationsList());
 
-    Assert.assertTrue(
+    assertTrue(
         lecture2.getCDDefinition().getCDAssociationsList().stream()
             .anyMatch(assoc2 -> assoc2.getCDAssocDir().isBidirectional()));
 
-    Assert.assertTrue(
+    assertTrue(
         lecture2.getCDDefinition().getCDAssociationsList().stream()
             .allMatch(assoc2 -> assoc2.getCDAssocDir().isDefinitiveNavigableRight()));
 
-    Assert.assertFalse(
+    assertFalse(
         lecture2.getCDDefinition().getCDAssociationsList().stream()
             .allMatch(assoc2 -> assoc2.getCDAssocDir().isBidirectional()));
   }
@@ -268,15 +269,15 @@ public class FullExpanderTest extends CDDiffTestBasis {
 
     fullExpander.updateDir4Diff(lecture1.getCDDefinition().getCDAssociationsList());
 
-    Assert.assertTrue(
+    assertTrue(
         lecture2.getCDDefinition().getCDAssociationsList().stream()
             .anyMatch(assoc -> assoc.getCDAssocDir().isDefinitiveNavigableLeft()));
 
-    Assert.assertTrue(
+    assertTrue(
         lecture2.getCDDefinition().getCDAssociationsList().stream()
             .noneMatch(assoc -> assoc.getCDAssocDir().isBidirectional()));
 
-    Assert.assertTrue(
+    assertTrue(
         lecture2.getCDDefinition().getCDAssociationsList().stream()
             .allMatch(
                 assoc ->
@@ -305,12 +306,12 @@ public class FullExpanderTest extends CDDiffTestBasis {
             .filter(assoc -> assoc.getCDAssocDir().isDefinitiveNavigableLeft())
             .count();
 
-    Assert.assertEquals(left2right + right2left, assocList.size());
+    assertEquals(left2right + right2left, assocList.size());
 
     for (ASTCDAssociation assoc : assocList) {
       String node = CD4CodeMill.prettyPrint(assoc, false);
-      Assert.assertTrue(node.contains("->"));
-      Assert.assertTrue(node.contains("Object;"));
+      assertTrue(node.contains("->"));
+      assertTrue(node.contains("Object;"));
     }
   }
 
@@ -326,6 +327,6 @@ public class FullExpanderTest extends CDDiffTestBasis {
     FullExpander fullExpander = new FullExpander(new BasicExpander(conflictCD));
     fullExpander.addAssociationsWithoutConflicts(assocList);
 
-    Assert.assertEquals(assocList, conflictCD.getCDDefinition().getCDAssociationsList());
+    assertEquals(assocList, conflictCD.getCDDefinition().getCDAssociationsList());
   }
 }

--- a/cddiff/src/test/java/de/monticore/cddiff/ow2cw/ReductionTrafoTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/ow2cw/ReductionTrafoTest.java
@@ -14,8 +14,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReductionTrafoTest extends CDDiffTestBasis {
 
@@ -99,7 +100,7 @@ public class ReductionTrafoTest extends CDDiffTestBasis {
 
     String cd2 = CD4CodeMill.prettyPrint(lecture2, false);
 
-    Assert.assertEquals(cd1, cd2);
+    assertEquals(cd1, cd2);
   }
 
   @Test
@@ -127,11 +128,11 @@ public class ReductionTrafoTest extends CDDiffTestBasis {
     for (ASTCDType type : typeList) {
       if (subList.stream()
           .anyMatch(sub -> sub.equals(type.getSymbol().getInternalQualifiedName()))) {
-        Assert.assertFalse(
+        assertFalse(
             type.getCDAttributeList().stream()
                 .anyMatch(attribute -> attribute.getName().equals("test")));
       } else {
-        Assert.assertTrue(
+        assertTrue(
             type.getCDAttributeList().stream()
                 .anyMatch(attribute -> attribute.getName().equals("test")));
       }
@@ -145,14 +146,14 @@ public class ReductionTrafoTest extends CDDiffTestBasis {
     new ReductionTrafo().createCommonInterface(employees8, "Object");
     ICD4CodeArtifactScope scope = CD4CodeMill.scopesGenitorDelegator().createFromAST(employees8);
 
-    Assert.assertTrue(
+    assertTrue(
         employees8.getCDDefinition().getCDClassesList().stream()
             .allMatch(
                 cdClass ->
                     CDInheritanceHelper.isSuperOf(
                         "Object", cdClass.getSymbol().getInternalQualifiedName(), scope)));
 
-    Assert.assertTrue(
+    assertTrue(
         employees8.getCDDefinition().getCDInterfacesList().stream()
             .allMatch(
                 cdInterface ->

--- a/cddiff/src/test/java/de/monticore/cddiff/ow2cw/VariableDiffTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/ow2cw/VariableDiffTest.java
@@ -8,9 +8,11 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.CDDiffUtil;
 import de.monticore.cddiff.ow2cw.expander.VariableExpander;
+import org.junit.jupiter.api.Test;
+
 import java.util.HashSet;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class VariableDiffTest extends CDDiffTestBasis {
 
@@ -31,41 +33,41 @@ public class VariableDiffTest extends CDDiffTestBasis {
 
     System.out.println(CD4CodeMill.prettyPrint(cd1, true));
 
-    Assert.assertTrue(
+    assertTrue(
         cd2.getCDDefinition().getModifier().isPresentStereotype()
             && cd2.getCDDefinition()
                 .getModifier()
                 .getStereotype()
                 .contains(VariableExpander.VAR_TAG));
 
-    Assert.assertTrue(
+    assertTrue(
         cd2.getCDDefinition().getCDClassesList().stream()
             .noneMatch(
                 subClass ->
                     subClass.getName().contains("Sub4Diff")
                         || subClass.getName().contains("ManagerTask")));
 
-    Assert.assertTrue(
+    assertTrue(
         cd2.getCDDefinition().getCDInterfacesList().stream()
             .noneMatch(subClass -> subClass.getName().contains("Doable")));
 
-    Assert.assertEquals(3, cd2.getCDDefinition().getCDAssociationsList().size());
+    assertEquals(3, cd2.getCDDefinition().getCDAssociationsList().size());
 
     int found = 0;
     for (ASTCDClass current : new HashSet<>(cd1.getCDDefinition().getCDClassesList())) {
       if (current.getName().equals("Employee")) {
-        Assert.assertFalse(CDInheritanceHelper.isSuperOf("Insurable", "Employee", scope1));
+        assertFalse(CDInheritanceHelper.isSuperOf("Insurable", "Employee", scope1));
         found++;
       }
       if (current.getName().equals("Person")) {
-        Assert.assertTrue(current.getCDAttributeList().isEmpty());
+        assertTrue(current.getCDAttributeList().isEmpty());
         found++;
       }
     }
-    Assert.assertEquals(2, found);
+    assertEquals(2, found);
 
-    Assert.assertEquals(3, cd1.getCDDefinition().getCDAssociationsList().size());
-    Assert.assertEquals(
+    assertEquals(3, cd1.getCDDefinition().getCDAssociationsList().size());
+    assertEquals(
         2, cd1.getCDDefinition().getCDEnumsList().get(0).getCDEnumConstantList().size());
   }
 }

--- a/cddiff/src/test/java/de/monticore/cddiff/similaritymeasure/SemanticObjectSizeMeasureTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/similaritymeasure/SemanticObjectSizeMeasureTest.java
@@ -1,12 +1,13 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.similaritymeasure;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** Test classes to test the similarity measure for semantic size differencing */
 public class SemanticObjectSizeMeasureTest extends CDDiffTestBasis {
@@ -17,7 +18,7 @@ public class SemanticObjectSizeMeasureTest extends CDDiffTestBasis {
    * desired again: Please test against concrete differences/etc. and not against an abstract
    * difference value that is subject to changes.
    */
-  @Ignore
+  @Disabled
   @Test
   public void testManger() {
     // Parse Test Modules

--- a/cddiff/src/test/java/de/monticore/cddiff/syndiff/AssocDiffTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/syndiff/AssocDiffTest.java
@@ -9,8 +9,9 @@ import de.monticore.odbasis._ast.ASTODArtifact;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AssocDiffTest extends CDDiffTestBasis {
 
@@ -95,11 +96,11 @@ public class AssocDiffTest extends CDDiffTestBasis {
         this.tgt = tgt.get();
         this.src = src.get();
       } else {
-        Assert.fail("Could not parse CDs.");
+        fail("Could not parse CDs.");
       }
 
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
   }
 }

--- a/cddiff/src/test/java/de/monticore/cddiff/syndiff/ComplexityTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/syndiff/ComplexityTest.java
@@ -1,7 +1,5 @@
 package de.monticore.cddiff.syndiff;
 
-import static org.junit.Assert.assertNotNull;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.alloycddiff.AlloyCDDiff;
@@ -12,12 +10,15 @@ import de.monticore.cddiff.syn2semdiff.Syn2SemDiff;
 import de.monticore.odbasis._ast.ASTODArtifact;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ComplexityTest extends CDDiffTestBasis {
   @Test
-  @Ignore
+  @Disabled
   public void testRuntime4Performance() {
 
     String path = "src/test/resources/de/monticore/cddiff/Performance/";
@@ -68,7 +69,7 @@ public class ComplexityTest extends CDDiffTestBasis {
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void testRunTime4PerformanceNoLink() {
     String path = "src/test/resources/de/monticore/cddiff/Performance/";
 
@@ -118,7 +119,7 @@ public class ComplexityTest extends CDDiffTestBasis {
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void testRunTime4Performance100() {
     String path = "src/test/resources/de/monticore/cddiff/Performance/";
 

--- a/cddiff/src/test/java/de/monticore/cddiff/syndiff/MemberDiffTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/syndiff/MemberDiffTest.java
@@ -8,8 +8,9 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffTestBasis;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MemberDiffTest extends CDDiffTestBasis {
 
@@ -49,11 +50,11 @@ public class MemberDiffTest extends CDDiffTestBasis {
         this.tgt = tgt.get();
         this.src = src.get();
       } else {
-        Assert.fail("Could not parse CDs.");
+        fail("Could not parse CDs.");
       }
 
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
   }
 }

--- a/cddiff/src/test/java/de/monticore/cddiff/syndiff/Performance.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/syndiff/Performance.java
@@ -1,7 +1,5 @@
 package de.monticore.cddiff.syndiff;
 
-import static org.junit.Assert.assertNotNull;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiff;
 import de.monticore.cddiff.CDDiffTestBasis;
@@ -10,13 +8,16 @@ import de.monticore.cddiff.ow2cw.ReductionTrafo;
 import de.monticore.cddiff.syn2semdiff.Syn2SemDiff;
 import de.monticore.odbasis._ast.ASTODArtifact;
 import java.util.List;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class Performance extends CDDiffTestBasis {
 
   @Test
-  @Ignore
+  @Disabled
   public void test() {
     String path = "src/test/resources/validation/Performance/";
 
@@ -56,7 +57,7 @@ public class Performance extends CDDiffTestBasis {
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void test10() {
     String path = "src/test/resources/validation/Performance/";
 
@@ -96,7 +97,7 @@ public class Performance extends CDDiffTestBasis {
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void test15() {
     String path = "src/test/resources/validation/Performance/";
 
@@ -136,7 +137,7 @@ public class Performance extends CDDiffTestBasis {
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void testOpenW() {
     String path = "src/test/resources/validation/Performance/";
 

--- a/cddiff/src/test/java/de/monticore/cddiff/syndiff/Syn2SemDiffTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/syndiff/Syn2SemDiffTest.java
@@ -10,8 +10,9 @@ import de.monticore.odvalidity.OD2CDMatcher;
 import de.monticore.prettyprint.IndentPrinter;
 import de.se_rwth.commons.logging.Log;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Syn2SemDiffTest extends CDDiffTestBasis {
 
@@ -27,7 +28,7 @@ public class Syn2SemDiffTest extends CDDiffTestBasis {
     Syn2SemDiff syn2semdiff = new Syn2SemDiff(compilationUnitNew, compilationUnitOld);
     List<ASTODArtifact> witnesses = syn2semdiff.generateODs(false);
 
-    Assert.assertTrue(witnesses.isEmpty());
+    assertTrue(witnesses.isEmpty());
   }
 
   @Test
@@ -42,7 +43,7 @@ public class Syn2SemDiffTest extends CDDiffTestBasis {
     Syn2SemDiff syn2semdiff = new Syn2SemDiff(compilationUnitNew, compilationUnitOld);
     List<ASTODArtifact> witnesses = syn2semdiff.generateODs(false);
 
-    Assert.assertTrue(witnesses.isEmpty());
+    assertTrue(witnesses.isEmpty());
   }
 
   @Test
@@ -57,7 +58,7 @@ public class Syn2SemDiffTest extends CDDiffTestBasis {
     Syn2SemDiff syn2semdiff = new Syn2SemDiff(compilationUnitNew, compilationUnitOld);
     List<ASTODArtifact> witnesses = syn2semdiff.generateODs(false);
 
-    Assert.assertTrue(witnesses.isEmpty());
+    assertTrue(witnesses.isEmpty());
   }
 
   @Test
@@ -72,14 +73,14 @@ public class Syn2SemDiffTest extends CDDiffTestBasis {
     Syn2SemDiff syn2semdiff = new Syn2SemDiff(compilationUnitNew, compilationUnitOld);
     List<ASTODArtifact> witnesses = syn2semdiff.generateODs(false);
 
-    Assert.assertFalse(witnesses.isEmpty());
+    assertFalse(witnesses.isEmpty());
 
     for (ASTODArtifact od : witnesses) {
       if (!new OD2CDMatcher()
           .checkIfDiffWitness(
               CDSemantics.SIMPLE_CLOSED_WORLD, compilationUnitNew, compilationUnitOld, od)) {
         Log.println(new OD4ReportFullPrettyPrinter(new IndentPrinter()).prettyprint(od));
-        Assert.fail();
+        fail();
       }
     }
   }
@@ -98,7 +99,7 @@ public class Syn2SemDiffTest extends CDDiffTestBasis {
           .checkIfDiffWitness(
               CDSemantics.SIMPLE_CLOSED_WORLD, compilationUnitNew, compilationUnitOld, od)) {
         Log.println(new OD4ReportFullPrettyPrinter(new IndentPrinter()).prettyprint(od));
-        Assert.fail();
+        fail();
       }
     }
   }
@@ -116,7 +117,7 @@ public class Syn2SemDiffTest extends CDDiffTestBasis {
           .checkIfDiffWitness(
               CDSemantics.SIMPLE_CLOSED_WORLD, compilationUnitNew, compilationUnitOld, od)) {
         Log.println(new OD4ReportFullPrettyPrinter(new IndentPrinter()).prettyprint(od));
-        Assert.fail();
+        fail();
       }
     }
   }
@@ -134,7 +135,7 @@ public class Syn2SemDiffTest extends CDDiffTestBasis {
           .checkIfDiffWitness(
               CDSemantics.SIMPLE_CLOSED_WORLD, compilationUnitNew, compilationUnitOld, od)) {
         Log.println(new OD4ReportFullPrettyPrinter(new IndentPrinter()).prettyprint(od));
-        Assert.fail();
+        fail();
       }
     }
   }

--- a/cddiff/src/test/java/de/monticore/cddiff/syndiff/SyntaxDiffTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/syndiff/SyntaxDiffTest.java
@@ -7,8 +7,10 @@ import de.monticore.cddiff.CDDiffTestBasis;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SyntaxDiffTest extends CDDiffTestBasis {
 
@@ -27,8 +29,8 @@ public class SyntaxDiffTest extends CDDiffTestBasis {
         parseModel("src/test/resources/de/monticore/cddiff/DigitalTwins/DigitalTwin1.cd");
 
     CDSyntaxDiff synDiff = new CDSyntaxDiff(compilationUnitNew, compilationUnitOld, List.of());
-    Assert.assertEquals(4, synDiff.getAddedClasses().size());
-    Assert.assertEquals(2, synDiff.getAddedAssocs().size());
+    assertEquals(4, synDiff.getAddedClasses().size());
+    assertEquals(2, synDiff.getAddedAssocs().size());
   }
 
   @Test
@@ -81,11 +83,11 @@ public class SyntaxDiffTest extends CDDiffTestBasis {
         this.tgt = tgt.get();
         this.src = src.get();
       } else {
-        Assert.fail("Could not parse CDs.");
+        fail("Could not parse CDs.");
       }
 
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
   }
 }

--- a/cddiff/src/test/java/de/monticore/cddiff/syndiff/TypeDIffTest.java
+++ b/cddiff/src/test/java/de/monticore/cddiff/syndiff/TypeDIffTest.java
@@ -17,9 +17,10 @@ import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TypeDIffTest extends CDDiffTestBasis {
 
@@ -59,7 +60,7 @@ public class TypeDIffTest extends CDDiffTestBasis {
           .checkIfDiffWitness(
               CDSemantics.SIMPLE_CLOSED_WORLD, compilationUnitNew, compilationUnitOld, od)) {
         Log.println(new OD4ReportFullPrettyPrinter(new IndentPrinter()).prettyprint(od));
-        Assertions.fail();
+        fail();
       }
     }
   }
@@ -83,7 +84,7 @@ public class TypeDIffTest extends CDDiffTestBasis {
           .checkIfDiffWitness(
               CDSemantics.SIMPLE_CLOSED_WORLD, compilationUnitNew, compilationUnitOld, od)) {
         Log.println(new OD4ReportFullPrettyPrinter(new IndentPrinter()).prettyprint(od));
-        Assertions.fail();
+        fail();
       }
     }
   }
@@ -108,7 +109,7 @@ public class TypeDIffTest extends CDDiffTestBasis {
           .checkIfDiffWitness(
               CDSemantics.SIMPLE_CLOSED_WORLD, compilationUnitNew, compilationUnitOld, od)) {
         Log.println(new OD4ReportFullPrettyPrinter(new IndentPrinter()).prettyprint(od));
-        Assertions.fail();
+        fail();
       }
     }
   }
@@ -214,11 +215,11 @@ public class TypeDIffTest extends CDDiffTestBasis {
         this.tgt = tgt.get();
         this.src = src.get();
       } else {
-        Assert.fail("Could not parse CDs.");
+        fail("Could not parse CDs.");
       }
 
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
   }
 }

--- a/cddiff/src/test/java/de/monticore/cdmatcher/CD2CDMatcherTest.java
+++ b/cddiff/src/test/java/de/monticore/cdmatcher/CD2CDMatcherTest.java
@@ -1,7 +1,6 @@
 package de.monticore.cdmatcher;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;

--- a/cddiff/src/test/java/de/monticore/odvalidity/AssociationsMatcherTest.java
+++ b/cddiff/src/test/java/de/monticore/odvalidity/AssociationsMatcherTest.java
@@ -13,9 +13,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssociationsMatcherTest {
 
@@ -37,7 +38,7 @@ public class AssociationsMatcherTest {
 
   AssociationsMatcher matcher;
 
-  @Before
+  @BeforeEach
   public void before() {
 
     LogStub.init();
@@ -80,6 +81,6 @@ public class AssociationsMatcherTest {
     assert (true);
 
     loadModels("/Cardinality.od", "/Cardinality.cd");
-    Assert.assertTrue(matcher.checkAssociations(od, cd, CDSemantics.SIMPLE_CLOSED_WORLD));
+    assertTrue(matcher.checkAssociations(od, cd, CDSemantics.SIMPLE_CLOSED_WORLD));
   }
 }

--- a/cddiff/src/test/java/de/monticore/odvalidity/ClassMatcherTest.java
+++ b/cddiff/src/test/java/de/monticore/odvalidity/ClassMatcherTest.java
@@ -9,9 +9,10 @@ import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import java.io.File;
 import java.io.FileNotFoundException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ClassMatcherTest {
   final String resources = "src/test/resources/de/monticore/odvalidity/classmatcher/";
@@ -39,7 +40,7 @@ public class ClassMatcherTest {
 
   final ClassMatcher classMatcher = new ClassMatcher();
 
-  @Before
+  @BeforeEach
   public void initTests() {
     LogStub.init();
     CD4CodeMill.init();
@@ -98,10 +99,10 @@ public class ClassMatcherTest {
       throws FileNotFoundException {
     reloadOD(odPath);
 
-    Assert.assertEquals(
+    assertEquals(
         shouldPass,
         classMatcher.checkAllObjectsInClassDiagram(od, cd, CDSemantics.SIMPLE_CLOSED_WORLD));
-    Assert.assertEquals(
+    assertEquals(
         shouldPass,
         classMatcher.checkAllObjectsInClassDiagram(od, cd, CDSemantics.SIMPLE_OPEN_WORLD));
   }
@@ -110,6 +111,6 @@ public class ClassMatcherTest {
       throws FileNotFoundException {
     reloadOD(odPath);
 
-    Assert.assertEquals(shouldPass, classMatcher.checkAllObjectsInClassDiagram(od, cd, semantic));
+    assertEquals(shouldPass, classMatcher.checkAllObjectsInClassDiagram(od, cd, semantic));
   }
 }

--- a/cddiff/src/test/java/de/monticore/odvalidity/ExampleDiffTest.java
+++ b/cddiff/src/test/java/de/monticore/odvalidity/ExampleDiffTest.java
@@ -1,6 +1,7 @@
 package de.monticore.odvalidity;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
@@ -8,8 +9,7 @@ import de.monticore.cddiff.CDDiffTestBasis;
 import de.monticore.cddiff.alloycddiff.CDSemantics;
 import java.io.IOException;
 import java.nio.file.Path;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExampleDiffTest extends CDDiffTestBasis {
   @Test
@@ -24,7 +24,7 @@ public class ExampleDiffTest extends CDDiffTestBasis {
 
     try {
       for (int i = 1; i <= 5; i++) {
-        Assert.assertTrue(
+        assertTrue(
             new OD2CDMatcher()
                 .checkIfDiffWitness(
                     CDSemantics.SIMPLE_CLOSED_WORLD,

--- a/cddiff/src/test/java/de/monticore/odvalidity/ModelLoaderTest.java
+++ b/cddiff/src/test/java/de/monticore/odvalidity/ModelLoaderTest.java
@@ -8,9 +8,11 @@ import de.se_rwth.commons.logging.LogStub;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ModelLoaderTest {
 
@@ -24,7 +26,7 @@ public class ModelLoaderTest {
 
   ModelLoader loader;
 
-  @Before
+  @BeforeEach
   public void reloadModels() {
 
     LogStub.init();
@@ -41,10 +43,10 @@ public class ModelLoaderTest {
     try {
 
       Optional<ASTCDCompilationUnit> cd = loader.loadCDModel(cdModel1);
-      Assert.assertTrue(cd.isPresent());
+      assertTrue(cd.isPresent());
 
     } catch (FileNotFoundException e) {
-      Assert.fail("File could not be found.");
+      fail("File could not be found.");
     }
   }
 
@@ -53,10 +55,10 @@ public class ModelLoaderTest {
     try {
 
       Optional<ASTODArtifact> od = loader.loadODModel(odModel1);
-      Assert.assertTrue(od.isPresent());
+      assertTrue(od.isPresent());
 
     } catch (FileNotFoundException e) {
-      Assert.fail("File could not be found.");
+      fail("File could not be found.");
     }
   }
 }

--- a/cddiff/src/test/java/de/monticore/odvalidity/NormalizeLinksTrafoTest.java
+++ b/cddiff/src/test/java/de/monticore/odvalidity/NormalizeLinksTrafoTest.java
@@ -16,16 +16,18 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NormalizeLinksTrafoTest {
 
   NormalizeLinksTrafo trafo;
 
-  @Before
+  @BeforeEach
   public void setUp() {
 
     OD4ReportMill.reset();
@@ -46,15 +48,15 @@ public class NormalizeLinksTrafoTest {
     // transform
     List<ASTODLink> result = trafo.transformLinksToLTR(odLinks);
 
-    Assert.assertEquals(7, result.size());
+    assertEquals(7, result.size());
     // check directions
-    result.forEach(l -> Assert.assertTrue(l.getODLinkDirection() instanceof ASTODLeftToRightDir));
+    result.forEach(l -> assertInstanceOf(ASTODLeftToRightDir.class, l.getODLinkDirection()));
     result.forEach(
-        l -> Assert.assertFalse((l.getODLinkDirection() instanceof ASTODRightToLeftDir)));
-    result.forEach(l -> Assert.assertFalse(l.getODLinkDirection() instanceof ASTODBiDir));
+        l -> assertFalse((l.getODLinkDirection() instanceof ASTODRightToLeftDir)));
+    result.forEach(l -> assertFalse(l.getODLinkDirection() instanceof ASTODBiDir));
 
     // check roles
-    result.forEach(l -> Assert.assertTrue(l.getODLinkRightSide().isPresentRole()));
+    result.forEach(l -> assertTrue(l.getODLinkRightSide().isPresentRole()));
 
     ODLinkFullPrettyPrinter p = new ODLinkFullPrettyPrinter(new IndentPrinter(), false);
     result.forEach(l -> System.out.println(p.prettyprint(l)));
@@ -71,7 +73,7 @@ public class NormalizeLinksTrafoTest {
     return od.get().getObjectDiagram();
   }
 
-  @After
+  @AfterEach
   public void reset() {
     OD4ReportMill.reset();
   }

--- a/cddiff/src/test/java/de/monticore/odvalidity/OD2CDMatcherTest.java
+++ b/cddiff/src/test/java/de/monticore/odvalidity/OD2CDMatcherTest.java
@@ -7,9 +7,10 @@ import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import java.io.File;
 import java.nio.file.Paths;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OD2CDMatcherTest {
 
@@ -25,7 +26,7 @@ public class OD2CDMatcherTest {
 
   File odModel1;
 
-  @Before
+  @BeforeEach
   public void reloadModels() {
     CD4CodeMill.reset();
     CD4CodeMill.init();
@@ -40,7 +41,7 @@ public class OD2CDMatcherTest {
   @Test
   public void singleInstanceCheckClosedWorldTest() {
     // TODO
-    Assert.assertFalse(
+    assertFalse(
         matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cdModel1, odModel1));
   }
 
@@ -49,11 +50,11 @@ public class OD2CDMatcherTest {
     final File cd1 = new File(resources + "IntegrationTest/OCLDiff/car.cd");
 
     File[] odFiles = Paths.get(resources + "IntegrationTest/OCLDiff").toFile().listFiles();
-    Assert.assertNotNull(odFiles);
+    assertNotNull(odFiles);
 
     for (File odFile : odFiles) {
       if (odFile.getName().endsWith(".od")) {
-        Assert.assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
+        assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
       }
     }
   }
@@ -64,12 +65,12 @@ public class OD2CDMatcherTest {
     final File cd2 = new File(resources + "IntegrationTest/Class/CD2.cd");
 
     File[] odFiles = Paths.get(resources + "IntegrationTest/Class").toFile().listFiles();
-    Assert.assertNotNull(odFiles);
+    assertNotNull(odFiles);
 
     for (File odFile : odFiles) {
       if (odFile.getName().endsWith(".od")) {
-        Assert.assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
-        Assert.assertFalse(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd2, odFile));
+        assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
+        assertFalse(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd2, odFile));
       }
     }
   }
@@ -80,12 +81,12 @@ public class OD2CDMatcherTest {
     final File cd2 = new File(resources + "IntegrationTest/Combination/Employees1A.cd");
 
     File[] odFiles = Paths.get(resources + "IntegrationTest/Combination").toFile().listFiles();
-    Assert.assertNotNull(odFiles);
+    assertNotNull(odFiles);
 
     for (File odFile : odFiles) {
       if (odFile.getName().endsWith(".od")) {
-        Assert.assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
-        Assert.assertFalse(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd2, odFile));
+        assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
+        assertFalse(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd2, odFile));
       }
     }
   }
@@ -96,12 +97,12 @@ public class OD2CDMatcherTest {
     final File cd2 = new File(resources + "IntegrationTest/Direction/Direction1A.cd");
 
     File[] odFiles = Paths.get(resources + "IntegrationTest/Direction").toFile().listFiles();
-    Assert.assertNotNull(odFiles);
+    assertNotNull(odFiles);
 
     for (File odFile : odFiles) {
       if (odFile.getName().endsWith(".od")) {
-        Assert.assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
-        Assert.assertFalse(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd2, odFile));
+        assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
+        assertFalse(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd2, odFile));
       }
     }
   }
@@ -112,12 +113,12 @@ public class OD2CDMatcherTest {
     final File cd2 = new File(resources + "IntegrationTest/Overlap/OverlapB.cd");
 
     File[] odFiles = Paths.get(resources + "IntegrationTest/Overlap").toFile().listFiles();
-    Assert.assertNotNull(odFiles);
+    assertNotNull(odFiles);
 
     for (File odFile : odFiles) {
       if (odFile.getName().endsWith(".od")) {
-        Assert.assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
-        Assert.assertFalse(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd2, odFile));
+        assertTrue(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd1, odFile));
+        assertFalse(matcher.checkODValidity(CDSemantics.SIMPLE_CLOSED_WORLD, cd2, odFile));
       }
     }
   }

--- a/cddiff/src/test/java/de/monticore/odvalidity/STAMatchingTest.java
+++ b/cddiff/src/test/java/de/monticore/odvalidity/STAMatchingTest.java
@@ -9,9 +9,11 @@ import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import java.io.File;
 import java.io.FileNotFoundException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class STAMatchingTest {
   String[] validBaseCDModelsOpenWorld = {
@@ -40,7 +42,7 @@ public class STAMatchingTest {
 
   ModelLoader loader = new ModelLoader();
 
-  @Before
+  @BeforeEach
   public void loadModels() {
     LogStub.init();
     Log.enableFailQuick(false);
@@ -67,9 +69,9 @@ public class STAMatchingTest {
       ASTCDCompilationUnit compCD = loader.loadCDModel(cdCompareModel).get();
 
       if (closedDiff[i]) {
-        Assert.assertTrue(matcher.isDiffWitness(CDSemantics.STA_CLOSED_WORLD, baseCD, compCD, od));
+        assertTrue(matcher.isDiffWitness(CDSemantics.STA_CLOSED_WORLD, baseCD, compCD, od));
       } else {
-        Assert.assertFalse(matcher.isDiffWitness(CDSemantics.STA_CLOSED_WORLD, baseCD, compCD, od));
+        assertFalse(matcher.isDiffWitness(CDSemantics.STA_CLOSED_WORLD, baseCD, compCD, od));
       }
     }
   }
@@ -90,9 +92,9 @@ public class STAMatchingTest {
       ASTCDCompilationUnit compCD = loader.loadCDModel(cdCompareModel).get();
 
       if (openDiff[i]) {
-        Assert.assertTrue(matcher.isDiffWitness(CDSemantics.STA_OPEN_WORLD, baseCD, compCD, od));
+        assertTrue(matcher.isDiffWitness(CDSemantics.STA_OPEN_WORLD, baseCD, compCD, od));
       } else {
-        Assert.assertFalse(matcher.isDiffWitness(CDSemantics.STA_OPEN_WORLD, baseCD, compCD, od));
+        assertFalse(matcher.isDiffWitness(CDSemantics.STA_OPEN_WORLD, baseCD, compCD, od));
       }
     }
   }

--- a/cdlang/src/cd2plantumltest/java/de/monticore/cd/plantuml/PlantUMLUtilTest.java
+++ b/cdlang/src/cd2plantumltest/java/de/monticore/cd/plantuml/PlantUMLUtilTest.java
@@ -1,7 +1,5 @@
 package de.monticore.cd.plantuml;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4analysis.CD4AnalysisTestBasis;
 import java.io.File;
 import java.io.IOException;
@@ -9,23 +7,21 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PlantUMLUtilTest extends CD4AnalysisTestBasis {
-
-  @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   /**
    * Checks if the PlantUMLUtil.writeCdToPlantUmlModelFile works correctly and does print a
    * .plantuml file into the correct output folder.
    */
   @Test
-  public void testWriteCdToPlantUmlModelFile() {
+  public void testWriteCdToPlantUmlModelFile(@TempDir Path tempDir) throws IOException {
     String pathCD = getFilePath("cd4analysis/prettyprint/QuantifiedNamedAssociations.cd");
-    Path outputPath =
-        Paths.get(folder.getRoot().getAbsolutePath(), "QuantifiedNamedAssociations.plantuml");
+    Path outputPath = tempDir.resolve("QuantifiedNamedAssociations.plantuml");
     PlantUMLConfig config = new PlantUMLConfig();
 
     try {
@@ -57,10 +53,9 @@ public class PlantUMLUtilTest extends CD4AnalysisTestBasis {
    * file into the correct output folder.
    */
   @Test
-  public void testWriteCdToPlantUmlSvg() {
+  public void testWriteCdToPlantUmlSvg(@TempDir Path tempDir) {
     String pathCD = getFilePath("cd4analysis/prettyprint/QuantifiedNamedAssociations.cd");
-    Path outputPath =
-        Paths.get(folder.getRoot().getAbsolutePath(), "QuantifiedNamedAssociations.svg");
+    Path outputPath = tempDir.resolve("QuantifiedNamedAssociations.svg");
     PlantUMLConfig config = new PlantUMLConfig();
 
     try {

--- a/cdlang/src/cd2plantumltest/java/de/monticore/cd4analysis/prettyprint/CD4AnalysisPlantUMLFullPrettyPrinterTest.java
+++ b/cdlang/src/cd2plantumltest/java/de/monticore/cd4analysis/prettyprint/CD4AnalysisPlantUMLFullPrettyPrinterTest.java
@@ -13,11 +13,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBasis {
 
@@ -68,7 +70,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     tool.init();
 
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit = p.parseCDCompilationUnit(filePath);
-    Assertions.assertTrue(astcdCompilationUnit.isPresent());
+    assertTrue(astcdCompilationUnit.isPresent());
 
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();
 
@@ -82,7 +84,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     expected = expected.replaceAll("(?m)^[ \t]*\r?\n", "").replaceAll("\r\n", "\n");
     System.out.println("Expected:\n" + expected);
 
-    Assert.assertEquals(expected, output);
+    assertEquals(expected, output);
   }
 
   /**
@@ -122,7 +124,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     tool.init();
 
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit = p.parseCDCompilationUnit(filePath);
-    Assertions.assertTrue(astcdCompilationUnit.isPresent());
+    assertTrue(astcdCompilationUnit.isPresent());
 
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();
 
@@ -136,7 +138,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     expected = expected.replaceAll("(?m)^[ \t]*\r?\n", "").replaceAll("\r\n", "\n");
     System.out.println("Expected: \n " + expected);
 
-    Assertions.assertEquals(expected, output);
+    assertEquals(expected, output);
   }
 
   /**
@@ -176,7 +178,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     tool.init();
 
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit = p.parseCDCompilationUnit(filePath);
-    Assertions.assertTrue(astcdCompilationUnit.isPresent());
+    assertTrue(astcdCompilationUnit.isPresent());
 
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();
 
@@ -190,7 +192,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     expected = expected.replaceAll("(?m)^[ \t]*\r?\n", "").replaceAll("\r\n", "\n");
     System.out.println("Expected: \n " + expected);
 
-    Assertions.assertEquals(expected, output);
+    assertEquals(expected, output);
   }
 
   /**
@@ -230,7 +232,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     tool.init();
 
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit = p.parseCDCompilationUnit(filePath);
-    Assertions.assertTrue(astcdCompilationUnit.isPresent());
+    assertTrue(astcdCompilationUnit.isPresent());
 
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();
 
@@ -244,7 +246,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     expected = expected.replaceAll("(?m)^[ \t]*\r?\n", "").replaceAll("\r\n", "\n");
     System.out.println("Expected: \n " + expected);
 
-    Assertions.assertEquals(expected, output);
+    assertEquals(expected, output);
   }
 
   /**
@@ -283,7 +285,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     tool.init();
 
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit = p.parseCDCompilationUnit(filePath);
-    Assertions.assertTrue(astcdCompilationUnit.isPresent());
+    assertTrue(astcdCompilationUnit.isPresent());
 
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();
 
@@ -297,7 +299,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     expected = expected.replaceAll("(?m)^[ \t]*\r?\n", "").replaceAll("\r\n", "\n");
     System.out.println("Expected: \n " + expected);
 
-    Assertions.assertEquals(expected, output);
+    assertEquals(expected, output);
   }
 
   /**
@@ -336,7 +338,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     tool.init();
 
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit = p.parseCDCompilationUnit(filePath);
-    Assertions.assertTrue(astcdCompilationUnit.isPresent());
+    assertTrue(astcdCompilationUnit.isPresent());
 
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();
 
@@ -350,7 +352,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     expected = expected.replaceAll("(?m)^[ \t]*\r?\n", "").replaceAll("\r\n", "\n");
     System.out.println("Expected: \n " + expected);
 
-    Assertions.assertEquals(expected, output);
+    assertEquals(expected, output);
   }
 
   /**
@@ -389,7 +391,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     tool.init();
 
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit = p.parseCDCompilationUnit(filePath);
-    Assertions.assertTrue(astcdCompilationUnit.isPresent());
+    assertTrue(astcdCompilationUnit.isPresent());
 
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();
 
@@ -403,7 +405,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     expected = expected.replaceAll("(?m)^[ \t]*\r?\n", "").replaceAll("\r\n", "\n");
     System.out.println("Expected: \n " + expected);
 
-    Assertions.assertEquals(expected, output);
+    assertEquals(expected, output);
   }
 
   /**
@@ -442,7 +444,7 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     tool.init();
 
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit = p.parseCDCompilationUnit(filePath);
-    Assertions.assertTrue(astcdCompilationUnit.isPresent());
+    assertTrue(astcdCompilationUnit.isPresent());
 
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();
 
@@ -456,6 +458,6 @@ public class CD4AnalysisPlantUMLFullPrettyPrinterTest extends CD4AnalysisTestBas
     expected = expected.replaceAll("(?m)^[ \t]*\r?\n", "").replaceAll("\r\n", "\n");
     System.out.println("Expected: \n " + expected);
 
-    Assertions.assertEquals(expected, output);
+    assertEquals(expected, output);
   }
 }

--- a/cdlang/src/main/java/de/monticore/symtabdefinition/SymTabDefinitionTool.java
+++ b/cdlang/src/main/java/de/monticore/symtabdefinition/SymTabDefinitionTool.java
@@ -127,9 +127,7 @@ public class SymTabDefinitionTool extends SymTabDefinitionToolTOP {
           for (ASTCDCompilationUnit compilationUnit : inputASTs) {
             prettyPrintInFolder(compilationUnit, cmd.getOptionValue(OPTION_PRETTYPRINT));
           }
-        } else if (cmd.getOptionValues(OPTION_PRETTYPRINT).length == inputASTs.size()
-            && cmd.getOptionValues(OPTION_PRETTYPRINT).length
-                == cmd.getOptionValues(OPTION_PRETTYPRINT).length) {
+        } else if (cmd.getOptionValues(OPTION_PRETTYPRINT).length == inputASTs.size()) {
           for (int i = 0; i < inputASTs.size(); i++) {
             prettyPrint(inputASTs.get(i), cmd.getOptionValues(OPTION_PRETTYPRINT)[i]);
           }

--- a/cdlang/src/test/java/de/monticore/CDGeneratorToolTest.java
+++ b/cdlang/src/test/java/de/monticore/CDGeneratorToolTest.java
@@ -14,9 +14,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.After;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CDGeneratorToolTest {
 
@@ -230,11 +231,11 @@ public class CDGeneratorToolTest {
     ICD4CodeArtifactScope scope =
         new CD4CodeSymbols2Json()
             .load(Paths.get("target/generated/example/rolefield/model/Example.cdsym").toString());
-    assertEquals(
-        scope.getCDTypeSymbols().get("A").get(0).getSpannedScope().getFieldSymbols().size(), 2);
+    assertEquals(2,
+        scope.getCDTypeSymbols().get("A").get(0).getSpannedScope().getFieldSymbols().size());
   }
 
-  @After
+  @AfterEach
   public void after() {
     CD4CodeMill.globalScope().clear();
     assertTrue(LogStub.getFindings().isEmpty());

--- a/cdlang/src/test/java/de/monticore/cd/CDSymbolTablesTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/CDSymbolTablesTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd._symboltable.CDSymbolTables;
 import de.monticore.cd4code.CD4CodeMill;
@@ -20,7 +20,7 @@ import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CDSymbolTablesTest extends CD4CodeTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/cd/OutTestBasis.java
+++ b/cdlang/src/test/java/de/monticore/cd/OutTestBasis.java
@@ -3,22 +3,21 @@ package de.monticore.cd;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import org.junit.After;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 
 /** a base class for tests to use stdout and stderr */
 public class OutTestBasis extends TestBasis {
   protected static final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
   protected static final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     System.setOut(new PrintStream(outContent));
     System.setErr(new PrintStream(errContent));
   }
 
-  @After
-  public void reset() {
+  @AfterEach  public void reset() {
     outContent.reset();
     errContent.reset();
   }

--- a/cdlang/src/test/java/de/monticore/cd/TestBasis.java
+++ b/cdlang/src/test/java/de/monticore/cd/TestBasis.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd;
 
-import static org.junit.Assert.*;
-
 import com.google.common.base.Joiner;
 import de.monticore.antlr4.MCConcreteParser;
 import de.monticore.ast.ASTNode;
@@ -20,10 +18,12 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /** The base class for the tests, to provide common functionality */
 public class TestBasis {
@@ -31,16 +31,17 @@ public class TestBasis {
   public static final String PATH = "src/test/resources/de/monticore/";
 
   /** have a temporary folder for the tests */
-  @Rule public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  Path folderPath;
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
     Log.enableFailQuick(false);
   }
 
   public String getTmpAbsolutePath() {
-    return folder.getRoot().getAbsolutePath();
+    return folderPath.toAbsolutePath().toString();
   }
 
   public String getTmpFilePath(String fileName) {
@@ -66,8 +67,8 @@ public class TestBasis {
     final String joinedErrors = getJoinedErrors();
     final boolean hasErrors = parser.hasErrors();
     parser.setError(false);
-    assertFalse(joinedErrors, hasErrors);
-    assertNotNull("The node should not be null", node);
+    assertFalse(hasErrors, joinedErrors);
+    assertNotNull(node, "The node should not be null");
     assertTrue(node.isPresent());
     checkLogError();
   }
@@ -88,23 +89,21 @@ public class TestBasis {
         fail("exptected " + i + " errors, but none were present");
       }
     }
-
-    assertEquals(
-        "exptected to get exaclty " + i + " errors, the errors where:\n" + getJoinedErrors(),
-        Log.getErrorCount(),
-        i);
+    
+    assertEquals(Log.getErrorCount(), i,
+        "exptected to get exaclty " + i + " errors, the errors where:\n" + getJoinedErrors());
     final List<Finding> findings = Log.getFindings();
     IntStream.range(0, i)
         .forEach(c -> assertEquals(listOfErrors.get(c), findings.get(c).toString()));
     Log.getFindings().clear();
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     Log.getFindings().clear();
   }
 
-  @After
+  @AfterEach
   public void after() {
     checkLogError();
   }

--- a/cdlang/src/test/java/de/monticore/cd/cdgen/AbstractCDGenTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/cdgen/AbstractCDGenTest.java
@@ -25,8 +25,7 @@ public class AbstractCDGenTest {
 
   protected DecoratorConfig setup;
   protected File outputDir;
-  ;
-
+  
   @BeforeEach
   public void init() {
     LogStub.initPlusLog();

--- a/cdlang/src/test/java/de/monticore/cd/cdgen/CDGenTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/cdgen/CDGenTest.java
@@ -20,7 +20,7 @@ import de.se_rwth.commons.logging.LogStub;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CDGenTest {
 

--- a/cdlang/src/test/java/de/monticore/cd/codegen/CDGeneratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/CDGeneratorTest.java
@@ -14,8 +14,8 @@ import de.monticore.generating.templateengine.TemplateHookPoint;
 import de.se_rwth.commons.logging.Log;
 import java.io.File;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CDGeneratorTest extends CD4CodeTestBasis {
 
@@ -25,7 +25,7 @@ public class CDGeneratorTest extends CD4CodeTestBasis {
 
   private ASTCDCompilationUnit compUnit;
 
-  @Before
+  @BeforeEach
   @Override
   public void initObjects() {
     super.initObjects();

--- a/cdlang/src/test/java/de/monticore/cd/codegen/ConstructorDecoratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/ConstructorDecoratorTest.java
@@ -11,12 +11,12 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.se_rwth.commons.logging.LogStub;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ConstructorDecoratorTest {
 
-  @Before
+  @BeforeEach
   public void before() {
     CD4CodeMill.globalScope().clear();
     CD4CodeMill.reset();
@@ -35,24 +35,20 @@ public class ConstructorDecoratorTest {
     ConstructorDecorator decorator = new ConstructorDecorator();
 
     assertEquals(2, ast.getCDDefinition().getCDClassesList().size());
-    assertEquals(ast.getCDDefinition().getCDClassesList().get(0).getCDMemberList().size(), 4);
+    assertEquals(4, ast.getCDDefinition().getCDClassesList().get(0).getCDMemberList().size());
     assertTrue(ast.getCDDefinition().getCDClassesList().get(1).getCDConstructorList().isEmpty());
     decorator.decorate(ast);
-    assertEquals(ast.getCDDefinition().getCDClassesList().get(0).getCDMemberList().size(), 6);
-    assertEquals(ast.getCDDefinition().getCDClassesList().get(1).getCDMemberList().size(), 1);
-    assertEquals(
-        ((ASTCDConstructor)
-                (ast.getCDDefinition().getCDClassesList().get(0).getCDMemberList().get(5)))
-            .getCDParameterList()
-            .get(0)
-            .getName(),
-        "x");
-    assertEquals(
-        ((ASTCDConstructor)
-                (ast.getCDDefinition().getCDClassesList().get(0).getCDMemberList().get(5)))
-            .getCDParameterList()
-            .get(1)
-            .getName(),
-        "isTrue");
+    assertEquals(6, ast.getCDDefinition().getCDClassesList().get(0).getCDMemberList().size());
+    assertEquals(1, ast.getCDDefinition().getCDClassesList().get(1).getCDMemberList().size());
+    assertEquals("x", ((ASTCDConstructor)
+            (ast.getCDDefinition().getCDClassesList().get(0).getCDMemberList().get(5)))
+        .getCDParameterList()
+        .get(0)
+        .getName());
+    assertEquals("isTrue", ((ASTCDConstructor)
+            (ast.getCDDefinition().getCDClassesList().get(0).getCDMemberList().get(5)))
+        .getCDParameterList()
+        .get(1)
+        .getName());
   }
 }

--- a/cdlang/src/test/java/de/monticore/cd/codegen/DecoratorAssert.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/DecoratorAssert.java
@@ -1,9 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd.codegen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import de.monticore.ast.ASTNode;
 import de.monticore.cd.facade.CDModifier;
 import de.monticore.cd4code._prettyprint.CD4CodeFullPrettyPrinter;
@@ -12,6 +9,8 @@ import de.monticore.types.MCTypeFacade;
 import de.monticore.types.mcbasictypes._ast.ASTMCPrimitiveType;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.monticore.umlmodifier._ast.ASTModifier;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class DecoratorAssert {
 
@@ -23,8 +22,8 @@ public final class DecoratorAssert {
 
   public static void assertDeepEquals(ASTNode expected, ASTNode actual) {
     assertTrue(
-        String.format("Expected: [%s], Actual: [%s]", getAsString(expected), getAsString(actual)),
-        expected.deepEquals(actual));
+        expected.deepEquals(actual),
+        String.format("Expected: [%s], Actual: [%s]", getAsString(expected), getAsString(actual)));
   }
 
   public static void assertDeepEquals(ASTMCType expected, ASTMCType actual) {
@@ -37,7 +36,7 @@ public final class DecoratorAssert {
   }
 
   public static void assertDeepEquals(CDModifier expected, ASTNode actual) {
-    assertTrue(actual instanceof ASTModifier);
+    assertInstanceOf(ASTModifier.class, actual);
     ASTModifier actualMod = (ASTModifier) actual;
     ASTModifier expectedMod = expected.build();
     assertEquals(expectedMod.isAbstract(), actualMod.isAbstract());
@@ -51,30 +50,30 @@ public final class DecoratorAssert {
   }
 
   public static void assertDeepEquals(Class<?> expected, ASTNode actual) {
-    assertTrue(actual instanceof ASTMCType);
+    assertInstanceOf(ASTMCType.class, actual);
     assertEquals(
         expected.getSimpleName(),
         (new CD4CodeFullPrettyPrinter(new IndentPrinter())).prettyprint((ASTMCType) actual));
   }
 
   public static void assertDeepEquals(String name, ASTNode actual) {
-    assertTrue(actual instanceof ASTMCType);
+    assertInstanceOf(ASTMCType.class, actual);
     assertEquals(
         name, (new CD4CodeFullPrettyPrinter(new IndentPrinter())).prettyprint((ASTMCType) actual));
   }
 
   public static void assertBoolean(ASTNode actual) {
-    assertTrue(actual instanceof ASTMCPrimitiveType);
+    assertInstanceOf(ASTMCPrimitiveType.class, actual);
     assertTrue(((ASTMCPrimitiveType) actual).isBoolean());
   }
 
   public static void assertInt(ASTNode actual) {
-    assertTrue(actual instanceof ASTMCPrimitiveType);
+    assertInstanceOf(ASTMCPrimitiveType.class, actual);
     assertTrue(((ASTMCPrimitiveType) actual).isInt());
   }
 
   public static void assertFloat(ASTNode actual) {
-    assertTrue(actual instanceof ASTMCPrimitiveType);
+    assertInstanceOf(ASTMCPrimitiveType.class, actual);
     assertTrue(((ASTMCPrimitiveType) actual).isFloat());
   }
 
@@ -84,21 +83,21 @@ public final class DecoratorAssert {
 
   public static void assertOptionalOf(Class<?> clazz, ASTNode actual) {
     String type = "Optional<" + clazz.getSimpleName() + ">";
-    assertTrue(actual instanceof ASTMCType);
+    assertInstanceOf(ASTMCType.class, actual);
     assertEquals(
         type, (new CD4CodeFullPrettyPrinter(new IndentPrinter())).prettyprint((ASTMCType) actual));
   }
 
   public static void assertOptionalOf(String name, ASTNode actual) {
     String type = "Optional<" + name + ">";
-    assertTrue(actual instanceof ASTMCType);
+    assertInstanceOf(ASTMCType.class, actual);
     assertEquals(
         type, (new CD4CodeFullPrettyPrinter(new IndentPrinter())).prettyprint((ASTMCType) actual));
   }
 
   public static void assertListOf(Class<?> clazz, ASTNode actual) {
     String type = "List<" + clazz.getSimpleName() + ">";
-    assertTrue(actual instanceof ASTMCType);
+    assertInstanceOf(ASTMCType.class, actual);
     assertEquals(
         type, (new CD4CodeFullPrettyPrinter(new IndentPrinter())).prettyprint((ASTMCType) actual));
   }

--- a/cdlang/src/test/java/de/monticore/cd/codegen/DecoratorTestCase.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/DecoratorTestCase.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd.codegen;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
@@ -14,13 +14,13 @@ import de.monticore.types.mcbasictypes._ast.ASTMCImportStatement;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class DecoratorTestCase {
 
   private static final String MODEL_PATH = "src/test/resources/";
 
-  @Before
+  @BeforeEach
   public void setUpDecoratorTestCase() {
     Log.init();
     Log.enableFailQuick(false);
@@ -35,7 +35,7 @@ public abstract class DecoratorTestCase {
     String qualifiedName = String.join("/", names);
 
     CD4CodeParser parser = CD4CodeMill.parser();
-    Optional<ASTCDCompilationUnit> ast = null;
+    Optional<ASTCDCompilationUnit> ast = Optional.empty();
     try {
       ast = parser.parse(MODEL_PATH + qualifiedName + ".cd");
     } catch (IOException e) {

--- a/cdlang/src/test/java/de/monticore/cd/codegen/DecoratorTestUtil.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/DecoratorTestUtil.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd.codegen;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
@@ -25,9 +25,9 @@ public final class DecoratorTestUtil {
             .filter(c -> name.equals(c.getName()))
             .collect(Collectors.toList());
     assertEquals(
-        String.format("Expected to find 1 class, but found '%s'", filtered.size()),
         1,
-        filtered.size());
+        filtered.size(),
+        String.format("Expected to find 1 class, but found '%s'", filtered.size()));
     return filtered.get(0);
   }
 
@@ -37,9 +37,9 @@ public final class DecoratorTestUtil {
             .filter(c -> name.equals(c.getName()))
             .collect(Collectors.toList());
     assertEquals(
-        String.format("Expected to find 1 interface, but found '%s'", filtered.size()),
         1,
-        filtered.size());
+        filtered.size(),
+        String.format("Expected to find 1 interface, but found '%s'", filtered.size()));
     return filtered.get(0);
   }
 
@@ -49,9 +49,9 @@ public final class DecoratorTestUtil {
             .filter(c -> name.equals(c.getName()))
             .collect(Collectors.toList());
     assertEquals(
-        String.format("Expected to find 1 enum, but found '%s'", filtered.size()),
         1,
-        filtered.size());
+        filtered.size(),
+        String.format("Expected to find 1 enum, but found '%s'", filtered.size()));
     return filtered.get(0);
   }
 
@@ -115,9 +115,9 @@ public final class DecoratorTestUtil {
       List<ASTCDMethod> methods, List<Predicate<ASTCDMethod>> predicates) {
     List<ASTCDMethod> filtered = filterMethods(methods, predicates);
     assertEquals(
-        String.format("Expected find 1 method, but found '%s'", filtered.size()),
         1,
-        filtered.size());
+        filtered.size(),
+        String.format("Expected find 1 method, but found '%s'", filtered.size()));
     return filtered.get(0);
   }
 
@@ -134,9 +134,9 @@ public final class DecoratorTestUtil {
             .filter(attribute -> name.equals(attribute.getName()))
             .collect(Collectors.toList());
     assertEquals(
-        String.format("Expected find 1 attribute, but found '%s'", filtered.size()),
         1,
-        filtered.size());
+        filtered.size(),
+        String.format("Expected find 1 attribute, but found '%s'", filtered.size()));
     return filtered.get(0);
   }
 
@@ -146,9 +146,9 @@ public final class DecoratorTestUtil {
             .filter(attribute -> name.equals(attribute.getName()))
             .collect(Collectors.toList());
     assertEquals(
-        String.format("Expected find 1 attribute, but found '%s'", filtered.size()),
         1,
-        filtered.size());
+        filtered.size(),
+        String.format("Expected find 1 attribute, but found '%s'", filtered.size()));
     return filtered.get(0);
   }
 }

--- a/cdlang/src/test/java/de/monticore/cd/codegen/TopDecoratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/TopDecoratorTest.java
@@ -3,7 +3,7 @@ package de.monticore.cd.codegen;
 
 import static de.monticore.cd.codegen.DecoratorAssert.assertDeepEquals;
 import static de.monticore.cd.facade.CDModifier.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import de.monticore.cd4codebasis._ast.ASTCDConstructor;
 import de.monticore.cdbasis._ast.ASTCDClass;
@@ -22,8 +22,8 @@ import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import de.se_rwth.commons.logging.MCFatalError;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -36,7 +36,7 @@ public class TopDecoratorTest extends DecoratorTestCase {
 
   private ASTCDCompilationUnit topCD;
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
     this.targetPath = Mockito.mock(MCPath.class);
@@ -67,10 +67,10 @@ public class TopDecoratorTest extends DecoratorTestCase {
 
     // Check Logs
     List<Finding> findings = Log.getFindings();
-    assertTrue("Log messages empty", findings.size() > 0);
+    assertFalse(findings.isEmpty(), "Log messages empty");
     Finding lastMsg = findings.get(findings.size() - 1);
-    assertTrue("Last Message was not an error", lastMsg.isError());
-    assertTrue("Reason not found in last message", lastMsg.getMsg().contains(reasonString));
+    assertTrue(lastMsg.isError(),"Last Message was not an error");
+    assertTrue(lastMsg.getMsg().contains(reasonString), "Reason not found in last message");
   }
 
   @Test
@@ -92,7 +92,7 @@ public class TopDecoratorTest extends DecoratorTestCase {
 
     // CheckLogs
     List<Finding> findings = Log.getFindings();
-    assertFalse("Log messages not empty", findings.size() > 0);
+    assertTrue(findings.isEmpty(), "Log messages not empty");
   }
 
   @Test

--- a/cdlang/src/test/java/de/monticore/cd/codegen/method/accessor/ListAccessorDecoratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/method/accessor/ListAccessorDecoratorTest.java
@@ -5,8 +5,8 @@ import static de.monticore.cd.codegen.DecoratorAssert.*;
 import static de.monticore.cd.codegen.DecoratorTestUtil.getMethodBy;
 import static de.monticore.cd.facade.CDModifier.PROTECTED;
 import static de.monticore.cd.facade.CDModifier.PUBLIC;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.codegen.methods.accessor.ListAccessorDecorator;
 import de.monticore.cd.facade.CDAttributeFacade;
@@ -18,8 +18,8 @@ import de.monticore.types.MCTypeFacade;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.se_rwth.commons.logging.LogStub;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ListAccessorDecoratorTest {
 
@@ -27,7 +27,7 @@ public class ListAccessorDecoratorTest {
 
   private List<ASTCDMethod> methods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
     ASTMCType listType = MCTypeFacade.getInstance().createListTypeOf(String.class);

--- a/cdlang/src/test/java/de/monticore/cd/codegen/method/accessor/MandatoryAccessorDecoratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/method/accessor/MandatoryAccessorDecoratorTest.java
@@ -5,8 +5,8 @@ import static de.monticore.cd.codegen.DecoratorAssert.assertDeepEquals;
 import static de.monticore.cd.codegen.DecoratorTestUtil.getMethodBy;
 import static de.monticore.cd.facade.CDModifier.PROTECTED;
 import static de.monticore.cd.facade.CDModifier.PUBLIC;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.codegen.methods.accessor.MandatoryAccessorDecorator;
 import de.monticore.cd.facade.CDAttributeFacade;
@@ -15,14 +15,14 @@ import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.generating.templateengine.GlobalExtensionManagement;
 import de.se_rwth.commons.logging.LogStub;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MandatoryAccessorDecoratorTest {
 
   private final GlobalExtensionManagement glex = new GlobalExtensionManagement();
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
   }

--- a/cdlang/src/test/java/de/monticore/cd/codegen/method/accessor/OptionalAccessorDecoratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/method/accessor/OptionalAccessorDecoratorTest.java
@@ -6,8 +6,8 @@ import static de.monticore.cd.codegen.DecoratorAssert.assertDeepEquals;
 import static de.monticore.cd.codegen.DecoratorTestUtil.getMethodBy;
 import static de.monticore.cd.facade.CDModifier.PROTECTED;
 import static de.monticore.cd.facade.CDModifier.PUBLIC;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.codegen.DecoratorTestCase;
 import de.monticore.cd.codegen.methods.accessor.OptionalAccessorDecorator;
@@ -20,9 +20,8 @@ import de.monticore.types.MCTypeFacade;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.se_rwth.commons.logging.LogStub;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class OptionalAccessorDecoratorTest extends DecoratorTestCase {
 
@@ -30,7 +29,7 @@ public class OptionalAccessorDecoratorTest extends DecoratorTestCase {
 
   private List<ASTCDMethod> methods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
 
@@ -53,7 +52,7 @@ public class OptionalAccessorDecoratorTest extends DecoratorTestCase {
   public void testGetMethod() {
     ASTCDMethod method = getMethodBy("getA", this.methods);
     assertTrue(method.getCDParameterList().isEmpty());
-    Assert.assertTrue(method.getMCReturnType().isPresentMCType());
+    assertTrue(method.getMCReturnType().isPresentMCType());
     assertDeepEquals(String.class, method.getMCReturnType().getMCType());
     assertDeepEquals(PUBLIC, method.getModifier());
   }
@@ -61,7 +60,7 @@ public class OptionalAccessorDecoratorTest extends DecoratorTestCase {
   @Test
   public void testIsPresentMethod() {
     ASTCDMethod method = getMethodBy("isPresentA", this.methods);
-    Assert.assertTrue(method.getMCReturnType().isPresentMCType());
+    assertTrue(method.getMCReturnType().isPresentMCType());
     assertBoolean(method.getMCReturnType().getMCType());
     assertDeepEquals(PUBLIC, method.getModifier());
     assertTrue(method.getCDParameterList().isEmpty());

--- a/cdlang/src/test/java/de/monticore/cd/codegen/method/mutator/ListMutatorDecoratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/method/mutator/ListMutatorDecoratorTest.java
@@ -6,8 +6,8 @@ import static de.monticore.cd.codegen.DecoratorTestUtil.getMethodBy;
 import static de.monticore.cd.codegen.DecoratorTestUtil.getMethodsBy;
 import static de.monticore.cd.facade.CDModifier.PROTECTED;
 import static de.monticore.cd.facade.CDModifier.PUBLIC;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.codegen.methods.mutator.ListMutatorDecorator;
 import de.monticore.cd.facade.CDAttributeFacade;
@@ -20,8 +20,8 @@ import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.se_rwth.commons.logging.LogStub;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ListMutatorDecoratorTest {
 
@@ -29,7 +29,7 @@ public class ListMutatorDecoratorTest {
 
   private List<ASTCDMethod> methods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
     LogStub.enableFailQuick(false);

--- a/cdlang/src/test/java/de/monticore/cd/codegen/method/mutator/MandatoryMutatorDecoratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/method/mutator/MandatoryMutatorDecoratorTest.java
@@ -5,8 +5,8 @@ import static de.monticore.cd.codegen.DecoratorAssert.assertDeepEquals;
 import static de.monticore.cd.codegen.DecoratorTestUtil.getMethodBy;
 import static de.monticore.cd.facade.CDModifier.PROTECTED;
 import static de.monticore.cd.facade.CDModifier.PUBLIC;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.codegen.methods.mutator.MandatoryMutatorDecorator;
 import de.monticore.cd.facade.CDAttributeFacade;
@@ -16,8 +16,8 @@ import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.generating.templateengine.GlobalExtensionManagement;
 import de.se_rwth.commons.logging.LogStub;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MandatoryMutatorDecoratorTest {
 
@@ -25,7 +25,7 @@ public class MandatoryMutatorDecoratorTest {
 
   private List<ASTCDMethod> methods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
     ASTCDAttribute attribute =

--- a/cdlang/src/test/java/de/monticore/cd/codegen/method/mutator/OptionalMutatorDecoratorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/codegen/method/mutator/OptionalMutatorDecoratorTest.java
@@ -5,8 +5,8 @@ import static de.monticore.cd.codegen.DecoratorAssert.assertDeepEquals;
 import static de.monticore.cd.codegen.DecoratorTestUtil.getMethodBy;
 import static de.monticore.cd.facade.CDModifier.PROTECTED;
 import static de.monticore.cd.facade.CDModifier.PUBLIC;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.codegen.methods.mutator.OptionalMutatorDecorator;
 import de.monticore.cd.facade.CDAttributeFacade;
@@ -18,8 +18,8 @@ import de.monticore.types.MCTypeFacade;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.se_rwth.commons.logging.LogStub;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class OptionalMutatorDecoratorTest {
 
@@ -27,7 +27,7 @@ public class OptionalMutatorDecoratorTest {
 
   private List<ASTCDMethod> methods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     LogStub.init();
     ASTMCType optionalType = MCTypeFacade.getInstance().createOptionalTypeOf(String.class);

--- a/cdlang/src/test/java/de/monticore/cd/json/CD2JsonUtilTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/json/CD2JsonUtilTest.java
@@ -15,7 +15,7 @@ import de.monticore.io.paths.MCPath;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CD2JsonUtilTest extends CD4AnalysisTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/cd/methodtemplates/CD4CTest.java
+++ b/cdlang/src/test/java/de/monticore/cd/methodtemplates/CD4CTest.java
@@ -1,9 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd.methodtemplates;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd.codegen.CdUtilsPrinter;
 import de.monticore.cd.facade.CDAttributeFacade;
@@ -32,8 +29,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /** Tests for parameterized calls of the {@link TemplateController} */
 public class CD4CTest extends CD4CodeTestBasis {
@@ -41,7 +40,7 @@ public class CD4CTest extends CD4CodeTestBasis {
   private GeneratorSetup config;
   private ASTCDCompilationUnit node;
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     LogStub.init();
     Log.enableFailQuick(false);
@@ -86,7 +85,7 @@ public class CD4CTest extends CD4CodeTestBasis {
         CD4C.getInstance().createMethod(clazz, "de.monticore.cd.methodtemplates.PrintMethod");
 
     assertTrue(methSignature.isPresent());
-    assertTrue(methSignature.get() instanceof ASTCDMethod);
+    assertInstanceOf(ASTCDMethod.class, methSignature.get());
     ASTCDMethod meth = (ASTCDMethod) methSignature.get();
     assertEquals("print", meth.getName());
 
@@ -109,7 +108,7 @@ public class CD4CTest extends CD4CodeTestBasis {
         CD4C.getInstance().createMethod(ast, "de.monticore.cd.methodtemplates.PrintMethod");
 
     assertTrue(methSignature.isPresent());
-    assertTrue(methSignature.get() instanceof ASTCDMethod);
+    assertInstanceOf(ASTCDMethod.class, methSignature.get());
     ASTCDMethod meth = (ASTCDMethod) methSignature.get();
     assertEquals("print", meth.getName());
 

--- a/cdlang/src/test/java/de/monticore/cd4analysis/ASTCDDefinitionCountElementsTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/ASTCDDefinitionCountElementsTest.java
@@ -1,14 +1,14 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4analysis;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._ast.ASTCDDefinition;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ASTCDDefinitionCountElementsTest extends CD4AnalysisTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/cd4analysis/CD4AnalysisTestBasis.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/CD4AnalysisTestBasis.java
@@ -21,7 +21,7 @@ import de.se_rwth.commons.logging.LogStub;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class CD4AnalysisTestBasis extends TestBasis {
   protected CD4AnalysisCoCoChecker coCoChecker;
@@ -29,7 +29,7 @@ public class CD4AnalysisTestBasis extends TestBasis {
   protected CD4AnalysisFullPrettyPrinter printer;
   protected CD4AnalysisSymbols2Json symbols2Json;
 
-  @Before
+  @BeforeEach
   public void initObjects() {
     LogStub.init();
     Log.enableFailQuick(false);

--- a/cdlang/src/test/java/de/monticore/cd4analysis/_symboltable/CD4AnalysisDeSerTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/_symboltable/CD4AnalysisDeSerTest.java
@@ -1,9 +1,9 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4analysis._symboltable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4analysis.CD4AnalysisMill;
@@ -24,8 +24,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CD4AnalysisDeSerTest extends CD4AnalysisTestBasis {
@@ -107,7 +107,7 @@ public class CD4AnalysisDeSerTest extends CD4AnalysisTestBasis {
     assertTrue(right.isIsDefinitiveNavigable());
   }
 
-  @Ignore("no inner classes are allowed")
+  @Disabled("no inner classes are allowed")
   @Test
   public void innerClass() throws IOException {
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit =

--- a/cdlang/src/test/java/de/monticore/cd4analysis/cocos/CD4AnalysisCoCoTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/cocos/CD4AnalysisCoCoTest.java
@@ -1,12 +1,12 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4analysis.cocos;
 
-import static org.junit.Assert.assertNotNull;
-
 import de.monticore.cd4analysis.CD4AnalysisTestBasis;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CD4AnalysisCoCoTest extends CD4AnalysisTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/cd4analysis/cocos/CDAssociationSourceNotEnumTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/cocos/CDAssociationSourceNotEnumTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4analysis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4analysis.CD4AnalysisMill;
 import de.monticore.cd4analysis.CD4AnalysisTestBasis;
@@ -15,8 +15,8 @@ import de.monticore.types.mcbasictypes.MCBasicTypesMill;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationSourceNotEnumTest extends CD4AnalysisTestBasis {
 
@@ -65,7 +65,6 @@ public class CDAssociationSourceNotEnumTest extends CD4AnalysisTestBasis {
     ast.accept(c.getTraverser());
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/cd4analysis/cocos/CDTypeModifierNotPrivateTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/cocos/CDTypeModifierNotPrivateTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4analysis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4analysis.CD4AnalysisTestBasis;
 import de.monticore.cdbasis.CDBasisMill;
@@ -11,8 +11,8 @@ import de.monticore.cdbasis.cocos.CDTypeModifierNotPrivate;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDTypeModifierNotPrivateTest extends CD4AnalysisTestBasis {
 
@@ -32,6 +32,5 @@ public class CDTypeModifierNotPrivateTest extends CD4AnalysisTestBasis {
     assertTrue(Log.getFindings().get(2).getMsg().startsWith(CDTypeModifierNotPrivate.ERROR_CODE));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/cd4analysis/cocos/CDTypeModifierNotProtectedTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/cocos/CDTypeModifierNotProtectedTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4analysis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4analysis.CD4AnalysisTestBasis;
 import de.monticore.cdbasis.CDBasisMill;
@@ -11,8 +11,8 @@ import de.monticore.cdbasis.cocos.CDTypeModifierNotProtected;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDTypeModifierNotProtectedTest extends CD4AnalysisTestBasis {
 
@@ -32,6 +32,5 @@ public class CDTypeModifierNotProtectedTest extends CD4AnalysisTestBasis {
     assertTrue(Log.getFindings().get(2).getMsg().startsWith(CDTypeModifierNotProtected.ERROR_CODE));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/cd4analysis/parser/TestCD4AnalysisParserTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/parser/TestCD4AnalysisParserTest.java
@@ -6,7 +6,7 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import java.io.IOException;
 import java.util.Optional;
 import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCD4AnalysisParserTest extends CD4AnalysisTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/cd4analysis/prettyprint/CD4AnalysisFullPrettyPrinterTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/prettyprint/CD4AnalysisFullPrettyPrinterTest.java
@@ -9,7 +9,7 @@ import de.monticore.cd4analysis.trafo.CD4AnalysisAfterParseTrafo;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CD4AnalysisFullPrettyPrinterTest extends CD4AnalysisTestBasis {

--- a/cdlang/src/test/java/de/monticore/cd4analysis/trafo/CDAssociationTrafoTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4analysis/trafo/CDAssociationTrafoTest.java
@@ -1,10 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4analysis.trafo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-
 import de.monticore.cd4analysis.CD4AnalysisMill;
 import de.monticore.cd4analysis.CD4AnalysisTestBasis;
 import de.monticore.cd4analysis._symboltable.CD4AnalysisSymbolTableCompleter;
@@ -19,8 +15,11 @@ import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDAssociationTrafoTest extends CD4AnalysisTestBasis {
   @Test
@@ -108,7 +107,7 @@ public class CDAssociationTrafoTest extends CD4AnalysisTestBasis {
   }
 
   @Test
-  @Ignore // TODO: See #3940
+  @Disabled // TODO: See #3940
   public void testWithCircularAssocsNavigable() throws IOException {
     this.testWithCircularAssocs(new CDAssociationCreateFieldsFromNavigableRoles());
   }
@@ -124,10 +123,8 @@ public class CDAssociationTrafoTest extends CD4AnalysisTestBasis {
     cdAssociationCreateFieldsTrafo.transform(compUnit);
 
     for (ASTCDClass clazz : compUnit.getCDDefinition().getCDClassesList()) {
-      assertNotEquals(
-          clazz.getName() + " did not generate with its attribute",
-          0,
-          clazz.getCDAttributeList().size());
+      assertNotEquals(0, clazz.getCDAttributeList().size(),
+          clazz.getName() + " did not generate with its attribute");
     }
   }
 }

--- a/cdlang/src/test/java/de/monticore/cd4code/CD4CodeTestBasis.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/CD4CodeTestBasis.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4code;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import de.monticore.cd.TestBasis;
 import de.monticore.cd._symboltable.BuiltInTypes;
@@ -22,7 +22,7 @@ import de.se_rwth.commons.logging.LogStub;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class CD4CodeTestBasis extends TestBasis {
   protected CD4CodeParser p;
@@ -31,7 +31,7 @@ public class CD4CodeTestBasis extends TestBasis {
   protected CD4CodeSymbols2Json symbols2Json;
   protected CD4CodeCoCoChecker coCoChecker;
 
-  @Before
+  @BeforeEach
   public void initObjects() {
     LogStub.init();
     Log.enableFailQuick(false);

--- a/cdlang/src/test/java/de/monticore/cd4code/_ast/ASTCDDefinitionTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/_ast/ASTCDDefinitionTest.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4code._ast;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code.CD4CodeTestBasis;
@@ -11,7 +11,7 @@ import de.monticore.cdbasis._ast.ASTCDDefinition;
 import de.monticore.cdbasis._ast.ASTCDType;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ASTCDDefinitionTest extends CD4CodeTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/cd4code/_symboltable/CD4CodeDeSerTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/_symboltable/CD4CodeDeSerTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4code._symboltable;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code.CD4CodeTestBasis;
@@ -14,7 +12,9 @@ import de.monticore.io.paths.MCPath;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CD4CodeDeSerTest extends CD4CodeTestBasis {

--- a/cdlang/src/test/java/de/monticore/cd4code/_symboltable/CD4CodePackageResolveTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/_symboltable/CD4CodePackageResolveTest.java
@@ -1,9 +1,9 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4code._symboltable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code.CD4CodeTestBasis;
@@ -22,13 +22,13 @@ import de.monticore.types.check.SymTypeOfGenerics;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CD4CodePackageResolveTest extends CD4CodeTestBasis {
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     CD4CodeMill.reset();
     CD4CodeMill.init();

--- a/cdlang/src/test/java/de/monticore/cd4code/_symboltable/CD4CodeSymbolTableCreatorDelegatorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/_symboltable/CD4CodeSymbolTableCreatorDelegatorTest.java
@@ -7,7 +7,7 @@ import de.monticore.cd4code.trafo.CD4CodeAfterParseTrafo;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CD4CodeSymbolTableCreatorDelegatorTest extends CD4CodeTestBasis {

--- a/cdlang/src/test/java/de/monticore/cd4code/_symboltable/SymbolTableSerializationTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/_symboltable/SymbolTableSerializationTest.java
@@ -15,13 +15,14 @@ import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SymbolTableSerializationTest {
 
-  @Before
+  @BeforeEach
   public void before() {
     CD4CodeMill.reset();
     CD4CodeMill.init();
@@ -171,7 +172,7 @@ public class SymbolTableSerializationTest {
     return scope;
   }
 
-  @After
+  @AfterEach
   public void after() {
     assertTrue(Log.getFindings().isEmpty());
   }

--- a/cdlang/src/test/java/de/monticore/cd4code/cocos/CD4CodeCoCoTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/cocos/CD4CodeCoCoTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4code.cocos;
 
-import static org.junit.Assert.assertNotNull;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code.CD4CodeTestBasis;
 import de.monticore.cd4code._symboltable.ICD4CodeArtifactScope;
@@ -10,7 +8,9 @@ import de.monticore.cd4code.trafo.CD4CodeAfterParseTrafo;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CD4CodeCoCoTest extends CD4CodeTestBasis {

--- a/cdlang/src/test/java/de/monticore/cd4code/cocos/CDAssociationUniqueInHierarchyTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/cocos/CDAssociationUniqueInHierarchyTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4code.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code.CD4CodeTestBasis;
@@ -13,8 +13,8 @@ import de.monticore.types.mcbasictypes.MCBasicTypesMill;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationUniqueInHierarchyTest extends CD4CodeTestBasis {
 
@@ -54,6 +54,5 @@ public class CDAssociationUniqueInHierarchyTest extends CD4CodeTestBasis {
     return as;
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/cd4code/cocos/CDAttributeTypeExistsCoCoTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/cocos/CDAttributeTypeExistsCoCoTest.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4code.cocos;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code.CD4CodeTestBasis;
@@ -14,7 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 import org.apache.commons.cli.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CDAttributeTypeExistsCoCoTest extends CD4CodeTestBasis {

--- a/cdlang/src/test/java/de/monticore/cd4code/parser/CD4CodeParserTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/parser/CD4CodeParserTest.java
@@ -6,7 +6,7 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import java.io.IOException;
 import java.util.Optional;
 import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CD4CodeParserTest extends CD4CodeTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/cd4code/prettyprint/CD4CodeFullPrettyPrinterTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/prettyprint/CD4CodeFullPrettyPrinterTest.java
@@ -6,8 +6,10 @@ import de.monticore.cd4code.CD4CodeTestBasis;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CD4CodeFullPrettyPrinterTest extends CD4CodeTestBasis {
@@ -52,11 +54,11 @@ public class CD4CodeFullPrettyPrinterTest extends CD4CodeTestBasis {
     checkNullAndPresence(p, prettyASTOpt);
 
     if (!ast.deepEquals(prettyASTOpt.get())) {
-      Assert.assertEquals(
-          "Did not deep-equal: " + filePath,
+      assertEquals(
           pretty,
-          CD4CodeMill.prettyPrint(prettyASTOpt.get(), true));
-      Assert.fail("Did not deep-equal: " + filePath);
+          CD4CodeMill.prettyPrint(prettyASTOpt.get(), true),
+          "Did not deep-equal: " + filePath);
+      fail("Did not deep-equal: " + filePath);
     }
   }
 }

--- a/cdlang/src/test/java/de/monticore/cd4code/visitor/CD4CodeVisitorTest.java
+++ b/cdlang/src/test/java/de/monticore/cd4code/visitor/CD4CodeVisitorTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cd4code.visitor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeTestBasis;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CD4CodeVisitorTest extends CD4CodeTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/symtabdefinition/SymTabDefinitionTestBasis.java
+++ b/cdlang/src/test/java/de/monticore/symtabdefinition/SymTabDefinitionTestBasis.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.symtabdefinition;
 
-import static org.junit.Assert.fail;
-
 import de.monticore.cd.TestBasis;
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.trafo.CD4CodeAfterParseTrafo;
@@ -22,6 +20,8 @@ import de.se_rwth.commons.logging.LogStub;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 
 public class SymTabDefinitionTestBasis extends TestBasis {
@@ -53,7 +53,7 @@ public class SymTabDefinitionTestBasis extends TestBasis {
     try {
       astcdCompilationUnit = parser.parse(getFilePath(filePath));
     } catch (IOException e) {
-      fail("Exception during parsing: " + e);
+      Assertions.fail("Exception during parsing: " + e);
     }
     checkNullAndPresence(parser, astcdCompilationUnit);
     final ASTCDCompilationUnit node = astcdCompilationUnit.get();

--- a/cdlang/src/test/java/de/monticore/symtabdefinition/cocos/STDFunctionSignatureParameterNamesUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/symtabdefinition/cocos/STDFunctionSignatureParameterNamesUniqueTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.symtabdefinition.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.symtabdefinition.SymTabDefinitionTestBasis;

--- a/cdlang/src/test/java/de/monticore/symtabdefinition/cocos/STDVariableUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/symtabdefinition/cocos/STDVariableUniqueTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.symtabdefinition.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.symtabdefinition.SymTabDefinitionTestBasis;

--- a/cdlang/src/test/java/de/monticore/symtabdefinition/symboltable/SymTabDefinitionSymbolTableCompleterTest.java
+++ b/cdlang/src/test/java/de/monticore/symtabdefinition/symboltable/SymTabDefinitionSymbolTableCompleterTest.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.symtabdefinition.symboltable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.symtabdefinition.SymTabDefinitionTestBasis;
@@ -18,11 +18,12 @@ public class SymTabDefinitionSymbolTableCompleterTest extends SymTabDefinitionTe
     prepareST(ast);
     ISymTabDefinitionArtifactScope as = (ISymTabDefinitionArtifactScope) ast.getEnclosingScope();
     assertEquals(0, as.getTypeVarSymbols().size());
-    assertEquals(0, as.resolveFunction("f").get().getSpannedScope().getTypeVarSymbols().size());
-    assertEquals(
-        1, as.resolveFunction("getTarget").get().getSpannedScope().getTypeVarSymbols().size());
-    assertEquals(
-        2, as.resolveFunction("p.getMapString").get().getSpannedScope().getTypeVarSymbols().size());
+    assertEquals(0,
+        as.resolveFunction("f").get().getSpannedScope().getTypeVarSymbols().size());
+    assertEquals(1,
+        as.resolveFunction("getTarget").get().getSpannedScope().getTypeVarSymbols().size());
+    assertEquals(2,
+        as.resolveFunction("p.getMapString").get().getSpannedScope().getTypeVarSymbols().size());
 
     checkLogError();
   }

--- a/cdlang/src/test/java/de/monticore/testcd4codebasis/CD4CodeBasisTestBasis.java
+++ b/cdlang/src/test/java/de/monticore/testcd4codebasis/CD4CodeBasisTestBasis.java
@@ -8,14 +8,14 @@ import de.monticore.testcd4codebasis._cocos.TestCD4CodeBasisCoCoChecker;
 import de.monticore.testcd4codebasis._parser.TestCD4CodeBasisParser;
 import de.monticore.testcd4codebasis._symboltable.ITestCD4CodeBasisGlobalScope;
 import de.se_rwth.commons.logging.LogStub;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class CD4CodeBasisTestBasis extends TestBasis {
   protected TestCD4CodeBasisParser p;
   protected CD4CodeBasisCoCos cdCD4CodeBasisCoCos;
   protected TestCD4CodeBasisCoCoChecker coCoChecker;
 
-  @Before
+  @BeforeEach
   public void initObjects() {
     LogStub.init();
     LogStub.enableFailQuick(false);

--- a/cdlang/src/test/java/de/monticore/testcd4codebasis/_symboltable/CD4CodeBasisDeSerTest.java
+++ b/cdlang/src/test/java/de/monticore/testcd4codebasis/_symboltable/CD4CodeBasisDeSerTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcd4codebasis._symboltable;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4codebasis._symboltable.CDMethodSignatureSymbol;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -18,7 +16,9 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CD4CodeBasisDeSerTest extends CD4CodeBasisTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcd4codebasis/_symboltable/CD4CodeBasisSTCompleterTest.java
+++ b/cdlang/src/test/java/de/monticore/testcd4codebasis/_symboltable/CD4CodeBasisSTCompleterTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcd4codebasis._symboltable;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.LinkedListMultimap;
 import de.monticore.cd4codebasis.CD4CodeBasisMill;
 import de.monticore.cd4codebasis._symboltable.CD4CodeBasisSymbolTableCompleter;
@@ -25,7 +23,9 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.NoSuchElementException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CD4CodeBasisSTCompleterTest extends CD4CodeBasisTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcd4codebasis/cocos/CD4CodeEnumConstantParameterMatchConstructorArgumentsTest.java
+++ b/cdlang/src/test/java/de/monticore/testcd4codebasis/cocos/CD4CodeEnumConstantParameterMatchConstructorArgumentsTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcd4codebasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4codebasis._cocos.CD4CodeBasisCoCoChecker;
 import de.monticore.cd4codebasis.cocos.ebnf.CD4CodeEnumConstantParameterMatchConstructorArguments;
@@ -14,8 +14,9 @@ import de.monticore.testcd4codebasis._symboltable.TestCD4CodeBasisSymbolTableCom
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CD4CodeEnumConstantParameterMatchConstructorArgumentsTest
     extends CD4CodeBasisTestBasis {
@@ -69,6 +70,6 @@ public class CD4CodeEnumConstantParameterMatchConstructorArgumentsTest
     assertTrue(Log.getFindings().get(1).getMsg().startsWith("0xCDCD2")); // for BAR
   }
 
-  @After
+  @AfterEach
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcd4codebasis/cocos/CDMethodSignatureParameterNamesUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/testcd4codebasis/cocos/CDMethodSignatureParameterNamesUniqueTest.java
@@ -2,8 +2,8 @@
 package de.monticore.testcd4codebasis.cocos;
 
 import static de.monticore.cd.TestBasis.getFilePath;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4codebasis.cocos.ebnf.CDMethodSignatureParameterNamesUnique;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -11,8 +11,8 @@ import de.monticore.testcd4codebasis.CD4CodeBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDMethodSignatureParameterNamesUniqueTest extends CD4CodeBasisTestBasis {
 
@@ -41,6 +41,5 @@ public class CDMethodSignatureParameterNamesUniqueTest extends CD4CodeBasisTestB
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC90"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcd4codebasis/parser/TestCD4CodeBasisParserTest.java
+++ b/cdlang/src/test/java/de/monticore/testcd4codebasis/parser/TestCD4CodeBasisParserTest.java
@@ -10,7 +10,7 @@ import de.monticore.cdinterfaceandenum._ast.ASTCDEnumConstant;
 import de.monticore.testcd4codebasis.CD4CodeBasisTestBasis;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCD4CodeBasisParserTest extends CD4CodeBasisTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcd4codebasis/prettyprint/TestCD4CodeBasisPretterPrinterTest.java
+++ b/cdlang/src/test/java/de/monticore/testcd4codebasis/prettyprint/TestCD4CodeBasisPretterPrinterTest.java
@@ -1,14 +1,14 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcd4codebasis.prettyprint;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4codebasis.CD4CodeBasisMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.testcd4codebasis.CD4CodeBasisTestBasis;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class TestCD4CodeBasisPretterPrinterTest extends CD4CodeBasisTestBasis {

--- a/cdlang/src/test/java/de/monticore/testcdassociation/CDAssociationTestBasis.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/CDAssociationTestBasis.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import de.monticore.cd.TestBasis;
 import de.monticore.cd._symboltable.BuiltInTypes;
@@ -19,13 +19,13 @@ import de.monticore.testcdassociation._visitor.TestCDAssociationTraverser;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class CDAssociationTestBasis extends TestBasis {
   protected TestCDAssociationParser p;
   protected CDAssociationCoCoChecker coCoChecker;
 
-  @Before
+  @BeforeEach
   public void initObjects() {
     TestCDAssociationMill.reset();
     TestCDAssociationMill.init();

--- a/cdlang/src/test/java/de/monticore/testcdassociation/ast/ASTCDCardinalityDeepEqualsTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/ast/ASTCDCardinalityDeepEqualsTest.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.ast;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation._ast.ASTCDCardAtLeastOne;
 import de.monticore.cdassociation._ast.ASTCDCardMult;
@@ -10,7 +10,7 @@ import de.monticore.cdassociation._ast.ASTCDCardOpt;
 import de.monticore.testcdassociation.TestCDAssociationMill;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ASTCDCardinalityDeepEqualsTest {
 

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationByAttributeFieldExistTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationByAttributeFieldExistTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.cocos.ebnf.CDAssociationByAttributeFieldExist;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationByAttributeFieldExistTest extends CDAssociationTestBasis {
 
@@ -44,7 +44,6 @@ public class CDAssociationByAttributeFieldExistTest extends CDAssociationTestBas
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC6B"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationHasSymbolTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationHasSymbolTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.cocos.ebnf.CDAssociationHasSymbol;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -12,7 +12,7 @@ import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedName;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationHasSymbolTest extends CDAssociationTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationNameLowerCaseTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationNameLowerCaseTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.cocos.ebnf.CDAssociationNameLowerCase;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationNameLowerCaseTest extends CDAssociationTestBasis {
 
@@ -44,7 +44,6 @@ public class CDAssociationNameLowerCaseTest extends CDAssociationTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC61"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationNameUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationNameUniqueTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.cocos.ebnf.CDAssociationNameUnique;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationNameUniqueTest extends CDAssociationTestBasis {
 
@@ -40,7 +40,6 @@ public class CDAssociationNameUniqueTest extends CDAssociationTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC64"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationNoTypeParametersTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationNoTypeParametersTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.CDAssociationMill;
 import de.monticore.cdassociation.cocos.ebnf.CDAssociationNoTypeParameters;
@@ -12,7 +12,7 @@ import de.monticore.testcdassociation._symboltable.ITestCDAssociationArtifactSco
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationNoTypeParametersTest extends CDAssociationTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationOrderedCardinalityGreaterOneTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationOrderedCardinalityGreaterOneTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.cocos.ebnf.CDAssociationOrderedCardinalityGreaterOne;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationOrderedCardinalityGreaterOneTest extends CDAssociationTestBasis {
 
@@ -41,7 +41,6 @@ public class CDAssociationOrderedCardinalityGreaterOneTest extends CDAssociation
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC65"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationRoleNameLowerCaseTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationRoleNameLowerCaseTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.cocos.ebnf.CDAssociationRoleNameLowerCase;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationRoleNameLowerCaseTest extends CDAssociationTestBasis {
 
@@ -43,7 +43,6 @@ public class CDAssociationRoleNameLowerCaseTest extends CDAssociationTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC66"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationRoleNameNoConflictWithLocalAttributeTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationRoleNameNoConflictWithLocalAttributeTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.cocos.ebnf.CDAssociationRoleNameNoConflictWithLocalAttribute;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationRoleNameNoConflictWithLocalAttributeTest extends CDAssociationTestBasis {
 
@@ -44,7 +44,6 @@ public class CDAssociationRoleNameNoConflictWithLocalAttributeTest extends CDAss
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xC4A27"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationSrcAndTargetTypeExistCheckerTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/CDAssociationSrcAndTargetTypeExistCheckerTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /*
  * The corresponding coco is superfluous, as this case is already dealt with in the construction
@@ -40,11 +40,10 @@ public class CDAssociationSrcAndTargetTypeExistCheckerTest extends CDAssociation
     Log.getFindings().clear();
     createSymTab(ast);
     completeSymTab(ast);
-    assertEquals(Log.getFindings().toString(), 1, Log.getFindings().size());
+    assertEquals(1, Log.getFindings().size(), Log.getFindings().toString());
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xA0324"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdassociation/cocos/RoleAndFieldNamesUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/cocos/RoleAndFieldNamesUniqueTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation.cocos.ebnf.RoleAndFieldNamesUnique;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class RoleAndFieldNamesUniqueTest extends CDAssociationTestBasis {
 
@@ -60,7 +60,6 @@ public class RoleAndFieldNamesUniqueTest extends CDAssociationTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xC4A28"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdassociation/parser/TestCDAssociationParserTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/parser/TestCDAssociationParserTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.parser;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cdassociation.CDAssociationMill;
 import de.monticore.cdassociation._ast.*;
 import de.monticore.cdassociation._visitor.CDAssociationVisitor2;
@@ -16,7 +14,9 @@ import de.monticore.testcdassociation.TestCDAssociationMill;
 import de.monticore.testcdassociation._visitor.TestCDAssociationTraverser;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCDAssociationParserTest extends CDAssociationTestBasis {
 
@@ -48,7 +48,7 @@ public class TestCDAssociationParserTest extends CDAssociationTestBasis {
         new CDAssociationVisitor2() {
           @Override
           public void visit(ASTCDCardinality node) {
-            assertTrue(node instanceof ASTCDCardMult);
+            assertInstanceOf(ASTCDCardMult.class, node);
           }
         };
     traverser.add4CDAssociation(visitor);
@@ -63,7 +63,7 @@ public class TestCDAssociationParserTest extends CDAssociationTestBasis {
         new CDAssociationVisitor2() {
           @Override
           public void visit(ASTCDCardinality node) {
-            assertTrue(node instanceof ASTCDCardOne);
+            assertInstanceOf(ASTCDCardOne.class, node);
           }
         };
     traverser.add4CDAssociation(visitor);
@@ -79,7 +79,7 @@ public class TestCDAssociationParserTest extends CDAssociationTestBasis {
         new CDAssociationVisitor2() {
           @Override
           public void visit(ASTCDCardinality node) {
-            assertTrue(node instanceof ASTCDCardAtLeastOne);
+            assertInstanceOf(ASTCDCardAtLeastOne.class, node);
           }
         };
     traverser.add4CDAssociation(visitor);
@@ -94,7 +94,7 @@ public class TestCDAssociationParserTest extends CDAssociationTestBasis {
         new CDAssociationVisitor2() {
           @Override
           public void visit(ASTCDCardinality node) {
-            assertTrue(node instanceof ASTCDCardOpt);
+            assertInstanceOf(ASTCDCardOpt.class, node);
           }
         };
     traverser.add4CDAssociation(visitor);
@@ -109,7 +109,7 @@ public class TestCDAssociationParserTest extends CDAssociationTestBasis {
         new CDAssociationVisitor2() {
           @Override
           public void visit(ASTCDCardinality node) {
-            assertTrue(node instanceof ASTCDCardOther);
+            assertInstanceOf(ASTCDCardOther.class, node);
             assertTrue(
                 (node.toCardinality().getLowerBound() == 2
                         && node.toCardinality().getUpperBound() == 3)

--- a/cdlang/src/test/java/de/monticore/testcdassociation/prettyprint/TestCDAssociationPrettyPrinterTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/prettyprint/TestCDAssociationPrettyPrinterTest.java
@@ -7,7 +7,7 @@ import de.monticore.testcdassociation.CDAssociationTestBasis;
 import de.monticore.testcdassociation._parser.TestCDAssociationParser;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class TestCDAssociationPrettyPrinterTest extends CDAssociationTestBasis {

--- a/cdlang/src/test/java/de/monticore/testcdassociation/symboltable/CDAssociationDeSerTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/symboltable/CDAssociationDeSerTest.java
@@ -1,9 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.symboltable;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertNotEquals;
-
 import de.monticore.cdassociation.CDAssociationMill;
 import de.monticore.cdassociation._symboltable.CDAssociationSymbol;
 import de.monticore.cdassociation._symboltable.CDRoleSymbol;
@@ -19,7 +16,9 @@ import de.monticore.testcdassociation._symboltable.TestCDAssociationSymbols2Json
 import de.se_rwth.commons.logging.Log;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDAssociationDeSerTest extends CDAssociationTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdassociation/symboltable/CDAssociationSTCompleterTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/symboltable/CDAssociationSTCompleterTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdassociation.symboltable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation._symboltable.CDRoleSymbol;
 import de.monticore.cdassociation.trafo.CDAssociationDirectCompositionTrafo;
@@ -15,8 +15,9 @@ import de.monticore.testcdassociation._symboltable.ITestCDAssociationArtifactSco
 import de.monticore.testcdassociation._visitor.TestCDAssociationTraverser;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationSTCompleterTest extends CDAssociationTestBasis {
 
@@ -43,7 +44,7 @@ public class CDAssociationSTCompleterTest extends CDAssociationTestBasis {
     checkLogError();
   }
 
-  @Ignore // TODO: resolven mit Paketen checken
+  @Disabled // TODO: resolven mit Paketen checken
   @Test
   public void genitorTestWithPkg() {
     ICDBasisArtifactScope artifactScope = processModel("cdassociation/parser/SimpleWithPkg.cd");

--- a/cdlang/src/test/java/de/monticore/testcdassociation/symboltable/CDAssociationSymbolTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdassociation/symboltable/CDAssociationSymbolTest.java
@@ -1,7 +1,7 @@
 package de.monticore.testcdassociation.symboltable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdassociation._symboltable.CDAssociationSymbol;
 import de.monticore.cdassociation._symboltable.ICDAssociationArtifactScope;
@@ -13,7 +13,7 @@ import de.monticore.testcdassociation.TestCDAssociationMill;
 import de.monticore.testcdassociation._symboltable.ITestCDAssociationArtifactScope;
 import de.monticore.testcdassociation._visitor.TestCDAssociationTraverser;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CDAssociationSymbolTest extends CDAssociationTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdbasis/CDBasisTestBasis.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/CDBasisTestBasis.java
@@ -14,13 +14,13 @@ import de.monticore.testcdbasis._visitor.TestCDBasisTraverser;
 import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import java.nio.file.Paths;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class CDBasisTestBasis extends TestBasis {
   protected TestCDBasisParser p;
   protected TestCDBasisCoCoChecker coCoChecker;
 
-  @Before
+  @BeforeEach
   public void initObjects() {
     // reset the log
     LogStub.init();

--- a/cdlang/src/test/java/de/monticore/testcdbasis/_symboltable/CDBasisDeSerTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/_symboltable/CDBasisDeSerTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis._symboltable;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._symboltable.CDBasisSymbolTableCompleter;
@@ -18,8 +16,10 @@ import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDBasisDeSerTest {
 
@@ -27,7 +27,7 @@ public class CDBasisDeSerTest {
   TestCDBasisParser parser;
   TestCDBasisSymbols2Json symbols2Json;
 
-  @Before
+  @BeforeEach
   public void setup() {
     // reset the GlobalScope
     TestCDBasisMill.reset();

--- a/cdlang/src/test/java/de/monticore/testcdbasis/_symboltable/CDBasisSTCompleterTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/_symboltable/CDBasisSTCompleterTest.java
@@ -1,9 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis._symboltable;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-
 import com.google.common.collect.LinkedListMultimap;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDClass;
@@ -28,8 +25,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDBasisSTCompleterTest {
 
@@ -37,7 +36,7 @@ public class CDBasisSTCompleterTest {
   TestCDBasisParser parser;
   TestCDBasisSymbols2Json symbols2Json;
 
-  @Before
+  @BeforeEach
   public void setup() {
     // reset the GlobalScope
     TestCDBasisMill.reset();

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDAttributeInitialTypeCompatibleTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDAttributeInitialTypeCompatibleTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4analysis.typescalculator.FullDeriveFromCD4Analysis;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -11,8 +11,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAttributeInitialTypeCompatibleTest extends CDBasisTestBasis {
 
@@ -46,6 +46,5 @@ public class CDAttributeInitialTypeCompatibleTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(2).getMsg().startsWith("0xCDC02"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDAttributeNameLowerCaseIfNotStaticTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDAttributeNameLowerCaseIfNotStaticTest.java
@@ -2,8 +2,8 @@
 package de.monticore.testcdbasis.cocos;
 
 import static de.monticore.cd.TestBasis.getFilePath;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.cocos.ebnf.CDAttributeNameLowerCaseIfNotStatic;
@@ -11,8 +11,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAttributeNameLowerCaseIfNotStaticTest extends CDBasisTestBasis {
 
@@ -40,7 +40,6 @@ public class CDAttributeNameLowerCaseIfNotStaticTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC03"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDAttributeTypeExistsTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDAttributeTypeExistsTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.cocos.ebnf.CDAttributeTypeExists;
@@ -10,8 +10,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAttributeTypeExistsTest extends CDBasisTestBasis {
 
@@ -39,11 +39,10 @@ public class CDAttributeTypeExistsTest extends CDBasisTestBasis {
     createSymTab(ast);
     completeSymTab(ast);
     coCoChecker.checkAll(ast);
-    assertEquals(Log.getFindings().toString(), 1, Log.getFindings().size());
+    assertEquals(1, Log.getFindings().size(), Log.getFindings().toString());
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xA0324"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDAttributeUniqueInClassTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDAttributeUniqueInClassTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -11,8 +11,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDAttributeUniqueInClassTest extends CDBasisTestBasis {
 
@@ -42,7 +42,6 @@ public class CDAttributeUniqueInClassTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC06"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDClassExtendsAtMostOneClassTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDClassExtendsAtMostOneClassTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.cocos.optional.CDClassExtendsAtMostOneClass;
@@ -10,8 +10,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDClassExtendsAtMostOneClassTest extends CDBasisTestBasis {
 
@@ -44,6 +44,5 @@ public class CDClassExtendsAtMostOneClassTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC2F"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDClassExtendsNotCyclicTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDClassExtendsNotCyclicTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -11,8 +11,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDClassExtendsNotCyclicTest extends CDBasisTestBasis {
 
@@ -44,6 +44,5 @@ public class CDClassExtendsNotCyclicTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(1).getMsg().startsWith("0xCDC07"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDClassNameUpperCaseTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDClassNameUpperCaseTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.cocos.ebnf.CDClassNameUpperCase;
@@ -10,8 +10,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDClassNameUpperCaseTest extends CDBasisTestBasis {
 
@@ -39,6 +39,5 @@ public class CDClassNameUpperCaseTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC0A"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDDefinitionNameUpperCaseTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDDefinitionNameUpperCaseTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -11,8 +11,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDDefinitionNameUpperCaseTest extends CDBasisTestBasis {
 
@@ -42,6 +42,5 @@ public class CDDefinitionNameUpperCaseTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC0B"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDDefinitionUniqueCDTypeNamesTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDDefinitionUniqueCDTypeNamesTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -11,8 +11,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDDefinitionUniqueCDTypeNamesTest extends CDBasisTestBasis {
 
@@ -42,6 +42,5 @@ public class CDDefinitionUniqueCDTypeNamesTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC0D"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDPackageNameUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDPackageNameUniqueTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.cocos.ebnf.CDPackageNameUnique;
@@ -10,8 +10,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDPackageNameUniqueTest extends CDBasisTestBasis {
 
@@ -39,6 +39,5 @@ public class CDPackageNameUniqueTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC0E"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDPackageNotContainingCDPackageTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDPackageNotContainingCDPackageTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.cocos.mcg2ebnf.CDPackageNotContainingCDPackage;
@@ -10,8 +10,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDPackageNotContainingCDPackageTest extends CDBasisTestBasis {
 
@@ -39,6 +39,5 @@ public class CDPackageNotContainingCDPackageTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC20"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDPackageUniqueCDTypeNamesTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDPackageUniqueCDTypeNamesTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -11,8 +11,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDPackageUniqueCDTypeNamesTest extends CDBasisTestBasis {
 
@@ -42,7 +42,6 @@ public class CDPackageUniqueCDTypeNamesTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC0F"));
   }
 
-  @After
-  @Override
+  @AfterEach  @Override
   public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDTypeNoInitializationOfDerivedAttributeTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/CDTypeNoInitializationOfDerivedAttributeTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.cocos.ebnf.CDTypeNoInitializationOfDerivedAttribute;
@@ -10,8 +10,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDTypeNoInitializationOfDerivedAttributeTest extends CDBasisTestBasis {
 
@@ -41,6 +41,5 @@ public class CDTypeNoInitializationOfDerivedAttributeTest extends CDBasisTestBas
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC0C"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/cocos/ModifierNotMultipleVisibilitiesCoCoTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/cocos/ModifierNotMultipleVisibilitiesCoCoTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.cocos.mcg.ModifierNotMultipleVisibilitiesCoCo;
@@ -10,8 +10,8 @@ import de.monticore.testcdbasis.CDBasisTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class ModifierNotMultipleVisibilitiesCoCoTest extends CDBasisTestBasis {
 
@@ -39,6 +39,5 @@ public class ModifierNotMultipleVisibilitiesCoCoTest extends CDBasisTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC10"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/parser/TestCDBasisParserTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/parser/TestCDBasisParserTest.java
@@ -5,7 +5,7 @@ import de.monticore.cdbasis._ast.*;
 import de.monticore.testcdbasis.CDBasisTestBasis;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCDBasisParserTest extends CDBasisTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdbasis/prettyprint/TestCDBasisPretterPrinterTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/prettyprint/TestCDBasisPretterPrinterTest.java
@@ -8,7 +8,7 @@ import de.monticore.prettyprint.IndentPrinter;
 import de.monticore.testcdbasis._parser.TestCDBasisParser;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class TestCDBasisPretterPrinterTest extends TestBasis {

--- a/cdlang/src/test/java/de/monticore/testcdbasis/resolving/TestCDBasisResolvingTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/resolving/TestCDBasisResolvingTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.resolving;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.TestBasis;
 import de.monticore.cd._symboltable.BuiltInTypes;
@@ -23,15 +23,15 @@ import de.monticore.testcdbasis._visitor.TestCDBasisTraverser;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class TestCDBasisResolvingTest extends TestBasis {
   protected static ICDBasisGlobalScope globalScope;
   protected static ICDBasisArtifactScope artifactScope;
 
-  @BeforeClass
+  @BeforeAll
   public static void parseCompleteModel() throws IOException {
     final TestCDBasisParser p = TestCDBasisMill.parser();
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit =
@@ -67,32 +67,30 @@ public class TestCDBasisResolvingTest extends TestBasis {
   @Test
   public void resolveCDType() {
     final Optional<CDTypeSymbol> a = globalScope.resolveCDType("cdbasis.parser.Packages.A");
-    assertFalse("CDType A could be resolved but shouldn't.", a.isPresent());
+    assertFalse(a.isPresent(), "CDType A could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<CDTypeSymbol> a1 = globalScope.resolveCDType("A");
-    assertFalse(
-        "CDType cdbasis.parser.Packages.A could be resolved but shouldn't.", a1.isPresent());
+    assertFalse(a1.isPresent(),
+        "CDType cdbasis.parser.Packages.A could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<CDTypeSymbol> a2 = globalScope.resolveCDType("cdbasis.parser.Packages.a.A");
-    assertTrue(
-        "CDType cdbasis.parser.Packages.a.A could not be resolved:\n" + getJoinedErrors(),
-        a2.isPresent());
+    assertTrue(a2.isPresent(),
+        "CDType cdbasis.parser.Packages.a.A could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<CDTypeSymbol> a3 = globalScope.resolveCDType("cdbasis.parser.Packages.a.b.c.C");
-    assertTrue(
-        "CDType cdbasis.parser.Packages.a.b.c.C could not be resolved:\n" + getJoinedErrors(),
-        a3.isPresent());
+    assertTrue(a3.isPresent(),
+        "CDType cdbasis.parser.Packages.a.b.c.C could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<CDTypeSymbol> a4 = artifactScope.resolveCDType("A");
-    assertFalse("CDType A could be resolved but shouldn't.", a4.isPresent());
+    assertFalse(a4.isPresent(), "CDType A could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<CDTypeSymbol> a5 = artifactScope.resolveCDTypeDown("a.A");
-    assertTrue("CDType a.A could not be resolved:\n" + getJoinedErrors(), a5.isPresent());
+    assertTrue(a5.isPresent(), "CDType a.A could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<CDTypeSymbol> a6 = artifactScope.resolveCDType("a.A");
@@ -113,54 +111,54 @@ public class TestCDBasisResolvingTest extends TestBasis {
   @Test
   public void resolveOOType() {
     final Optional<OOTypeSymbol> a = globalScope.resolveOOType("A");
-    assertFalse("OOTypeSymbol A could be resolved but shouldn't.", a.isPresent());
+    assertFalse(a.isPresent(), "OOTypeSymbol A could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<OOTypeSymbol> a2 = globalScope.resolveOOType("cdbasis.parser.Packages.a.A");
-    assertTrue("OOTypeSymbol A could not be resolved:\n" + getJoinedErrors(), a2.isPresent());
+    assertTrue(a2.isPresent(), "OOTypeSymbol A could not be resolved:\n" + getJoinedErrors());
     checkLogError();
   }
 
   @Test
   public void resolveField() {
     final Optional<FieldSymbol> a1 = globalScope.resolveField("B.a1");
-    assertFalse("Field B.a1 could be resolved but shouldn't.", a1.isPresent());
+    assertFalse(a1.isPresent(), "Field B.a1 could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<FieldSymbol> a1_2 = globalScope.resolveField("cdbasis.parser.Packages.a.B.a1");
-    assertTrue("Field a.B.a1 could not be resolved:\n" + getJoinedErrors(), a1_2.isPresent());
+    assertTrue(a1_2.isPresent(), "Field a.B.a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<FieldSymbol> a1_3 = artifactScope.resolveFieldDown("a.B.a1");
-    assertTrue("Field a.B.a1 could not be resolved:\n" + getJoinedErrors(), a1_3.isPresent());
+    assertTrue(a1_3.isPresent(), "Field a.B.a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<FieldSymbol> a1_4 = artifactScope.resolveFieldDown("d.D.a1");
-    assertTrue("Field d.D.a1 could not be resolved:\n" + getJoinedErrors(), a1_4.isPresent());
+    assertTrue(a1_4.isPresent(), "Field d.D.a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<OOTypeSymbol> b = globalScope.resolveOOType("cdbasis.parser.Packages.a.B");
-    assertTrue("OOTypeSymbol a.B could not be resolved:\n" + getJoinedErrors(), b.isPresent());
+    assertTrue(b.isPresent(), "OOTypeSymbol a.B could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<FieldSymbol> a1_5 = b.get().getSpannedScope().resolveField("a1");
-    assertTrue("Field a1 could not be resolved:\n" + getJoinedErrors(), a1_5.isPresent());
+    assertTrue(a1_5.isPresent(), "Field a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<VariableSymbol> a1_6 = b.get().getSpannedScope().resolveVariable("a1");
-    assertTrue("Field a1 could not be resolved:\n" + getJoinedErrors(), a1_6.isPresent());
+    assertTrue(a1_6.isPresent(), "Field a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<OOTypeSymbol> d = globalScope.resolveOOType("cdbasis.parser.Packages.d.D");
-    assertTrue("OOTypeSymbol d.D could not be resolved:\n" + getJoinedErrors(), d.isPresent());
+    assertTrue(d.isPresent(), "OOTypeSymbol d.D could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<FieldSymbol> a1_7 = d.get().getSpannedScope().resolveField("a1");
-    assertTrue("Field a1 could not be resolved:\n" + getJoinedErrors(), a1_7.isPresent());
+    assertTrue(a1_7.isPresent(), "Field a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<VariableSymbol> a1_8 = d.get().getSpannedScope().resolveVariable("a1");
-    assertTrue("Field a1 could not be resolved:\n" + getJoinedErrors(), a1_8.isPresent());
+    assertTrue(a1_8.isPresent(), "Field a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
   }
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/resolving/TestCDBasisResolvingWithoutPackageDeclTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/resolving/TestCDBasisResolvingWithoutPackageDeclTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.resolving;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.TestBasis;
 import de.monticore.cd._symboltable.BuiltInTypes;
@@ -24,15 +24,15 @@ import de.monticore.testcdbasis._visitor.TestCDBasisTraverser;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class TestCDBasisResolvingWithoutPackageDeclTest extends TestBasis {
   protected static ICDBasisGlobalScope globalScope;
   protected static ICDBasisArtifactScope artifactScope;
 
-  @BeforeClass
+  @BeforeAll
   public static void parseCompleteModel() throws IOException {
     final TestCDBasisParser p = TestCDBasisMill.parser();
     final Optional<ASTCDCompilationUnit> astcdCompilationUnit =
@@ -68,36 +68,33 @@ public class TestCDBasisResolvingWithoutPackageDeclTest extends TestBasis {
   @Test
   public void resolveCDType() {
     final Optional<CDTypeSymbol> a = globalScope.resolveCDType("Packages.A");
-    assertFalse("CDType A could be resolved but shouldn't.", a.isPresent());
+    assertFalse(a.isPresent(), "CDType A could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<CDTypeSymbol> a1 = globalScope.resolveCDType("A");
-    assertFalse(
-        "CDType cdbasis.parser.Packages.A could be resolved but shouldn't.", a1.isPresent());
+    assertFalse(a1.isPresent(), "CDType cdbasis.parser.Packages.A could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<CDTypeSymbol> a2 = globalScope.resolveCDType("Packages.a.A");
-    assertTrue(
-        "CDType cdbasis.parser.Packages.a.A could not be resolved:\n" + getJoinedErrors(),
-        a2.isPresent());
+    assertTrue(a2.isPresent(),
+        "CDType cdbasis.parser.Packages.a.A could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<CDTypeSymbol> a3 = globalScope.resolveCDType("Packages.a.b.c.C");
-    assertTrue(
-        "CDType cdbasis.parser.Packages.a.b.c.C could not be resolved:\n" + getJoinedErrors(),
-        a3.isPresent());
+    assertTrue(a3.isPresent(),
+        "CDType cdbasis.parser.Packages.a.b.c.C could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<CDTypeSymbol> a4 = artifactScope.resolveCDType("A");
-    assertFalse("CDType A could be resolved but shouldn't.", a4.isPresent());
+    assertFalse(a4.isPresent(), "CDType A could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<CDTypeSymbol> a5 = artifactScope.resolveCDTypeDown("a.A");
-    assertTrue("CDType a.A could not be resolved:\n" + getJoinedErrors(), a5.isPresent());
+    assertTrue(a5.isPresent(), "CDType a.A could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<CDTypeSymbol> a6 = artifactScope.resolveCDType("a.A");
-    assertTrue("CDType a.A could not be resolved:\n" + getJoinedErrors(), a6.isPresent());
+    assertTrue(a6.isPresent(), "CDType a.A could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final ICDBasisScope enclosingScopeA = a2.get().getEnclosingScope();
@@ -114,54 +111,54 @@ public class TestCDBasisResolvingWithoutPackageDeclTest extends TestBasis {
   @Test
   public void resolveOOType() {
     final Optional<OOTypeSymbol> a = globalScope.resolveOOType("A");
-    assertFalse("OOTypeSymbol A could be resolved but shouldn't.", a.isPresent());
+    assertFalse(a.isPresent(), "OOTypeSymbol A could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<OOTypeSymbol> a2 = globalScope.resolveOOType("Packages.a.A");
-    assertTrue("OOTypeSymbol A could not be resolved:\n" + getJoinedErrors(), a2.isPresent());
+    assertTrue(a2.isPresent(), "OOTypeSymbol A could not be resolved:\n" + getJoinedErrors());
     checkLogError();
   }
 
   @Test
   public void resolveField() {
     final Optional<FieldSymbol> a1 = globalScope.resolveField("B.a1");
-    assertFalse("Field B.a1 could be resolved but shouldn't.", a1.isPresent());
+    assertFalse(a1.isPresent(), "Field B.a1 could be resolved but shouldn't.");
     checkLogError();
 
     final Optional<FieldSymbol> a1_2 = globalScope.resolveField("Packages.a.B.a1");
-    assertTrue("Field a.B.a1 could not be resolved:\n" + getJoinedErrors(), a1_2.isPresent());
+    assertTrue(a1_2.isPresent(), "Field a.B.a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<FieldSymbol> a1_3 = artifactScope.resolveField("a.B.a1");
-    assertTrue("Field a.B.a1 could not be resolved:\n" + getJoinedErrors(), a1_3.isPresent());
+    assertTrue(a1_3.isPresent(), "Field a.B.a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<FieldSymbol> a1_4 = artifactScope.resolveFieldDown("d.D.a1");
-    assertTrue("Field d.D.a1 could not be resolved:\n" + getJoinedErrors(), a1_4.isPresent());
+    assertTrue(a1_4.isPresent(), "Field d.D.a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<OOTypeSymbol> b = globalScope.resolveOOType("Packages.a.B");
-    assertTrue("OOTypeSymbol a.B could not be resolved:\n" + getJoinedErrors(), b.isPresent());
+    assertTrue(b.isPresent(), "OOTypeSymbol a.B could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<FieldSymbol> a1_5 = b.get().getSpannedScope().resolveField("a1");
-    assertTrue("Field a1 could not be resolved:\n" + getJoinedErrors(), a1_5.isPresent());
+    assertTrue(a1_5.isPresent(), "Field a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<VariableSymbol> a1_6 = b.get().getSpannedScope().resolveVariable("a1");
-    assertTrue("Field a1 could not be resolved:\n" + getJoinedErrors(), a1_6.isPresent());
+    assertTrue(a1_6.isPresent(), "Field a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<OOTypeSymbol> d = globalScope.resolveOOType("Packages.d.D");
-    assertTrue("OOTypeSymbol d.D could not be resolved:\n" + getJoinedErrors(), d.isPresent());
+    assertTrue(d.isPresent(), "OOTypeSymbol d.D could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<FieldSymbol> a1_7 = d.get().getSpannedScope().resolveField("a1");
-    assertTrue("Field a1 could not be resolved:\n" + getJoinedErrors(), a1_7.isPresent());
+    assertTrue(a1_7.isPresent(), "Field a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
 
     final Optional<VariableSymbol> a1_8 = d.get().getSpannedScope().resolveVariable("a1");
-    assertTrue("Field a1 could not be resolved:\n" + getJoinedErrors(), a1_8.isPresent());
+    assertTrue(a1_8.isPresent(), "Field a1 could not be resolved:\n" + getJoinedErrors());
     checkLogError();
   }
 }

--- a/cdlang/src/test/java/de/monticore/testcdbasis/trafo/CDBasisTrafoTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdbasis/trafo/CDBasisTrafoTest.java
@@ -1,9 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdbasis.trafo;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertTrue;
-
 import de.monticore.cd.TestBasis;
 import de.monticore.cd.facade.CDModifier;
 import de.monticore.cdbasis._ast.*;
@@ -15,12 +12,14 @@ import de.monticore.testcdbasis._visitor.TestCDBasisTraverser;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDBasisTrafoTest extends TestBasis {
 
-  @Before
+  @BeforeEach
   public void setupAll() {
     // reset the GlobalScope
     TestCDBasisMill.reset();
@@ -88,7 +87,7 @@ public class CDBasisTrafoTest extends TestBasis {
     assertEquals(expectedDefPkgName, cd.getDefaultPackage().getMCQualifiedName().getQName());
 
     for (ASTCDElement e : cd.getCDElementList()) {
-      assertTrue(e instanceof ASTCDPackage);
+      assertInstanceOf(ASTCDPackage.class, e);
       ASTCDPackage pkg = (ASTCDPackage) e;
       assertTrue(pkg.getMCQualifiedName().getQName().startsWith(expectedDefPkgName));
     }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/CDInterfaceAndEnumTestBasis.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/CDInterfaceAndEnumTestBasis.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import de.monticore.cd.TestBasis;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -18,13 +18,13 @@ import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class CDInterfaceAndEnumTestBasis extends TestBasis {
   protected TestCDInterfaceAndEnumParser p;
   protected CDInterfaceAndEnumCoCoChecker coCoChecker;
 
-  @Before
+  @BeforeEach
   public void initObjects() {
     TestCDInterfaceAndEnumMill.reset();
     TestCDInterfaceAndEnumMill.init();

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/_symboltable/CDInterfaceAndEnumDeSerTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/_symboltable/CDInterfaceAndEnumDeSerTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum._symboltable;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._symboltable.CDBasisSymbolTableCompleter;
@@ -21,8 +19,10 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDInterfaceAndEnumDeSerTest {
 
@@ -30,7 +30,7 @@ public class CDInterfaceAndEnumDeSerTest {
   TestCDInterfaceAndEnumParser parser;
   TestCDInterfaceAndEnumSymbols2Json symbols2Json;
 
-  @Before
+  @BeforeEach
   public void setup() {
     TestCDInterfaceAndEnumMill.reset();
     TestCDInterfaceAndEnumMill.init();

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/_symboltable/CDInterfaceAndEnumSTCompleterTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/_symboltable/CDInterfaceAndEnumSTCompleterTest.java
@@ -1,12 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum._symboltable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import com.google.common.collect.LinkedListMultimap;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._symboltable.CDTypeSymbol;
@@ -20,7 +14,9 @@ import de.se_rwth.commons.logging.Log;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDInterfaceAndEnumSTCompleterTest extends CDInterfaceAndEnumTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDAttributeInInterfaceInitializedTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDAttributeInInterfaceInitializedTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDAttributeInInterfaceInitialized;
@@ -10,7 +10,7 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CDAttributeInInterfaceInitializedTest extends CDInterfaceAndEnumTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDAttributeInInterfaceIsPublicTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDAttributeInInterfaceIsPublicTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDAttributeInInterfaceIsPublic;
@@ -10,7 +10,7 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CDAttributeInInterfaceIsPublicTest extends CDInterfaceAndEnumTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDClassExtendsOnlyClassesTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDClassExtendsOnlyClassesTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDClassExtendsOnlyClasses;
@@ -10,8 +10,8 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDClassExtendsOnlyClassesTest extends CDInterfaceAndEnumTestBasis {
 
@@ -44,6 +44,5 @@ public class CDClassExtendsOnlyClassesTest extends CDInterfaceAndEnumTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC08"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDClassImplementsNotCyclicTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDClassImplementsNotCyclicTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos; /* (c) https://github.com/MontiCore/monticore */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDClassImplementsNotCyclic;
@@ -10,8 +10,8 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDClassImplementsNotCyclicTest extends CDInterfaceAndEnumTestBasis {
 
@@ -44,6 +44,5 @@ public class CDClassImplementsNotCyclicTest extends CDInterfaceAndEnumTestBasis 
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC09"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDClassImplementsOnlyInterfacesTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDClassImplementsOnlyInterfacesTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDClassImplementsOnlyInterfaces;
@@ -10,8 +10,8 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDClassImplementsOnlyInterfacesTest extends CDInterfaceAndEnumTestBasis {
 
@@ -44,6 +44,5 @@ public class CDClassImplementsOnlyInterfacesTest extends CDInterfaceAndEnumTestB
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDCF4"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDEnumConstantUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDEnumConstantUniqueTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDEnumConstantUnique;
@@ -10,8 +10,8 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDEnumConstantUniqueTest extends CDInterfaceAndEnumTestBasis {
 
@@ -44,6 +44,5 @@ public class CDEnumConstantUniqueTest extends CDInterfaceAndEnumTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC30"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDEnumImplementsNotCyclicTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDEnumImplementsNotCyclicTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDEnumImplementsNotCyclic;
@@ -10,8 +10,8 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDEnumImplementsNotCyclicTest extends CDInterfaceAndEnumTestBasis {
 
@@ -44,6 +44,5 @@ public class CDEnumImplementsNotCyclicTest extends CDInterfaceAndEnumTestBasis {
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDC31"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDEnumImplementsOnlyInterfacesTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDEnumImplementsOnlyInterfacesTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDEnumImplementsOnlyInterfaces;
@@ -10,8 +10,8 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDEnumImplementsOnlyInterfacesTest extends CDInterfaceAndEnumTestBasis {
 
@@ -44,6 +44,5 @@ public class CDEnumImplementsOnlyInterfacesTest extends CDInterfaceAndEnumTestBa
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDCF5"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDInterfaceExtendsNotCyclicTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDInterfaceExtendsNotCyclicTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDInterfaceExtendsNotCyclic;
@@ -10,8 +10,8 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDInterfaceExtendsNotCyclicTest extends CDInterfaceAndEnumTestBasis {
 
@@ -45,6 +45,5 @@ public class CDInterfaceExtendsNotCyclicTest extends CDInterfaceAndEnumTestBasis
     assertTrue(Log.getFindings().get(1).getMsg().startsWith("0xCDC32"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDInterfaceExtendsOnlyInterfacesTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/cocos/CDInterfaceExtendsOnlyInterfacesTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testcdinterfaceandenum.cocos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdinterfaceandenum.cocos.ebnf.CDInterfaceExtendsOnlyInterfaces;
@@ -10,8 +10,8 @@ import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CDInterfaceExtendsOnlyInterfacesTest extends CDInterfaceAndEnumTestBasis {
 
@@ -44,6 +44,5 @@ public class CDInterfaceExtendsOnlyInterfacesTest extends CDInterfaceAndEnumTest
     assertTrue(Log.getFindings().get(0).getMsg().startsWith("0xCDCF6"));
   }
 
-  @After
-  public void after() {}
+  @AfterEach  public void after() {}
 }

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/parser/TestCDInterfaceAndEnumParserTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/parser/TestCDInterfaceAndEnumParserTest.java
@@ -9,7 +9,7 @@ import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
 import de.monticore.testcdinterfaceandenum.CDInterfaceAndEnumTestBasis;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCDInterfaceAndEnumParserTest extends CDInterfaceAndEnumTestBasis {
 

--- a/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/prettyprint/TestCDInterfaceAndEnumPretterPrinterTest.java
+++ b/cdlang/src/test/java/de/monticore/testcdinterfaceandenum/prettyprint/TestCDInterfaceAndEnumPretterPrinterTest.java
@@ -7,8 +7,9 @@ import de.monticore.cdinterfaceandenum.CDInterfaceAndEnumMill;
 import de.monticore.testcdinterfaceandenum._parser.TestCDInterfaceAndEnumParser;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class TestCDInterfaceAndEnumPretterPrinterTest extends TestBasis {
@@ -25,6 +26,6 @@ public class TestCDInterfaceAndEnumPretterPrinterTest extends TestBasis {
     final Optional<ASTCDCompilationUnit> astcdCompilationUnitReParsed =
         p.parse_StringCDCompilationUnit(output);
     checkNullAndPresence(p, astcdCompilationUnitReParsed);
-    Assert.assertTrue(astcdCompilationUnit.get().deepEquals(astcdCompilationUnitReParsed.get()));
+    assertTrue(astcdCompilationUnit.get().deepEquals(astcdCompilationUnitReParsed.get()));
   }
 }

--- a/cdlang/src/test/java/de/monticore/testtypeimporter/TestTypeImporterTest.java
+++ b/cdlang/src/test/java/de/monticore/testtypeimporter/TestTypeImporterTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.testtypeimporter;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd.TestBasis;
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
@@ -19,7 +17,9 @@ import de.monticore.testtypeimporter._symboltable.ITestTypeImporterGlobalScope;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTypeImporterTest extends TestBasis {
   @Test

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/AddAttributeTest.java
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/AddAttributeTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.trafo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,12 +10,12 @@ import de.monticore.literals.mccommonliterals.MCCommonLiteralsMill;
 import de.monticore.tf.AddAttribute;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class AddAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     CD4CodeMill.init();
   }

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/CreatingTest.java
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/CreatingTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.trafo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDClass;
@@ -11,12 +11,12 @@ import de.monticore.tf.CreatingNested;
 import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedType;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CreatingTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     CD4CodeMill.init();
   }

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/MoveOptionalAttributeTest.java
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/MoveOptionalAttributeTest.java
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.trafo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.tf.MoveOptionalAttribute;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by
@@ -19,7 +19,7 @@ import org.junit.Test;
  */
 public class MoveOptionalAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     CD4CodeMill.init();
   }
@@ -36,16 +36,15 @@ public class MoveOptionalAttributeTest {
     assertTrue(moveAttr.doPatternMatching());
     moveAttr.doReplacement();
 
-    assertEquals(ast.get().getCDDefinition().getCDClassesList().size(), 2);
-    assertEquals(ast.get().getCDDefinition().getCDClassesList().get(0).getName(), "A");
-    assertEquals(
-        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().size(), 0);
-    assertEquals(ast.get().getCDDefinition().getCDClassesList().get(1).getName(), "B");
-    assertEquals(
-        ast.get().getCDDefinition().getCDClassesList().get(1).getCDAttributeList().size(), 1);
-    assertEquals(
-        ast.get().getCDDefinition().getCDClassesList().get(1).getCDAttributeList().get(0).getName(),
-        "foo");
+    assertEquals(2, ast.get().getCDDefinition().getCDClassesList().size());
+    assertEquals("A", ast.get().getCDDefinition().getCDClassesList().get(0).getName());
+    assertEquals(0,
+        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().size());
+    assertEquals("B", ast.get().getCDDefinition().getCDClassesList().get(1).getName());
+    assertEquals(1,
+        ast.get().getCDDefinition().getCDClassesList().get(1).getCDAttributeList().size());
+    assertEquals("foo",
+        ast.get().getCDDefinition().getCDClassesList().get(1).getCDAttributeList().get(0).getName());
   }
 
   @Test
@@ -60,10 +59,10 @@ public class MoveOptionalAttributeTest {
     assertTrue(moveAttr.doPatternMatching());
     moveAttr.doReplacement();
 
-    assertEquals(ast.get().getCDDefinition().getCDClassesList().size(), 1);
-    assertEquals(ast.get().getCDDefinition().getCDClassesList().get(0).getName(), "A");
-    assertEquals(
-        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().size(), 0);
+    assertEquals(1, ast.get().getCDDefinition().getCDClassesList().size());
+    assertEquals("A", ast.get().getCDDefinition().getCDClassesList().get(0).getName());
+    assertEquals(0,
+        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().size());
   }
 
   @Test
@@ -78,9 +77,9 @@ public class MoveOptionalAttributeTest {
     assertTrue(moveAttr.doPatternMatching());
     moveAttr.doReplacement();
 
-    assertEquals(ast.get().getCDDefinition().getCDClassesList().size(), 1);
-    assertEquals(ast.get().getCDDefinition().getCDClassesList().get(0).getName(), "B");
-    assertEquals(
-        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().size(), 0);
+    assertEquals(1, ast.get().getCDDefinition().getCDClassesList().size());
+    assertEquals("B", ast.get().getCDDefinition().getCDClassesList().get(0).getName());
+    assertEquals(0,
+        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().size());
   }
 }

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/RefactorCDsTest.java
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/RefactorCDsTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.trafo;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.tf.AddMethodToEnum;
 import de.monticore.tf.RefactorCDs;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by
@@ -20,7 +20,7 @@ import org.junit.Test;
  */
 public class RefactorCDsTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     CD4CodeMill.init();
   }

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/ReplaceDerivedAttributeTest.java.bug
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/ReplaceDerivedAttributeTest.java.bug
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.trafo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -10,8 +10,8 @@ import de.monticore.tf.ReplaceDerivedAttribute;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by
@@ -20,7 +20,7 @@ import org.junit.Test;
  */
 public class ReplaceDerivedAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     CD4CodeMill.init();
     Log.enableFailQuick(false);

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/SplitNameTest.java.bug
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/SplitNameTest.java.bug
@@ -1,16 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.trafo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.tf.SplitName;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by
@@ -19,7 +19,7 @@ import org.junit.Test;
  */
 public class SplitNameTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     CD4CodeMill.init();
   }

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/constraintModularisationTests/ConstraintTest.java
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/constraintModularisationTests/ConstraintTest.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.trafo.constraintModularisationTests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd._visitor.CDMemberVisitor;
 import de.monticore.cd4code.CD4CodeMill;
@@ -11,9 +11,9 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.tf.*;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /** Created by Alexander Wilts on 31.10.2016. */
 public class ConstraintTest {
@@ -21,7 +21,7 @@ public class ConstraintTest {
   private final String DexInfrastructureCD =
       "src/test/resources/de/monticore/trafo/GroupDexInfrastructure.cd";
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     CD4CodeMill.init();
   }
@@ -383,7 +383,7 @@ public class ConstraintTest {
   }
 
   @Test
-  @Ignore // TODO: This test fails due to the order of interfaces and classes
+  @Disabled // TODO: This test fails due to the order of interfaces and classes
   public void testTrafoOptionalInOrInList() throws IOException {
     Optional<ASTCDCompilationUnit> astOpt = CD4CodeMill.parser().parse(DexInfrastructureCD);
 

--- a/cdmerge/src/main/java/de/monticore/cdmerge/matching/strategies/DefaultAssociationMatcher.java
+++ b/cdmerge/src/main/java/de/monticore/cdmerge/matching/strategies/DefaultAssociationMatcher.java
@@ -579,7 +579,7 @@ public class DefaultAssociationMatcher extends MatcherBase implements Associatio
               typeName =
                   CDMergeUtils.getTypeName((ASTCDAttribute) attributeSymbol.get().getAstNode());
             }
-            if (typeName != ""
+            if (!typeName.isEmpty()
                 && typeName.equals(CDMergeUtils.getTypeName(qualifier2.getByType()))) {
               matchTypeName = true;
             } else {
@@ -629,7 +629,7 @@ public class DefaultAssociationMatcher extends MatcherBase implements Associatio
               typeName =
                   CDMergeUtils.getTypeName((ASTCDAttribute) attributeSymbol.get().getAstNode());
             }
-            if (typeName != ""
+            if (!typeName.isEmpty()
                 && typeName.equals(CDMergeUtils.getTypeName(qualifier1.getByType()))) {
               matchTypeName = true;
             } else {

--- a/cdmerge/src/test/java/de/monticore/cdmerge/BaseTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/BaseTest.java
@@ -13,11 +13,12 @@ import de.monticore.cdmerge.log.MCLoggerWrapper;
 import de.monticore.cdmerge.merging.mergeresult.MergeResult;
 import de.monticore.cdmerge.merging.mergeresult.MergeStepResult;
 import de.monticore.cdmerge.util.CDMergeUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.BeforeClass;
 
 public class BaseTest {
 
@@ -39,7 +40,7 @@ public class BaseTest {
 
   protected ICD4CodeGlobalScope globalScope;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     MCLoggerWrapper.init(ErrorLevel.WARNING, true);
   }
@@ -48,7 +49,7 @@ public class BaseTest {
     parser = CD4CodeMill.parser();
   }
 
-  @Before
+  @BeforeEach
   public void initBefore() {
     CD4CodeMill.reset();
     CD4CodeMill.init();

--- a/cdmerge/src/test/java/de/monticore/cdmerge/CDMergeTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/CDMergeTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge;
 
-import static org.junit.Assert.fail;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.config.MergeParameter;
@@ -12,8 +10,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDMergeTest extends BaseTest {
   @Test
@@ -31,7 +30,7 @@ public class CDMergeTest extends BaseTest {
 
     ASTCDCompilationUnit mergedCD = CDMerge.merge(inputSet, "ABC", new HashSet<>());
 
-    Assert.assertNotNull(mergedCD);
+    assertNotNull(mergedCD);
     System.out.println(CD4CodeMill.prettyPrint(mergedCD, true));
   }
 
@@ -53,7 +52,7 @@ public class CDMergeTest extends BaseTest {
 
     ASTCDCompilationUnit mergedCD = CDMerge.merge(inputSet, "UniversitySystem", params);
 
-    Assert.assertNotNull(mergedCD);
+    assertNotNull(mergedCD);
     System.out.println(CD4CodeMill.prettyPrint(mergedCD, true));
   }
 
@@ -77,9 +76,9 @@ public class CDMergeTest extends BaseTest {
 
     ASTCDCompilationUnit mergedCD = CDMerge.merge(inputSet, "MergeDriveAndEmployment", params);
 
-    Assert.assertNotNull(mergedCD);
+    assertNotNull(mergedCD);
     System.out.println(CD4CodeMill.prettyPrint(mergedCD, true));
-    Assert.assertTrue(mergedCD.deepEquals(expected, false));
+    assertTrue(mergedCD.deepEquals(expected, false));
   }
 
   @Test
@@ -111,7 +110,7 @@ public class CDMergeTest extends BaseTest {
 
       ASTCDCompilationUnit mergedCD = CDMerge.merge(permutation, "CarRental", params);
 
-      Assert.assertNotNull(mergedCD);
+      assertNotNull(mergedCD);
     }
   }
 
@@ -164,13 +163,13 @@ public class CDMergeTest extends BaseTest {
 
     ASTCDCompilationUnit mergedCD = CDMerge.merge(inputSet, "CarRental", params);
 
-    Assert.assertNotNull(mergedCD);
+    assertNotNull(mergedCD);
   }
 
   @Test
   public void testParseMrgConfig() {
     final String file = "src/test/resources/json/mrg-config.json";
-    Assert.assertTrue(
+    assertTrue(
         CDMerge.parseMrgConfig(file)
             .containsAll(
                 Set.of(

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AmbiguousMatchTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AmbiguousMatchTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AmbiguousMatchTest extends BaseTest {
   private static final String INPUT_MODEL_1 =

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationAmbiguousRole.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationAmbiguousRole.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociationAmbiguousRole extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCardinalities.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCardinalities.java
@@ -1,7 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -16,18 +17,17 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociationCardinalities extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/cardinalities/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Association/cardinalities/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/cardinalities/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Association/cardinalities/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Association" + "/cardinalities/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/cardinalities/mergedCD.cd";
 
   @Test
   public void testAssociationCardinalities() throws IOException {
@@ -39,7 +39,7 @@ public class AssociationCardinalities extends BaseTest {
     try {
       MergeResult results = cdMerger.mergeCDs();
       processResult(results);
-      org.junit.Assert.assertTrue(
+      assertTrue(
           parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
               .deepEquals(expectedCD, false));
     } catch (MergingException e) {

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionAssociation.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionAssociation.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssociationCompositionAssociation extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/compositionAssociation/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Association/compositionAssociation/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/compositionAssociation/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Association/compositionAssociation/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Association" + "/compositionAssociation/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/compositionAssociation/mergedCD.cd";
 
   @Test
   public void testAssociationCompositionAssociation() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class AssociationCompositionAssociation extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionDesignissue.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionDesignissue.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociationCompositionDesignissue extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationDerived.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationDerived.java
@@ -13,18 +13,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssociationDerived extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/testDerived/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Association/testDerived/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/testDerived/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Association/testDerived/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Association" + "/testDerived/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/testDerived/mergedCD.cd";
 
   @Test
   public void testAssociationDerived() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class AssociationDerived extends BaseTest {
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
 
-    org.junit.Assert.assertTrue(results.getMergedCD().get().deepEquals(expectedCD, false));
+    assertTrue(results.getMergedCD().get().deepEquals(expectedCD, false));
   }
 
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNavigations.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNavigations.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssociationNavigations extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/navigations/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Association/navigations/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/navigations/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Association/navigations/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Association" + "/navigations/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/navigations/mergedCD.cd";
 
   @Test
   public void testAssociationNavigations() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class AssociationNavigations extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNoMatch.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNoMatch.java
@@ -1,7 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -16,18 +17,17 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociationNoMatch extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/noMatch/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Association/noMatch/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/noMatch/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Association/noMatch/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Association" + "/noMatch/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/noMatch/mergedCD.cd";
 
   @Test
   public void testAssociationNoMatch() throws IOException, MergingException {
@@ -38,7 +38,7 @@ public class AssociationNoMatch extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     try {
       MergeResult result = cdMerger.mergeCDs();
-      org.junit.Assert.assertTrue(result.getMergedCD().get().deepEquals(expectedCD, false));
+      assertTrue(result.getMergedCD().get().deepEquals(expectedCD, false));
       if (result.getMaxErrorLevel().ordinal() < ErrorLevel.WARNING.ordinal()) {
         fail("Warnings expected due to ambiguous association roles");
       }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierConflict.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociationQualifierConflict extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierOK.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierOK.java
@@ -14,7 +14,9 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssociationQualifierOK extends BaseTest {
 
@@ -36,7 +38,7 @@ public class AssociationQualifierOK extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesAttributeConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesAttributeConflict.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociationRolesAttributeConflict extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesConflict.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociationRolesConflict extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesSimple.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesSimple.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssociationRolesSimple extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/rolesSimple/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Association/rolesSimple/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/rolesSimple/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Association/rolesSimple/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Association" + "/rolesSimple/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/rolesSimple/mergedCD.cd";
 
   @Test
   public void testAssociationRolesSimple() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class AssociationRolesSimple extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesWithAssocName.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesWithAssocName.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssociationRolesWithAssocName extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/rolesWithAssocName/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Association/rolesWithAssocName/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/rolesWithAssocName/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Association/rolesWithAssocName/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Association" + "/rolesWithAssocName/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/rolesWithAssocName/mergedCD.cd";
 
   @Test
   public void testAssociationRolesWithAssocName() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class AssociationRolesWithAssocName extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociativityTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociativityTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociativityTest extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeConflictDifferentTypes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeConflictDifferentTypes.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AttributeConflictDifferentTypes extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDifferentAttributes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDifferentAttributes.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AttributeDifferentAttributes extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Attribute";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/differentAttributes/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/Attribute" + "/differentAttributes/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/differentAttributes/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/Attribute" + "/differentAttributes/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Attribute" + "/differentAttributes/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/differentAttributes/mergedCD.cd";
 
   @Test
   public void testAttributeDifferentAttributes() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class AttributeDifferentAttributes extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDuplicateAttributes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDuplicateAttributes.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AttributeDuplicateAttributes extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Attribute";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/duplicateAttributes/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/Attribute" + "/duplicateAttributes/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/duplicateAttributes/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/Attribute" + "/duplicateAttributes/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Attribute" + "/duplicateAttributes/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/duplicateAttributes/mergedCD.cd";
 
   @Test
   public void testAttributeDuplicateAttributes() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class AttributeDuplicateAttributes extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralAllFlavours.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralAllFlavours.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GeneralAllFlavours extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/allFlavours/CDA.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/General" + "/allFlavours/CDA.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/allFlavours/CDB.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/General" + "/allFlavours/CDB.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/General" + "/allFlavours/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/allFlavours/mergedCD.cd";
 
   @Test
   public void testAllFlavours() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class GeneralAllFlavours extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralFourClassDiagrams.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralFourClassDiagrams.java
@@ -1,7 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -17,24 +18,21 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeneralFourClassDiagrams extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/four_classdiagrams/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/General" + "/four_classdiagrams/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/four_classdiagrams/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/General" + "/four_classdiagrams/B.cd";
+  private static final String INPUT_MODEL_3 = INPUT_MODEL_DIR + "/four_classdiagrams/C.cd";
 
-  private static final String INPUT_MODEL_3 =
-      "src/test/resources/class_diagrams/General" + "/four_classdiagrams/C.cd";
+  private static final String INPUT_MODEL_4 = INPUT_MODEL_DIR + "/four_classdiagrams/D.cd";
 
-  private static final String INPUT_MODEL_4 =
-      "src/test/resources/class_diagrams/General" + "/four_classdiagrams/D.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/General" + "/four_classdiagrams/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/four_classdiagrams/mergedCD.cd";
 
   @Test
   public void testFourCDs() throws IOException, MergingException {
@@ -48,7 +46,7 @@ public class GeneralFourClassDiagrams extends BaseTest {
     try {
       MergeResult results = cdMerger.mergeCDs();
       processResult(results);
-      org.junit.Assert.assertTrue(
+      assertTrue(
           parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
               .deepEquals(expectedCD, false));
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralOffice.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralOffice.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GeneralOffice extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/office/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/General" + "/office/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/office/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/General" + "/office/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/General/office" + "/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/office/mergedCD.cd";
 
   @Test
   public void testOffice() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class GeneralOffice extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult result = cdMerger.mergeCDs();
     processResult(result);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(result.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictCyclicInheritance.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictCyclicInheritance.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InheritanceConflictCyclicInheritance extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictSuperclasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictSuperclasses.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InheritanceConflictSuperclasses extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDisjointInterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDisjointInterfaces.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InheritanceDisjointInterfaces extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/disjointInterfaces/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/disjointInterfaces/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/disjointInterfaces/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/disjointInterfaces/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance" + "/disjointInterfaces/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/disjointInterfaces/mergedCD.cd";
 
   @Test
   public void testInheritanceDisjointInterfaces() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class InheritanceDisjointInterfaces extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDuplicateSuperinterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDuplicateSuperinterfaces.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InheritanceDuplicateSuperinterfaces extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/duplicateSuperinterfaces/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/duplicateSuperinterfaces/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance" + "/duplicateSuperinterfaces/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/mergedCD.cd";
 
   @Test
   public void testInheritanceDuplicateSuperinterfaces() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class InheritanceDuplicateSuperinterfaces extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup1.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup1.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InheritanceInheritanceAttributePullup1 extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup1/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/inheritanceAttributePullup1/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup1/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/inheritanceAttributePullup1/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance" + "/inheritanceAttributePullup1/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/inheritanceAttributePullup1/mergedCD.cd";
 
   @Test
   public void testInheritanceInheritanceAttributePullup1() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class InheritanceInheritanceAttributePullup1 extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup2.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup2.java
@@ -1,7 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -16,18 +17,17 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InheritanceInheritanceAttributePullup2 extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup2/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/inheritanceAttributePullup2/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup2/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/inheritanceAttributePullup2/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance" + "/inheritanceAttributePullup2/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/inheritanceAttributePullup2/mergedCD.cd";
 
   @Test
   public void testInheritanceInheritanceAttributePullup2() throws IOException {
@@ -45,7 +45,7 @@ public class InheritanceInheritanceAttributePullup2 extends BaseTest {
       fail("Unexpected Exception " + e.getMessage());
     }
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup3.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup3.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InheritanceInheritanceAttributePullup3 extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup3/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/inheritanceAttributePullup3/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup3/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/inheritanceAttributePullup3/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance" + "/inheritanceAttributePullup3/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/inheritanceAttributePullup3/mergedCD.cd";
 
   @Test
   public void testInheritanceInheritanceAttributePullup3() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class InheritanceInheritanceAttributePullup3 extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces1.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces1.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InheritanceRedundantSuperinterfaces1 extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/redundantSuperinterfaces1/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/redundantSuperinterfaces1/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance" + "/redundantSuperinterfaces1/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/mergedCD.cd";
 
   @Test
   public void testInheritanceRedundantSuperinterfaces1() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class InheritanceRedundantSuperinterfaces1 extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces2.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces2.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InheritanceRedundantSuperinterfaces2 extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/redundantSuperinterfaces2/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/redundantSuperinterfaces2/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance" + "/redundantSuperinterfaces2/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/mergedCD.cd";
 
   @Test
   public void testInheritanceRedundantSuperinterfaces2() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class InheritanceRedundantSuperinterfaces2 extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceClasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceClasses.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InheritanceTransitiveInheritanceClasses extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/transitiveInheritanceClasses/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/transitiveInheritanceClasses/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/transitiveInheritanceClasses/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/transitiveInheritanceClasses/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance" + "/transitiveInheritanceClasses/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/transitiveInheritanceClasses/mergedCD.cd";
 
   @Test
   public void testInheritanceTransitiveInheritanceClasses() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class InheritanceTransitiveInheritanceClasses extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceInterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceInterfaces.java
@@ -14,19 +14,22 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InheritanceTransitiveInheritanceInterfaces extends BaseTest {
-
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
+  
   private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams" + "/Inheritance/transitiveInheritanceInterfaces/A.cd";
+      INPUT_MODEL_DIR + "/transitiveInheritanceInterfaces/A.cd";
 
   private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams" + "/Inheritance/transitiveInheritanceInterfaces/B.cd";
+      INPUT_MODEL_DIR + "/transitiveInheritanceInterfaces/B.cd";
 
   private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Inheritance"
-          + "/transitiveInheritanceInterfaces/mergedCD.cd";
+      INPUT_MODEL_DIR + "/transitiveInheritanceInterfaces/mergedCD.cd";
 
   @Test
   public void testInheritanceTransitiveInheritanceInterfaces()
@@ -38,7 +41,7 @@ public class InheritanceTransitiveInheritanceInterfaces extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/StereotypeMergeTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/StereotypeMergeTest.java
@@ -15,26 +15,26 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StereotypeMergeTest extends BaseTest {
 
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams";
+  
   // A stereo
-  private static final String INPUT_MODEL_A =
-      "src/test/resources/class_diagrams" + "/Stereotypes/CD1.cd";
+  private static final String INPUT_MODEL_A = INPUT_MODEL_DIR + "/Stereotypes/CD1.cd";
 
   // B stereo
-  private static final String INPUT_MODEL_B =
-      "src/test/resources/class_diagrams" + "/Stereotypes/CD2.cd";
+  private static final String INPUT_MODEL_B = INPUT_MODEL_DIR + "/Stereotypes/CD2.cd";
 
   // No stereos
-  private static final String INPUT_MODEL_NO =
-      "src/test/resources/class_diagrams" + "/Stereotypes/CD3.cd";
+  private static final String INPUT_MODEL_NO = INPUT_MODEL_DIR + "/Stereotypes/CD3.cd";
 
   // multiple stereos
-  private static final String INPUT_MODEL_MULT =
-      "src/test/resources/class_diagrams" + "/Stereotypes/CD4.cd";
+  private static final String INPUT_MODEL_MULT = INPUT_MODEL_DIR + "/Stereotypes/CD4.cd";
 
   @Test
   public void testMergeWithOneSide() throws IOException, MergingException {
@@ -46,24 +46,22 @@ public class StereotypeMergeTest extends BaseTest {
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
 
-    Assert.assertTrue(results.mergeSuccess());
-    Assert.assertTrue(results.getMergedCD().isPresent());
+    assertTrue(results.mergeSuccess());
+    assertTrue(results.getMergedCD().isPresent());
 
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
-    Assert.assertTrue("CDDefinition stereo missing", def.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "CDDefinition stereo incorrect", def.getModifier().getStereotype().contains("A1"));
+    assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
+    assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
     ASTCDClass cl = def.getCDClassesList().get(0);
-    Assert.assertTrue("Class stereo missing", cl.getModifier().isPresentStereotype());
-    Assert.assertTrue("Class stereo incorrect", cl.getModifier().getStereotype().contains("A2"));
+    assertTrue(cl.getModifier().isPresentStereotype(), "Class stereo missing");
+    assertTrue(cl.getModifier().getStereotype().contains("A2"), "Class stereo incorrect");
     ASTCDAttribute attr_a =
         cl.getCDAttributeList().stream().filter(a -> a.getName().equals("cd1")).findAny().get();
     ASTCDAttribute attr_no =
         cl.getCDAttributeList().stream().filter(a -> a.getName().equals("cd3")).findAny().get();
-    Assert.assertTrue("Attribute stereo missing", attr_a.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "Attribute stereo incorrect", attr_a.getModifier().getStereotype().contains("A3"));
-    Assert.assertFalse("Attribute stereo not missing", attr_no.getModifier().isPresentStereotype());
+    assertTrue(attr_a.getModifier().isPresentStereotype(), "Attribute stereo missing");
+    assertTrue(attr_a.getModifier().getStereotype().contains("A3"), "Attribute stereo incorrect");
+    assertFalse(attr_no.getModifier().isPresentStereotype(), "Attribute stereo not missing");
   }
 
   @Test
@@ -76,24 +74,22 @@ public class StereotypeMergeTest extends BaseTest {
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
 
-    Assert.assertTrue(results.mergeSuccess());
-    Assert.assertTrue(results.getMergedCD().isPresent());
+    assertTrue(results.mergeSuccess());
+    assertTrue(results.getMergedCD().isPresent());
 
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
-    Assert.assertTrue("CDDefinition stereo missing", def.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "CDDefinition stereo incorrect", def.getModifier().getStereotype().contains("A1"));
+    assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
+    assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
     ASTCDClass cl = def.getCDClassesList().get(0);
-    Assert.assertTrue("Class stereo missing", cl.getModifier().isPresentStereotype());
-    Assert.assertTrue("Class stereo incorrect", cl.getModifier().getStereotype().contains("A2"));
+    assertTrue(cl.getModifier().isPresentStereotype(), "Class stereo missing");
+    assertTrue(cl.getModifier().getStereotype().contains("A2"), "Class stereo incorrect");
     ASTCDAttribute attr_a =
         cl.getCDAttributeList().stream().filter(a -> a.getName().equals("cd1")).findAny().get();
     ASTCDAttribute attr_no =
         cl.getCDAttributeList().stream().filter(a -> a.getName().equals("cd3")).findAny().get();
-    Assert.assertTrue("Attribute stereo missing", attr_a.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "Attribute stereo incorrect", attr_a.getModifier().getStereotype().contains("A3"));
-    Assert.assertFalse("Attribute stereo not missing", attr_no.getModifier().isPresentStereotype());
+    assertTrue(attr_a.getModifier().isPresentStereotype(), "Attribute stereo missing");
+    assertTrue(attr_a.getModifier().getStereotype().contains("A3"), "Attribute stereo incorrect");
+    assertFalse(attr_no.getModifier().isPresentStereotype(), "Attribute stereo not missing");
   }
 
   @Test
@@ -106,32 +102,27 @@ public class StereotypeMergeTest extends BaseTest {
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
 
-    Assert.assertTrue(results.mergeSuccess());
-    Assert.assertTrue(results.getMergedCD().isPresent());
+    assertTrue(results.mergeSuccess());
+    assertTrue(results.getMergedCD().isPresent());
 
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
-    Assert.assertTrue("CDDefinition stereo missing", def.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "CDDefinition stereo incorrect", def.getModifier().getStereotype().contains("A1"));
-    Assert.assertTrue(
-        "CDDefinition stereo incorrect", def.getModifier().getStereotype().contains("B1"));
+    assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
+    assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
+    assertTrue(def.getModifier().getStereotype().contains("B1"), "CDDefinition stereo incorrect");
     ASTCDClass cl = def.getCDClassesList().get(0);
-    Assert.assertTrue("Class stereo missing", cl.getModifier().isPresentStereotype());
-    Assert.assertTrue("Class stereo incorrect", cl.getModifier().getStereotype().contains("A2"));
-    Assert.assertTrue("Class stereo incorrect", cl.getModifier().getStereotype().contains("B2"));
-    Assert.assertTrue(
-        "Attribute stereo missing",
-        ((ASTCDAttribute) cl.getCDMember(0)).getModifier().isPresentStereotype());
+    assertTrue(cl.getModifier().isPresentStereotype(), "Class stereo missing");
+    assertTrue(cl.getModifier().getStereotype().contains("A2"), "Class stereo incorrect");
+    assertTrue(cl.getModifier().getStereotype().contains("B2"), "Class stereo incorrect");
+    assertTrue(((ASTCDAttribute) cl.getCDMember(0)).getModifier().isPresentStereotype(),
+        "Attribute stereo missing");
     ASTCDAttribute attr_a =
         cl.getCDAttributeList().stream().filter(a -> a.getName().equals("cd1")).findAny().get();
     ASTCDAttribute attr_b =
         cl.getCDAttributeList().stream().filter(a -> a.getName().equals("cd2")).findAny().get();
-    Assert.assertTrue("Attribute stereo missing", attr_a.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "Attribute stereo incorrect", attr_a.getModifier().getStereotype().contains("A3"));
-    Assert.assertTrue("Attribute stereo missing", attr_b.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "Attribute stereo incorrect", attr_b.getModifier().getStereotype().contains("B3"));
+    assertTrue(attr_a.getModifier().isPresentStereotype(), "Attribute stereo missing");
+    assertTrue(attr_a.getModifier().getStereotype().contains("A3"), "Attribute stereo incorrect");
+    assertTrue(attr_b.getModifier().isPresentStereotype(), "Attribute stereo missing");
+    assertTrue(attr_b.getModifier().getStereotype().contains("B3"), "Attribute stereo incorrect");
   }
 
   @Test
@@ -144,34 +135,30 @@ public class StereotypeMergeTest extends BaseTest {
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
 
-    Assert.assertTrue(results.mergeSuccess());
-    Assert.assertTrue(results.getMergedCD().isPresent());
+    assertTrue(results.mergeSuccess());
+    assertTrue(results.getMergedCD().isPresent());
 
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
-    Assert.assertTrue("CDDefinition stereo missing", def.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "CDDefinition stereo incorrect", def.getModifier().getStereotype().contains("A1"));
-    Assert.assertTrue(
-        "CDDefinition stereo incorrect", def.getModifier().getStereotype().contains("D1"));
-    Assert.assertTrue(
-        "CDDefinition stereo incorrect", def.getModifier().getStereotype().contains("DD1"));
+    assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
+    assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
+    assertTrue(def.getModifier().getStereotype().contains("D1"), "CDDefinition stereo incorrect");
+    assertTrue(def.getModifier().getStereotype().contains("DD1"), "CDDefinition stereo incorrect");
     ASTCDClass cl = def.getCDClassesList().get(0);
-    Assert.assertTrue("Class stereo missing", cl.getModifier().isPresentStereotype());
-    Assert.assertTrue("Class stereo incorrect", cl.getModifier().getStereotype().contains("A2"));
-    Assert.assertTrue("Class stereo incorrect", cl.getModifier().getStereotype().contains("D2"));
-    Assert.assertTrue("Class stereo incorrect", cl.getModifier().getStereotype().contains("DD2"));
+    assertTrue(cl.getModifier().isPresentStereotype(), "Class stereo missing");
+    assertTrue(cl.getModifier().getStereotype().contains("A2"), "Class stereo incorrect");
+    assertTrue(cl.getModifier().getStereotype().contains("D2"), "Class stereo incorrect");
+    assertTrue(cl.getModifier().getStereotype().contains("DD2"), "Class stereo incorrect");
     ASTCDAttribute attr_a =
         cl.getCDAttributeList().stream().filter(a -> a.getName().equals("cd1")).findAny().get();
     ASTCDAttribute attr_mult =
         cl.getCDAttributeList().stream().filter(a -> a.getName().equals("cd4")).findAny().get();
-    Assert.assertTrue("Attribute stereo missing", attr_a.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "Attribute stereo incorrect", attr_a.getModifier().getStereotype().contains("A3"));
-    Assert.assertTrue("Attribute stereo missing", attr_mult.getModifier().isPresentStereotype());
-    Assert.assertTrue(
-        "Attribute stereo incorrect", attr_mult.getModifier().getStereotype().contains("D3"));
-    Assert.assertTrue(
-        "Attribute stereo incorrect", attr_mult.getModifier().getStereotype().contains("DD3"));
+    assertTrue(attr_a.getModifier().isPresentStereotype(), "Attribute stereo missing");
+    assertTrue(attr_a.getModifier().getStereotype().contains("A3"), "Attribute stereo incorrect");
+    assertTrue(attr_mult.getModifier().isPresentStereotype(), "Attribute stereo missing");
+    assertTrue(
+        attr_mult.getModifier().getStereotype().contains("D3"), "Attribute stereo incorrect");
+    assertTrue(
+        attr_mult.getModifier().getStereotype().contains("DD3"), "Attribute stereo incorrect");
   }
 
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesAbstractClasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesAbstractClasses.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypesAbstractClasses extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/abstractClasses/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/Types" + "/abstractClasses/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/abstractClasses/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/Types" + "/abstractClasses/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Types" + "/abstractClasses/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/abstractClasses/mergedCD.cd";
 
   @Test
   public void testTypesAbstractClasses() throws IOException, MergingException {
@@ -37,7 +38,7 @@ public class TypesAbstractClasses extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassEnum.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypesHeterogeneousClassEnum extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousClassEnum/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousClassEnum/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousClassEnum/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousClassEnum/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousClassEnum/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/heterogeneousClassEnum/mergedCD.cd";
 
   @Test
   public void testTypesHeterogeneousClassEnum() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class TypesHeterogeneousClassEnum extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassInterface.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassInterface.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypesHeterogeneousClassInterface extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousClassInterface/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousClassInterface/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousClassInterface/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousClassInterface/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousClassInterface/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/heterogeneousClassInterface/mergedCD.cd";
 
   @Test
   public void testTypesHeterogeneousClassInterface() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class TypesHeterogeneousClassInterface extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousInterfaceEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousInterfaceEnum.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypesHeterogeneousInterfaceEnum extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousInterfaceEnum/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousInterfaceEnum/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousInterfaceEnum/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousInterfaceEnum/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Types" + "/heterogeneousInterfaceEnum/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/heterogeneousInterfaceEnum/mergedCD.cd";
 
   @Test
   public void testTypesHeterogeneousInterfaceEnum() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class TypesHeterogeneousInterfaceEnum extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesMergeEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesMergeEnum.java
@@ -14,18 +14,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypesMergeEnum extends BaseTest {
+  
+  private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
+  
+  private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/mergeEnum/A.cd";
 
-  private static final String INPUT_MODEL_1 =
-      "src/test/resources/class_diagrams/Types" + "/mergeEnum/A.cd";
+  private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/mergeEnum/B.cd";
 
-  private static final String INPUT_MODEL_2 =
-      "src/test/resources/class_diagrams/Types" + "/mergeEnum/B.cd";
-
-  private static final String EXPECTED =
-      "src/test/resources/class_diagrams/Types" + "/mergeEnum/mergedCD.cd";
+  private static final String EXPECTED = INPUT_MODEL_DIR + "/mergeEnum/mergedCD.cd";
 
   @Test
   public void testTypesMergeEnum() throws IOException, MergingException {
@@ -36,7 +37,7 @@ public class TypesMergeEnum extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    org.junit.Assert.assertTrue(
+    assertTrue(
         parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get()))
             .deepEquals(expectedCD, false));
   }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesNameConflictNonHeteorogenous.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesNameConflictNonHeteorogenous.java
@@ -1,9 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import com.google.common.base.Preconditions;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -16,7 +13,10 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TypesNameConflictNonHeteorogenous extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/matching/matchresult/MatchNodeTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/matching/matchresult/MatchNodeTest.java
@@ -2,7 +2,7 @@
 package de.monticore.cdmerge.matching.matchresult;
 
 import de.monticore.cdmerge.BaseTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit tests for the functionality of the MergeNode Class. */
 public class MatchNodeTest extends BaseTest {

--- a/cdmerge/src/test/java/de/monticore/cdmerge/matching/strategies/DefaulCDMatcherTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/matching/strategies/DefaulCDMatcherTest.java
@@ -1,8 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.matching.strategies;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdbasis._ast.*;
@@ -18,8 +17,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DefaulCDMatcherTest extends BaseTest {
 
@@ -37,7 +36,7 @@ public class DefaulCDMatcherTest extends BaseTest {
 
   private List<ASTCDDefinition> inputCds;
 
-  @Before
+  @BeforeEach
   public void initTest() throws IOException {
     CDMergeConfig.Builder b = new CDMergeConfig.Builder(false);
     b.withParam(MergeParameter.MODEL_PATH, MODEL_PATH)
@@ -66,19 +65,19 @@ public class DefaulCDMatcherTest extends BaseTest {
     List<MatchNode<ASTCDType, ASTCDDefinition>> nodes;
     nodes = result.findNodes(t -> t.getElement().getName().equals("Person"));
     for (MatchNode<ASTCDType, ASTCDDefinition> node : nodes) {
-      assertTrue(node.getMatchedElements().size() == 1);
+      assertEquals(1, node.getMatchedElements().size());
     }
     nodes = result.findNodes(t -> t.getElement().getName().equals("Room"));
     for (MatchNode<ASTCDType, ASTCDDefinition> node : nodes) {
-      assertTrue(node.getMatchedElements().size() == 1);
+      assertEquals(1, node.getMatchedElements().size());
     }
     nodes = result.findNodes(t -> t.getElement().getName().equals("Student"));
     for (MatchNode<ASTCDType, ASTCDDefinition> node : nodes) {
-      assertTrue(node.getMatchedElements().size() == 0);
+      assertEquals(0, node.getMatchedElements().size());
     }
     nodes = result.findNodes(t -> t.getElement().getName().equals("CourseOfStudy"));
     for (MatchNode<ASTCDType, ASTCDDefinition> node : nodes) {
-      assertTrue(node.getMatchedElements().size() == 0);
+      assertEquals(0, node.getMatchedElements().size());
     }
   }
 
@@ -89,8 +88,8 @@ public class DefaulCDMatcherTest extends BaseTest {
     List<MatchNode<ASTCDAttribute, ASTCDClass>> nodes;
     nodes = result.findNodes(t -> t.getElement().getName().equals("emplNumber"));
     for (MatchNode<ASTCDAttribute, ASTCDClass> node : nodes) {
-      assertTrue(node.getMatchedElements().size() == 1);
-      assertTrue(node.getParent().getName().equals("Employee"));
+      assertEquals(1, node.getMatchedElements().size());
+      assertEquals("Employee", node.getParent().getName());
     }
   }
 
@@ -102,19 +101,19 @@ public class DefaulCDMatcherTest extends BaseTest {
 
     nodes =
         result.findNodes(t -> t.getElement().getRightQualifiedName().getBaseName().equals("Room"));
-    assertEquals("Find asscociations with right reference 'Room'", 5, nodes.size());
+    assertEquals(5, nodes.size(), "Find asscociations with right reference 'Room'");
 
     nodes =
         result.findNodes(t -> t.getElement().getLeftQualifiedName().getBaseName().equals("Room"));
-    assertEquals("Find asscociations with left reference 'Room'", 1, nodes.size());
+    assertEquals(1, nodes.size(), "Find asscociations with left reference 'Room'");
     assertEquals(
-        "Find asscociations with left reference 'Room'",
         1,
-        nodes.get(0).getMatchedElements().size());
+        nodes.get(0).getMatchedElements().size(),
+        "Find asscociations with left reference 'Room'");
 
     nodes =
         result.findNodes(t -> t.getElement().getLeftQualifiedName().toString().equals("Person"));
-    assertEquals("Find asscociations with left reference 'Person'", 2, nodes.size());
+    assertEquals(2, nodes.size(), "Find asscociations with left reference 'Person'");
 
     // FIXME Fails in Maven
     // assertEquals("Find asscociations with left reference 'Person'", 1,
@@ -123,19 +122,19 @@ public class DefaulCDMatcherTest extends BaseTest {
     nodes =
         result.findNodes(
             t -> t.getElement().getRightQualifiedName().getBaseName().equals("Person"));
-    assertEquals("Find asscociations with right reference 'Person'", 1, nodes.size());
+    assertEquals(1, nodes.size(), "Find asscociations with right reference 'Person'");
     assertEquals(
-        "Find asscociations with right reference 'Person'",
         1,
-        nodes.get(0).getMatchedElements().size());
-
+        nodes.get(0).getMatchedElements().size(),
+        "Find asscociations with right reference 'Person'");
+    
     nodes =
         result.findNodes(
             t -> t.getElement().getLeftQualifiedName().getBaseName().equals("Department"));
-    assertEquals("Find asscociations with left reference 'Department'", 2, nodes.size());
+    assertEquals(2, nodes.size(), "Find asscociations with left reference 'Department'");
     assertEquals(
-        "Find asscociations with left reference 'Department'",
         0,
-        nodes.get(0).getMatchedElements().size());
+        nodes.get(0).getMatchedElements().size(),
+        "Find asscociations with left reference 'Department'");
   }
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/matching/strategies/DefaultAssociationMatcherTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/matching/strategies/DefaultAssociationMatcherTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.matching.strategies;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.ImmutableList;
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -18,7 +16,9 @@ import de.monticore.cdmerge.merging.mergeresult.MergeBlackBoard;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /** A Unit Test for the default association matcher */
 public class DefaultAssociationMatcherTest extends BaseTest {
@@ -52,7 +52,7 @@ public class DefaultAssociationMatcherTest extends BaseTest {
     if (named) {
       assertTrue(association1.isPresentName());
       assertTrue(association2.isPresentName());
-      assertTrue(association1.getName().equals(association2.getName()));
+      assertEquals(association1.getName(), association2.getName());
     }
   }
 
@@ -100,7 +100,7 @@ public class DefaultAssociationMatcherTest extends BaseTest {
         for (Match<ASTCDAssociation, ASTCDDefinition> match : matchNode.getMatches()) {
 
           // The associations should lie in different class diagrams
-          assertFalse(match.getNode1().getParent().equals(match.getNode2().getParent()));
+          assertNotEquals(match.getNode1().getParent(), match.getNode2().getParent());
 
           // Check if the associations match
           ASTCDAssociation association1 = match.getNode1().getElement();
@@ -109,7 +109,7 @@ public class DefaultAssociationMatcherTest extends BaseTest {
         }
       }
       // Check if the size is set correctly
-      assertTrue(associations.size() == astcdDefinition.getCDAssociationsList().size());
+      assertEquals(associations.size(), astcdDefinition.getCDAssociationsList().size());
     }
   }
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/strategies/EnumConstantsMergeTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/strategies/EnumConstantsMergeTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.strategies;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdinterfaceandenum._ast.ASTCDEnum;
 import de.monticore.cdinterfaceandenum._ast.ASTCDEnumConstant;
@@ -15,9 +13,12 @@ import de.monticore.cdmerge.merging.strategies.DefaultAtributeMerger;
 import de.monticore.cdmerge.merging.strategies.DefaultTypeMergeStrategy;
 import de.monticore.umlmodifier._ast.ASTModifier;
 import de.monticore.umlmodifier._ast.ASTModifierBuilder;
+import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class EnumConstantsMergeTest extends BaseTest {
 
@@ -34,8 +35,7 @@ public class EnumConstantsMergeTest extends BaseTest {
         .withParam(MergeParameter.SAVE_RESULT_TO_FILE, MergeParameter.OFF)
         .withParam(MergeParameter.CHECK_ONLY)
         .withParam(MergeParameter.LOG_DEBUG, MergeParameter.ON);
-    ;
-
+    
     MergeBlackBoard blackBoard = new MergeBlackBoard(b.build());
     this.TESTANT = new DefaultTypeMergeStrategy(blackBoard, new DefaultAtributeMerger(blackBoard));
   }
@@ -695,7 +695,7 @@ public class EnumConstantsMergeTest extends BaseTest {
   public void testMergeEnumsConflictParameter() {}
 
   private void checkOrder(List<ASTCDEnumConstant> expected, List<ASTCDEnumConstant> testresult) {
-    assertTrue(expected.size() == testresult.size());
+    assertEquals(expected.size(), testresult.size());
     for (int i = 0; i < testresult.size(); i++) {
       assertTrue(expected.get(i).getName().equalsIgnoreCase(testresult.get(i).getName()));
     }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/util/ASTCDElementCollectorTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/util/ASTCDElementCollectorTest.java
@@ -1,14 +1,14 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import java.io.IOException;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ASTCDElementCollectorTest extends BaseTest {
 

--- a/cdmerge/src/test/java/de/monticore/cdmerge/util/ASTCDHelperTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/util/ASTCDHelperTest.java
@@ -1,15 +1,14 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import java.io.IOException;
 import java.nio.file.Paths;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ASTCDHelperTest extends BaseTest {
 
@@ -17,7 +16,7 @@ public class ASTCDHelperTest extends BaseTest {
 
   public ASTCDHelper testant;
 
-  @Before
+  @BeforeEach
   public void initHelper() throws IOException {
     ASTCDCompilationUnit cd = loadModel(Paths.get(MODEL_PATH, INPUT_MODEL_FILE).toString());
     this.testant = new ASTCDHelper(cd);
@@ -34,33 +33,33 @@ public class ASTCDHelperTest extends BaseTest {
   @Test
   public void testGetInterface() {
     assertTrue(testant.getInterface("Human").isPresent());
-    assertTrue(!testant.getInterface("noInterface").isPresent());
+    assertFalse(testant.getInterface("noInterface").isPresent());
   }
 
   @Test
   public void testGetClass() {
     assertTrue(testant.getClass("Employee").isPresent());
     assertTrue(testant.getClass("Room").isPresent());
-    assertTrue(!testant.getClass("noclass").isPresent());
+    assertFalse(testant.getClass("noclass").isPresent());
   }
 
   @Test
   public void testGetEnum() {
     assertTrue(testant.getEnum("StaffFunction").isPresent());
-    assertTrue(!testant.getClass("noenum").isPresent());
+    assertFalse(testant.getClass("noenum").isPresent());
   }
 
   @Test
   public void testGetAttributesForClass() {
     assertTrue(testant.getAttributeFromClass("emplNumber", "Employee").isPresent());
     assertTrue(testant.getAttributeFromClass("email", "Employee").isPresent());
-    assertTrue(!testant.getAttributeFromClass("noAttribute", "Employee").isPresent());
+    assertFalse(testant.getAttributeFromClass("noAttribute", "Employee").isPresent());
   }
 
   @Test
   public void testGetNamedAssociation() {
     assertTrue(testant.getNamedAssociations("employment").isPresent());
-    assertTrue(!testant.getNamedAssociations("novalidassocname").isPresent());
+    assertFalse(testant.getNamedAssociations("novalidassocname").isPresent());
   }
 
   @Test

--- a/cdmerge/src/test/java/de/monticore/cdmerge/util/JPrimitiveTypeTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/util/JPrimitiveTypeTest.java
@@ -1,33 +1,33 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdmerge.util;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cdmerge.BaseTest;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /** TODO: Write me! */
 public class JPrimitiveTypeTest extends BaseTest {
 
   @Test
   public void testGetType() {
-    assertTrue(JPrimitiveType.getType("byte") == JPrimitiveType.BYTE);
-    assertTrue(JPrimitiveType.getType("short") == JPrimitiveType.SHORT);
-    assertTrue(JPrimitiveType.getType("int") == JPrimitiveType.INT);
-    assertTrue(JPrimitiveType.getType("long") == JPrimitiveType.LONG);
-    assertTrue(JPrimitiveType.getType("float") == JPrimitiveType.FLOAT);
-    assertTrue(JPrimitiveType.getType("double") == JPrimitiveType.DOUBLE);
-    assertTrue(JPrimitiveType.getType("boolean") == JPrimitiveType.BOOLEAN);
-    assertTrue(JPrimitiveType.getType("char") == JPrimitiveType.CHAR);
-    assertTrue(JPrimitiveType.getType("string") == JPrimitiveType.STRING);
+    assertSame(JPrimitiveType.BYTE, JPrimitiveType.getType("byte"));
+    assertSame(JPrimitiveType.SHORT, JPrimitiveType.getType("short"));
+    assertSame(JPrimitiveType.INT, JPrimitiveType.getType("int"));
+    assertSame(JPrimitiveType.LONG, JPrimitiveType.getType("long"));
+    assertSame(JPrimitiveType.FLOAT, JPrimitiveType.getType("float"));
+    assertSame(JPrimitiveType.DOUBLE, JPrimitiveType.getType("double"));
+    assertSame(JPrimitiveType.BOOLEAN, JPrimitiveType.getType("boolean"));
+    assertSame(JPrimitiveType.CHAR, JPrimitiveType.getType("char"));
+    assertSame(JPrimitiveType.STRING, JPrimitiveType.getType("string"));
 
     try {
       JPrimitiveType.getType("Date");
       fail("NoSuchElementException expected!");
     } catch (NoSuchElementException e) {
-      assertTrue(e.getMessage().equals("JPrimitiveType does not contain a type with name Date"));
+      assertEquals("JPrimitiveType does not contain a type with name Date", e.getMessage());
     }
   }
 
@@ -52,7 +52,7 @@ public class JPrimitiveTypeTest extends BaseTest {
     Optional<JPrimitiveType> type =
         JPrimitiveType.getCommonSuperType(JPrimitiveType.BOOLEAN, JPrimitiveType.BOOLEAN);
     assertTrue(type.isPresent());
-    assertTrue(type.get() == JPrimitiveType.BOOLEAN);
+    assertSame(JPrimitiveType.BOOLEAN, type.get());
 
     // One boolean
     type = JPrimitiveType.getCommonSuperType(JPrimitiveType.BOOLEAN, JPrimitiveType.CHAR);
@@ -61,16 +61,16 @@ public class JPrimitiveTypeTest extends BaseTest {
     // Chars and Strings
     type = JPrimitiveType.getCommonSuperType(JPrimitiveType.STRING, JPrimitiveType.CHAR);
     assertTrue(type.isPresent());
-    assertTrue(type.get() == JPrimitiveType.STRING);
+    assertSame(JPrimitiveType.STRING, type.get());
 
     // Float and double
     type = JPrimitiveType.getCommonSuperType(JPrimitiveType.FLOAT, JPrimitiveType.DOUBLE);
     assertTrue(type.isPresent());
-    assertTrue(type.get() == JPrimitiveType.DOUBLE);
+    assertSame(JPrimitiveType.DOUBLE, type.get());
 
     // String and double
     type = JPrimitiveType.getCommonSuperType(JPrimitiveType.STRING, JPrimitiveType.DOUBLE);
     assertTrue(type.isPresent());
-    assertTrue(type.get() == JPrimitiveType.STRING);
+    assertSame(JPrimitiveType.STRING, type.get());
   }
 }

--- a/cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
+++ b/cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
@@ -13,14 +13,14 @@ import javax.annotation.Nullable;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDGenGradlePluginTest {
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
   File testProjectDir;
   File settingsFile;
   File propertiesFile;
@@ -30,9 +30,8 @@ public class CDGenGradlePluginTest {
 
   File resourceMainDir;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
-    testProjectDir = temporaryFolder.newFolder();
     settingsFile = new File(testProjectDir, "settings.gradle");
     buildFile = new File(testProjectDir, "build.gradle");
     propertiesFile = new File(testProjectDir, "gradle.properties");
@@ -66,7 +65,7 @@ public class CDGenGradlePluginTest {
     String projVersion = loadProperties().getProperty("version");
     File cd4aJarFile = new File(libs, "cd4analysis-" + projVersion + ".jar");
 
-    Assert.assertTrue(libs.exists());
+    assertTrue(libs.exists());
     String buildFileContent =
         "plugins {"
             + "    id 'de.rwth.se.cdgen' "
@@ -106,8 +105,8 @@ public class CDGenGradlePluginTest {
             .withProjectDir(testProjectDir)
             .withArguments(withProperties("build", "--info", "--stacktrace"))
             .build();
-    Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateClassDiagrams").getOutcome());
-    Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":compileJava").getOutcome());
+    assertEquals(TaskOutcome.SUCCESS, result.task(":generateClassDiagrams").getOutcome());
+    assertEquals(TaskOutcome.SUCCESS, result.task(":compileJava").getOutcome());
   }
 
   @Test
@@ -139,7 +138,7 @@ public class CDGenGradlePluginTest {
     String projVersion = loadProperties().getProperty("version");
     File cd4aJarFile = new File(libs, "cd4analysis-" + projVersion + ".jar");
 
-    Assert.assertTrue(libs.exists());
+    assertTrue(libs.exists());
     String buildFileContent =
         "plugins {"
             + "    id 'de.rwth.se.cdgen' "
@@ -204,12 +203,12 @@ public class CDGenGradlePluginTest {
             .withProjectDir(testProjectDir)
             .withArguments(withProperties("build", "--info", "--stacktrace"))
             .build();
-    Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateClassDiagrams").getOutcome());
-    Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":compileJava").getOutcome());
+    assertEquals(TaskOutcome.SUCCESS, result.task(":generateClassDiagrams").getOutcome());
+    assertEquals(TaskOutcome.SUCCESS, result.task(":compileJava").getOutcome());
 
     if (!result.getOutput().contains("I am decorating")) {
       System.err.println(result.getOutput());
-      Assert.fail("Failed to find \"I am decorating\" in output");
+      fail("Failed to find \"I am decorating\" in output");
     }
   }
 

--- a/cdtool/src/test/java/de/monticore/CD4CodeToolGeneratorTest.java
+++ b/cdtool/src/test/java/de/monticore/CD4CodeToolGeneratorTest.java
@@ -7,8 +7,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CD4CodeToolGeneratorTest extends CD4CodeTestBasis {
 
@@ -36,13 +37,10 @@ public class CD4CodeToolGeneratorTest extends CD4CodeTestBasis {
       "target/generated/auctionTP"
     };
     de.monticore.CD4CodeTool.main(input);
-
-    Assert.assertTrue(
-        "Did not find via templatepath provided template content ",
-        Files.readLines(
-                new File("target/generated/auctionTP/Auction/auction/Auction.java"),
-                Charset.defaultCharset())
-            .contains("// empty body provided by the templatePath arg"));
+    
+    assertTrue(Files.readLines(new File("target/generated/auctionTP/Auction/auction/Auction.java"),
+            Charset.defaultCharset()).contains("// empty body provided by the templatePath arg"),
+        "Did not find via templatepath provided template content ");
   }
 
   @Test
@@ -93,12 +91,11 @@ public class CD4CodeToolGeneratorTest extends CD4CodeTestBasis {
     CD4CodeTool.main(input);
 
     // Test if the config template was loaded from the additional template path
-    Assert.assertTrue(
-        "Did not find via templatepath provided template content ",
-        Files.readLines(
-                new File("target/generated/auctionTPDCT/Auction/auction/Auction.java"),
+    assertTrue(
+        Files.readLines(new File("target/generated/auctionTPDCT/Auction/auction/Auction.java"),
                 Charset.defaultCharset())
-            .contains("// empty body provided and configured by the config template"));
+            .contains("// empty body provided and configured by the config template"),
+        "Did not find via templatepath provided template content ");
   }
 
   @Test
@@ -119,12 +116,11 @@ public class CD4CodeToolGeneratorTest extends CD4CodeTestBasis {
     CD4CodeTool.main(input);
 
     // Test if the config template was loaded from the additional template path
-    Assert.assertTrue(
-        "Did not find via templatepath provided template content ",
-        Files.readLines(
-                new File("target/generated/auctionTPCT/Auction/auction/Auction.java"),
+    assertTrue(
+        Files.readLines(new File("target/generated/auctionTPCT/Auction/auction/Auction.java"),
                 Charset.defaultCharset())
-            .contains("// empty body provided and configured by the config template"));
+            .contains("// empty body provided and configured by the config template"),
+        "Did not find via templatepath provided template content ");
   }
 
   @Test
@@ -146,11 +142,10 @@ public class CD4CodeToolGeneratorTest extends CD4CodeTestBasis {
     CD4CodeTool.main(input);
 
     // Test if the config template was loaded from the additional template path
-    Assert.assertTrue(
-        "Did not find via templatepath provided template content ",
-        Files.readLines(
-                new File("target/generated/auctionTPCTSep/Auction/auction/Auction.java"),
+    assertTrue(
+        Files.readLines(new File("target/generated/auctionTPCTSep/Auction/auction/Auction.java"),
                 Charset.defaultCharset())
-            .contains("// empty body provided and configured by the config template"));
+            .contains("// empty body provided and configured by the config template"),
+        "Did not find via templatepath provided template content ");
   }
 }

--- a/cdtool/src/test/java/de/monticore/CDDiffCLIToolTest.java
+++ b/cdtool/src/test/java/de/monticore/CDDiffCLIToolTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffUtil;
 import de.monticore.cddiff.alloycddiff.CDSemantics;
@@ -16,9 +14,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.io.file.PathUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CDDiffCLIToolTest {
 
@@ -27,7 +26,7 @@ public class CDDiffCLIToolTest {
 
   final String[] cwDiffOptions = {"", "--rule-based"};
 
-  @Before
+  @BeforeEach
   public void init() {
     LogStub.init();
   }
@@ -102,7 +101,7 @@ public class CDDiffCLIToolTest {
 
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
-            Assert.assertTrue(
+            assertTrue(
                 new OD2CDMatcher()
                     .checkIfDiffWitness(
                         CDSemantics.SIMPLE_CLOSED_WORLD,
@@ -194,7 +193,7 @@ public class CDDiffCLIToolTest {
 
       for (File odFile : odFiles) {
         if (odFile.getName().endsWith(".od")) {
-          Assert.assertTrue(
+          assertTrue(
               new OD2CDMatcher()
                   .checkIfDiffWitness(
                       CDSemantics.SIMPLE_CLOSED_WORLD,
@@ -454,7 +453,7 @@ public class CDDiffCLIToolTest {
 
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
-            Assert.assertTrue(
+            assertTrue(
                 new OD2CDMatcher()
                     .checkIfDiffWitness(
                         CDSemantics.SIMPLE_CLOSED_WORLD,
@@ -497,12 +496,12 @@ public class CDDiffCLIToolTest {
 
       // no corresponding .od files are generated
       File[] odFiles = Paths.get(output).toFile().listFiles();
-      Assert.assertNotNull(odFiles);
+      assertNotNull(odFiles);
 
       try {
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
-            Assert.assertTrue(
+            assertTrue(
                 new OD2CDMatcher()
                     .checkIfDiffWitness(
                         CDSemantics.STA_CLOSED_WORLD,
@@ -515,7 +514,7 @@ public class CDDiffCLIToolTest {
       } catch (Exception e) {
         e.printStackTrace();
         Log.warn("This should not happen!");
-        Assert.fail();
+        fail();
       }
     }
   }
@@ -546,21 +545,21 @@ public class CDDiffCLIToolTest {
 
     // no corresponding .od files are generated
     File[] odFiles = Paths.get(output).toFile().listFiles();
-    Assert.assertNotNull(odFiles);
+    assertNotNull(odFiles);
 
     try {
       ASTCDCompilationUnit ast1 = Objects.requireNonNull(CDDiffUtil.loadCD(cd1)).deepClone();
       ASTCDCompilationUnit ast2 = Objects.requireNonNull(CDDiffUtil.loadCD(cd2)).deepClone();
       for (File odFile : odFiles) {
         if (odFile.getName().endsWith(".od")) {
-          Assert.assertTrue(
+          assertTrue(
               new OD2CDMatcher()
                   .checkIfDiffWitness(
                       CDSemantics.STA_OPEN_WORLD,
                       ast1,
                       ast2,
                       CDDiffUtil.loadODModel(odFile.getPath())));
-          Assert.assertTrue(
+          assertTrue(
               new OD2CDMatcher()
                   .checkIfDiffWitness(
                       CDSemantics.STA_CLOSED_WORLD,
@@ -573,7 +572,7 @@ public class CDDiffCLIToolTest {
     } catch (Exception e) {
       e.printStackTrace();
       Log.warn("This should not happen!");
-      Assert.fail();
+      fail();
     }
   }
 }

--- a/cdtool/src/test/java/de/monticore/ExampleCommandTest.java
+++ b/cdtool/src/test/java/de/monticore/ExampleCommandTest.java
@@ -1,11 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import de.monticore.cd.OutTestBasis;
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
@@ -28,17 +23,17 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExampleCommandTest extends OutTestBasis {
 
   static final String outputPath = "target/generated/example-commands/";
 
-  @Before
+  @BeforeEach
   public void resetMill() {
     CD4CodeMill.reset();
   }
@@ -70,7 +65,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeMill.globalScope().clear();
     fileName = "src/test/resources/doc/MyLife.cd";
     CD4CodeTool.main(new String[] {"-i", fileName, "--path", outputPath + "symbols", "-pp"});
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /** Step1: Getting started for command: java -jar MCCD.jar -i src/MyExample.cd */
@@ -78,7 +73,7 @@ public class ExampleCommandTest extends OutTestBasis {
   public void testGettingStartedExample() {
     String fileName = "src/test/resources/doc/MyExample.cd";
     CD4CodeTool.main(new String[] {"-i", fileName});
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /** Step2: Pretty printing for command: java -jar MCCD.jar -i src/MyExample.cd -pp */
@@ -86,7 +81,7 @@ public class ExampleCommandTest extends OutTestBasis {
   public void testPrettyPrintingExample1() {
     String fileName = "src/test/resources/doc/MyExample.cd";
     CD4CodeTool.main(new String[] {"-i", fileName, "-pp"});
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -101,7 +96,7 @@ public class ExampleCommandTest extends OutTestBasis {
     assertTrue(
         loadAndCheckCD("src/test/resources/doc/MyExample.cd")
             .deepEquals(loadAndCheckCD(outputPath + "MyExample.cd"), false));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /** Step3: storing symbols for command: java -jar MCCD.jar -i src/MyExample.cd -s */
@@ -118,7 +113,7 @@ public class ExampleCommandTest extends OutTestBasis {
 
     // test if the result exists and no errors occur
     assertTrue(Files.exists(Paths.get(outputPath + "MyExample.cdsym")));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -134,7 +129,7 @@ public class ExampleCommandTest extends OutTestBasis {
 
     // test if the result exists and no errors occur
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -149,7 +144,7 @@ public class ExampleCommandTest extends OutTestBasis {
           "-i", fileName, "-s", outputPath + "symbols/MyExample.cdsym", "--fieldfromrole", "all"
         });
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -169,7 +164,7 @@ public class ExampleCommandTest extends OutTestBasis {
           "navigable"
         });
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -195,9 +190,9 @@ public class ExampleCommandTest extends OutTestBasis {
     tool.run(new String[] {"-i", fileName});
 
     // Then
-    Assertions.assertEquals(
+    assertEquals(
         3, Log.getFindingsCount(), "Actual findings: " + Log.getFindings().toString());
-    Assert.assertEquals("0xA0324 Cannot find symbol Address", Log.getFindings().get(0).getMsg());
+    assertEquals("0xA0324 Cannot find symbol Address", Log.getFindings().get(0).getMsg());
     Log.clearFindings();
   }
 
@@ -210,12 +205,12 @@ public class ExampleCommandTest extends OutTestBasis {
   public void testStoringSymbolsPerPathsExample2() {
     String fileName = "src/test/resources/doc/MyAddress.cd";
     CD4CodeTool.main(new String[] {"-i", fileName, "-s", outputPath + "symbols/MyAddress.cdsym"});
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
     CD4CodeMill.globalScope().clear();
     fileName = "src/test/resources/doc/MyLife.cd";
     CD4CodeTool.main(
         new String[] {"-i", fileName, "--defaultpackage", "--path", outputPath + "symbols"});
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -234,7 +229,7 @@ public class ExampleCommandTest extends OutTestBasis {
                     Files.exists(
                         Paths.get(
                             outputPath + "out/" + retrieveRelativeGenPath(c, cd) + ".java"))));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -258,7 +253,7 @@ public class ExampleCommandTest extends OutTestBasis {
                     Files.exists(
                         Paths.get(
                             outputPath + "out/" + retrieveRelativeGenPath(c, cd) + ".java"))));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -296,7 +291,7 @@ public class ExampleCommandTest extends OutTestBasis {
 
       for (File odFile : odFiles) {
         if (odFile.getName().endsWith(".od")) {
-          Assert.assertTrue(
+          assertTrue(
               new OD2CDMatcher()
                   .checkIfDiffWitness(
                       CDSemantics.SIMPLE_CLOSED_WORLD,
@@ -320,7 +315,7 @@ public class ExampleCommandTest extends OutTestBasis {
     final String fileName = "src/test/resources/doc/Teaching.cd";
     CD4CodeTool.main(
         new String[] {"-i", fileName, "--merge", "src/test/resources/doc/Management.cd", "-pp"});
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   /**
@@ -342,7 +337,7 @@ public class ExampleCommandTest extends OutTestBasis {
           "UniversitySystem.cd"
         });
     assertTrue(Files.exists(Paths.get(outputPath + "out/UniversitySystem.cd")));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   protected void resetGlobalScope() {

--- a/cdtool/src/test/java/de/monticore/ToolTest.java
+++ b/cdtool/src/test/java/de/monticore/ToolTest.java
@@ -1,23 +1,19 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd.OutTestBasis;
 import java.io.File;
 import java.io.IOException;
 import org.apache.commons.cli.ParseException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 public class ToolTest extends OutTestBasis {
   @SuppressWarnings("deprecation")
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   protected static final String TOOL_PATH = "src/test/resources/de/monticore/";
 
@@ -28,7 +24,7 @@ public class ToolTest extends OutTestBasis {
     CD4CodeTool.main(new String[] {"-i", cd1, "--merge", cd2});
 
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   @Test
@@ -38,7 +34,7 @@ public class ToolTest extends OutTestBasis {
     final String cd3 = TOOL_PATH + "cdmerge/Person/C.cd";
     final String out = "target/generated/multi-merge";
     CD4CodeTool.main(new String[] {"-i", cd1, "--merge", cd2, cd3, "-o", out, "-pp", "Merge.cd"});
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   @Test
@@ -49,7 +45,7 @@ public class ToolTest extends OutTestBasis {
     CD4CodeTool.main(new String[] {"-i", fileName, "-f", "false"});
 
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   @Test
@@ -60,11 +56,11 @@ public class ToolTest extends OutTestBasis {
     CD4CodeTool.main(new String[] {"-i", fileName, "-h", "-f", "false"});
 
     // assertTrue(getOut(), getOut().startsWith("usage: cd-"));
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   @Test
-  @Ignore // todo test has always(?) been broken and not correctly tested to far... -> requires
+  @Disabled // todo test has always(?) been broken and not correctly tested to far... -> requires
   // rework
   public void testToolNoBuiltInTypes() throws IOException, ParseException {
     final File file = new File(TOOL_PATH + "cd/Complete.cd");
@@ -74,7 +70,7 @@ public class ToolTest extends OutTestBasis {
     CD4CodeTool.main(new String[] {"-i", fileName, "-nt", "-f", "false"});
 
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   @Test
@@ -86,11 +82,11 @@ public class ToolTest extends OutTestBasis {
     CD4CodeTool.main(new String[] {"-i", fileName, "-f", "false"});
 
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
-    assertTrue(getErr(), getErr().isEmpty());
+    assertTrue(getErr().isEmpty(), getErr());
   }
 
   @Test
-  @Ignore // TODO MB
+  @Disabled // TODO MB
   public void testToolPlantUML() throws IOException, ParseException {
     final File file = new File(TOOL_PATH + "cd/Complete.cd");
     assertTrue(file.exists());
@@ -106,7 +102,7 @@ public class ToolTest extends OutTestBasis {
   }
 
   @Test
-  @Ignore // TODO MB
+  @Disabled // TODO MB
   public void testToolPlantUML2() throws IOException, ParseException {
     final File file = new File(TOOL_PATH + "cd/Complete.cd");
     assertTrue(file.exists());
@@ -129,7 +125,7 @@ public class ToolTest extends OutTestBasis {
   }
 
   @Test
-  @Ignore // TODO MB
+  @Disabled // TODO MB
   public void testToolPlantUML3() throws IOException, ParseException {
     final File file = new File(TOOL_PATH + "cd/Complete.cd");
     assertTrue(file.exists());
@@ -147,7 +143,7 @@ public class ToolTest extends OutTestBasis {
   // if Log.error is called resulting in a System.exit()
   Thread failOnExitHook;
 
-  @Before
+  @BeforeEach
   public void setUpFailOnExitHook() {
     // This will(should) result in an indefinitely blocked process,
     // s.
@@ -166,8 +162,7 @@ public class ToolTest extends OutTestBasis {
     Runtime.getRuntime().addShutdownHook(failOnExitHook);
   }
 
-  @After
-  public void removeFailOnExitHook() {
+  @AfterEach  public void removeFailOnExitHook() {
     Runtime.getRuntime().removeShutdownHook(failOnExitHook);
   }
 }

--- a/language-server/src/test/java/de/monticore/cd4analysis/_lsp/features/code_lens/AssociationCodeLensStrategyTest.java
+++ b/language-server/src/test/java/de/monticore/cd4analysis/_lsp/features/code_lens/AssociationCodeLensStrategyTest.java
@@ -35,10 +35,10 @@ class AssociationCodeLensStrategyTest extends AbstractCodeLensTest {
     Range firstLine = new Range(new Position(1, 8), new Position(1, 9));
     Range secondLine = new Range(new Position(2, 8), new Position(2, 9));
 
-    assertEquals(codeLenses.get(0).getRange(), firstLine);
-    assertEquals(codeLenses.get(0).getCommand().getTitle(), TITLE);
-    assertEquals(codeLenses.get(1).getRange(), secondLine);
-    assertEquals(codeLenses.get(1).getCommand().getTitle(), TITLE);
+    assertEquals(firstLine, codeLenses.get(0).getRange());
+    assertEquals(TITLE, codeLenses.get(0).getCommand().getTitle());
+    assertEquals(secondLine, codeLenses.get(1).getRange());
+    assertEquals(TITLE, codeLenses.get(1).getCommand().getTitle());
   }
 
   @Test
@@ -60,12 +60,12 @@ class AssociationCodeLensStrategyTest extends AbstractCodeLensTest {
     Range secondLine = new Range(new Position(2, 8), new Position(2, 9));
     Range thirdLine = new Range(new Position(3, 8), new Position(3, 9));
 
-    assertEquals(codeLenses.get(0).getRange(), firstLine);
-    assertEquals(codeLenses.get(0).getCommand().getTitle(), TITLE);
-    assertEquals(codeLenses.get(1).getRange(), secondLine);
-    assertEquals(codeLenses.get(1).getCommand().getTitle(), TITLE);
-    assertEquals(codeLenses.get(2).getRange(), thirdLine);
-    assertEquals(codeLenses.get(2).getCommand().getTitle(), TITLE);
+    assertEquals(firstLine, codeLenses.get(0).getRange());
+    assertEquals(TITLE, codeLenses.get(0).getCommand().getTitle());
+    assertEquals(secondLine, codeLenses.get(1).getRange());
+    assertEquals(TITLE, codeLenses.get(1).getCommand().getTitle());
+    assertEquals(thirdLine, codeLenses.get(2).getRange());
+    assertEquals(TITLE, codeLenses.get(2).getCommand().getTitle());
   }
 
   @Test
@@ -81,7 +81,7 @@ class AssociationCodeLensStrategyTest extends AbstractCodeLensTest {
 
     Range firstLine = new Range(new Position(3, 8), new Position(3, 9));
 
-    assertEquals(codeLenses.get(0).getRange(), firstLine);
-    assertEquals(codeLenses.get(0).getCommand().getTitle(), TITLE);
+    assertEquals(firstLine, codeLenses.get(0).getRange());
+    assertEquals(TITLE, codeLenses.get(0).getCommand().getTitle());
   }
 }

--- a/symtabdefinitiontool/stdefgradle/src/test/java/de/monticore/symtabdefinitiontool/gradleplugin/SymTabDefinitionGradlePluginTest.java
+++ b/symtabdefinitiontool/stdefgradle/src/test/java/de/monticore/symtabdefinitiontool/gradleplugin/SymTabDefinitionGradlePluginTest.java
@@ -10,24 +10,24 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SymTabDefinitionGradlePluginTest {
 
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
   File testProjectDir;
   File settingsFile;
   File propertiesFile;
   File buildFile;
   File modelDir;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
-    testProjectDir = temporaryFolder.newFolder();
     settingsFile = new File(testProjectDir, "settings.gradle");
     buildFile = new File(testProjectDir, "build.gradle");
     propertiesFile = new File(testProjectDir, "gradle.properties");
@@ -56,12 +56,12 @@ public class SymTabDefinitionGradlePluginTest {
 
     File cdlangLibs = new File("../../cdlang/target/libs");
     File cd4aJarFile = new File(cdlangLibs, "cd4analysis-" + projVersion + ".jar");
-    Assert.assertTrue(cdlangLibs.exists());
+    assertTrue(cd4aJarFile.exists());
 
     File stdeftoolLibs = new File("../target/libs");
     File stdeftoolJarFile =
         new File(stdeftoolLibs, "cd4analysis-" + projVersion + "-symtabdefinitiontool.jar");
-    Assert.assertTrue(stdeftoolLibs.exists());
+    assertTrue(stdeftoolJarFile.exists());
 
     String buildFileContent =
         "plugins {\n"
@@ -94,7 +94,7 @@ public class SymTabDefinitionGradlePluginTest {
             .withProjectDir(testProjectDir)
             .withArguments("build", "--info", "--stacktrace")
             .build();
-    Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateSymbolTables").getOutcome());
+    assertEquals(TaskOutcome.SUCCESS, result.task(":generateSymbolTables").getOutcome());
   }
 
   void writeFile(File destination, String content) throws IOException {

--- a/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/ClassAdapterTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/ClassAdapterTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.designPatternTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdlib.designPattern.AdapterPattern;
@@ -10,9 +8,12 @@ import de.monticore.cdlib.utilities.FileUtility;
 import de.monticore.generating.templateengine.reporting.Reporting;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class AdapterPattern Test ClassAdapter
@@ -23,13 +24,13 @@ import org.junit.Test;
  */
 public class ClassAdapterTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();
   }
 
-  @After
+  @AfterEach
   public void flush() {
     Reporting.flush(null);
   }

--- a/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/DecoratorTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/DecoratorTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.designPatternTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdlib.designPattern.DecoratorPattern;
@@ -14,8 +12,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class DecoratorPattern
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class DecoratorTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/FacadeTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/FacadeTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.designPatternTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.designPattern.FacadePattern;
@@ -14,8 +12,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class FacadePattern
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class FacadeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/FactoryTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/FactoryTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.designPatternTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.designPattern.FactoryPattern;
@@ -14,8 +12,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class FactoryPattern
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class FactoryTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/ObjectAdapterTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/ObjectAdapterTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.designPatternTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdlib.designPattern.AdapterPattern;
@@ -14,8 +12,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class AdapterPattern Test objectAdapter
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class ObjectAdapterTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/ObserverTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/ObserverTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.designPatternTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdlib.designPattern.ObserverPattern;
@@ -14,8 +12,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class ObserverPattern
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class ObserverTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/ProxyTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/ProxyTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.designPatternTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -15,8 +13,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class ProxyPattern
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class ProxyTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/VisitorTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/designPatternTests/VisitorTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.designPatternTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._prettyprint.CD4CodeFullPrettyPrinter;
@@ -19,9 +17,11 @@ import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class Visitor
@@ -32,7 +32,7 @@ import org.junit.Test;
  */
 public class VisitorTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();
@@ -56,7 +56,7 @@ public class VisitorTest {
 
   /** Test method introduceVisitorPattern */
   @Test
-  @Ignore // Also in master 1a795a08b0d34e976f41c303a1314cdc2e479d38
+  @Disabled // Also in master 1a795a08b0d34e976f41c303a1314cdc2e479d38
   public void testDesignPatternVisitor() throws IOException {
 
     FileUtility utility = new FileUtility("cdlib/Node");

--- a/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestCases.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestCases.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.evaluationTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._prettyprint.CD4CodeFullPrettyPrinter;
@@ -20,8 +20,8 @@ import de.monticore.generating.templateengine.reporting.reporter.TransformationR
 import de.monticore.prettyprint.IndentPrinter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Testcases Created by
@@ -30,7 +30,7 @@ import org.junit.Test;
  */
 public class TestCases {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestCasesExtractClass.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestCasesExtractClass.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.evaluationTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.Refactoring.*;
 import de.monticore.cdlib.refactorings.ExtractSuperClass;
@@ -16,8 +14,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test Testcases for ExtractClass
@@ -28,7 +28,7 @@ import org.junit.Test;
  */
 public class TestCasesExtractClass {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestCasesExtractSuperclass.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestCasesExtractSuperclass.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.evaluationTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.ExtractIntermediateClass;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -13,8 +11,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test ExtractSuperclass for Testcases
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class TestCasesExtractSuperclass {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestCasesPullUp.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestCasesPullUp.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.evaluationTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.PullUp;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -13,8 +11,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test Testcases for Pull Up
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class TestCasesPullUp {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestTime1.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestTime1.java
@@ -12,8 +12,8 @@ import de.monticore.generating.templateengine.reporting.reporter.TransformationR
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Date;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Check Executiontime for Testcase 1
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class TestTime1 {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestTime2.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/evaluationTests/TestTime2.java
@@ -12,8 +12,8 @@ import de.monticore.generating.templateengine.reporting.reporter.TransformationR
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Date;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Check Executiontime for Testcase 2
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class TestTime2 {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/CollapseHierarchyTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/CollapseHierarchyTest.java
@@ -1,9 +1,9 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -17,8 +17,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Collapse Hierarchy
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class CollapseHierarchyTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/EncapsulateAttributeTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/EncapsulateAttributeTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -16,8 +14,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class EncapsulateAttributes
@@ -28,7 +28,7 @@ import org.junit.Test;
  */
 public class EncapsulateAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();
@@ -308,10 +308,10 @@ public class EncapsulateAttributeTest {
 
     // Encapsulate attributes
     assertFalse(refactoring.encapsulateAttributes(Lists.newArrayList("a"), utility.getAst()));
-    assertTrue(oldAst.equals(utility.getAst()));
+    assertEquals(oldAst, utility.getAst());
 
     // Check, if ast with private attributes isn't changed
     assertTrue(refactoring.encapsulateAttributes(utility.getAst()));
-    assertTrue(oldAst.equals(utility.getAst()));
+    assertEquals(oldAst, utility.getAst());
   }
 }

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractClassTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractClassTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -15,8 +13,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class ParameterObject
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class ExtractClassTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractInterfaceTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractInterfaceTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.ExtractInterface;
@@ -14,8 +12,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class ExtractInterface
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class ExtractInterfaceTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractIntermediateClassAttributeTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractIntermediateClassAttributeTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdlib.refactorings.ExtractIntermediateClassArbitraryNumber;
@@ -14,8 +12,11 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test class ExtractIntermediateClass
@@ -26,7 +27,7 @@ import org.junit.Test;
  */
 public class ExtractIntermediateClassAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractIntermediateClassTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractIntermediateClassTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.ExtractIntermediateClass;
@@ -14,8 +12,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class ExtractSuperclass
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class ExtractIntermediateClassTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractSuperClassTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ExtractSuperClassTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
@@ -15,8 +13,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class ExtractClass
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class ExtractSuperClassTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();
@@ -70,14 +70,11 @@ public class ExtractSuperClassTest {
         1,
         utility.getAst().getCDDefinition().getCDClassesList().get(2).getCDAttributeList().size());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty());
     assertTrue(
         utility
             .getAst()
@@ -162,15 +159,12 @@ public class ExtractSuperClassTest {
             .getCDAttributeList()
             .get(0)
             .deepEquals(a));
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty()
-            ^ true);
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty()
-            ^ true);
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty());
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty());
     assertEquals(
         "ClassAClassBClassC",
         utility.getAst().getCDDefinition().getCDClassesList().get(0).printSuperclasses());
@@ -203,14 +197,11 @@ public class ExtractSuperClassTest {
         1,
         utility.getAst().getCDDefinition().getCDClassesList().get(2).getCDAttributeList().size());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty());
     assertTrue(
         utility
             .getAst()
@@ -297,15 +288,12 @@ public class ExtractSuperClassTest {
             .getCDAttributeList()
             .get(0)
             .deepEquals(a));
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty()
-            ^ true);
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty()
-            ^ true);
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty());
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty());
     assertEquals(
         "TestName",
         utility.getAst().getCDDefinition().getCDClassesList().get(0).printSuperclasses());
@@ -334,14 +322,11 @@ public class ExtractSuperClassTest {
     assertEquals(
         1, utility.getAst().getCDDefinition().getCDClassesList().get(2).getCDMethodList().size());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty());
     assertTrue(
         utility
             .getAst()
@@ -424,15 +409,12 @@ public class ExtractSuperClassTest {
             .getCDMethodList()
             .get(0)
             .deepEquals(a));
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty()
-            ^ true);
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty()
-            ^ true);
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty());
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty());
     assertEquals(
         "ClassAClassBClassC",
         utility.getAst().getCDDefinition().getCDClassesList().get(0).printSuperclasses());
@@ -461,14 +443,11 @@ public class ExtractSuperClassTest {
     assertEquals(
         1, utility.getAst().getCDDefinition().getCDClassesList().get(2).getCDMethodList().size());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
     assertTrue(
-        !utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty()
-            ^ true);
+        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty());
     assertTrue(
         utility
             .getAst()
@@ -550,15 +529,12 @@ public class ExtractSuperClassTest {
             .getCDMethodList()
             .get(0)
             .deepEquals(a));
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty()
-            ^ true);
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
-    assertTrue(
-        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty()
-            ^ true);
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(0).getSuperclassList().isEmpty());
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
+    assertFalse(
+        utility.getAst().getCDDefinition().getCDClassesList().get(2).getSuperclassList().isEmpty());
     assertEquals(
         "TestName",
         utility.getAst().getCDDefinition().getCDClassesList().get(0).printSuperclasses());

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/InlineClassTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/InlineClassTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.InlineClass;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -13,8 +11,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class InlineClass
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class InlineClassTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/MoveTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/MoveTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -15,8 +13,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class move
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class MoveTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PullUpAssociationTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PullUpAssociationTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.PullUp;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -13,8 +11,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class PullUp
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class PullUpAssociationTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PullUpAttributeTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PullUpAttributeTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdlib.refactorings.PullUp;
@@ -14,8 +12,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class PullUp
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class PullUpAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PullUpAttrsTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PullUpAttrsTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdlib.Refactoring.*;
@@ -13,8 +11,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test class PullUp
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class PullUpAttrsTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PullUpMethodTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PullUpMethodTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
@@ -15,8 +13,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class PullUp
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class PullUpMethodTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PushDownTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/PushDownTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -16,8 +14,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class PushDown
@@ -28,7 +28,7 @@ import org.junit.Test;
  */
 public class PushDownTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RemoveAttributeTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RemoveAttributeTest.java
@@ -1,7 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
@@ -14,8 +15,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportManager;
 import de.monticore.generating.templateengine.reporting.commons.ReportingRepository;
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test remove Attribute
@@ -24,7 +25,7 @@ import org.junit.Test;
  */
 public class RemoveAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();
@@ -60,12 +61,12 @@ public class RemoveAttributeTest {
     ASTCDAttribute attributeFirst = classA.getCDAttributeList().get(0);
     assertEquals("a", attributeFirst.getName());
     assertEquals("int", attributeFirst.getMCType().printType());
-    assertEquals(true, attributeFirst.getModifier().isPublic());
+    assertTrue(attributeFirst.getModifier().isPublic());
 
     ASTCDAttribute attributeSecond = classA.getCDAttributeList().get(1);
     assertEquals("b", attributeSecond.getName());
     assertEquals("String", attributeSecond.getMCType().printType());
-    assertEquals(true, attributeSecond.getModifier().isPrivate());
+    assertTrue(attributeSecond.getModifier().isPrivate());
 
     ASTCDAttribute attributeThird = classA.getCDAttributeList().get(2);
     assertEquals("c", attributeThird.getName());
@@ -80,7 +81,7 @@ public class RemoveAttributeTest {
     attributeFirst = classA.getCDAttributeList().get(0);
     assertEquals("a", attributeFirst.getName());
     assertEquals("int", attributeFirst.getMCType().printType());
-    assertEquals(true, attributeFirst.getModifier().isPublic());
+    assertTrue(attributeFirst.getModifier().isPublic());
 
     attributeSecond = classA.getCDAttributeList().get(1);
     assertEquals("c", attributeThird.getName());

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RemoveClassTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RemoveClassTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.Remove;
@@ -14,8 +14,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class Remove Removing class
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class RemoveClassTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RemoveMethodTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RemoveMethodTest.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -14,8 +14,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportManager;
 import de.monticore.generating.templateengine.reporting.commons.ReportingRepository;
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test method renaming classes
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class RemoveMethodTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RenameAttributeTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RenameAttributeTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -15,8 +15,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class Rename
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class RenameAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RenameClassTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/RenameClassTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.Rename;
@@ -14,8 +14,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class Rename Renaming classes
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class RenameClassTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ReplaceDelegationByAttributeTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/ReplaceDelegationByAttributeTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.ReplaceDelegationByAttribute;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -13,8 +11,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class ReplaceDelegationByAttribute
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class ReplaceDelegationByAttributeTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();
@@ -57,9 +57,8 @@ public class ReplaceDelegationByAttributeTest {
     // Check input
     assertEquals("A", utility.getAst().getCDDefinition().getCDClassesList().get(0).getName());
     assertEquals("B", utility.getAst().getCDDefinition().getCDClassesList().get(1).getName());
-    assertFalse(
-        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
+    assertTrue(
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
     assertEquals(
         "B",
         utility

--- a/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/SwitchInheritanceDelegationTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/refactoringTests/SwitchInheritanceDelegationTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.refactoringTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.refactorings.SwitchInheritanceDelegation;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -13,8 +11,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class SwitchInheritanceDelegation
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class SwitchInheritanceDelegationTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();
@@ -109,9 +109,8 @@ public class SwitchInheritanceDelegationTest {
     // Check input
     assertEquals("A", utility.getAst().getCDDefinition().getCDClassesList().get(0).getName());
     assertEquals("B", utility.getAst().getCDDefinition().getCDClassesList().get(1).getName());
-    assertFalse(
-        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty()
-            ^ true);
+    assertTrue(
+        utility.getAst().getCDDefinition().getCDClassesList().get(1).getSuperclassList().isEmpty());
     assertEquals(
         "B",
         utility

--- a/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/AddMethodTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/AddMethodTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.utilityTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
@@ -15,8 +15,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class TransformationUtility
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class AddMethodTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/ChangeInheritanceClass.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/ChangeInheritanceClass.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.utilityTests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -13,8 +13,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class TransformationUtility
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class ChangeInheritanceClass {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/ChangeNameInAssociationTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/ChangeNameInAssociationTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.utilityTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -14,8 +14,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class TransformationUtility
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class ChangeNameInAssociationTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/CreateInheritanceInterfaceTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/CreateInheritanceInterfaceTest.java
@@ -1,8 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.utilityTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -14,8 +14,8 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class TransformationUtility
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class CreateInheritanceInterfaceTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();

--- a/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/FileUtilityTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/FileUtilityTest.java
@@ -1,7 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.utilityTests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdlib.utilities.FileUtility;
@@ -13,8 +14,8 @@ import de.monticore.generating.templateengine.reporting.reporter.TransformationR
 import de.se_rwth.commons.logging.Log;
 import java.io.File;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class FileUtility
@@ -25,7 +26,7 @@ import org.junit.Test;
  */
 public class FileUtilityTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();
@@ -55,8 +56,8 @@ public class FileUtilityTest {
     // Create Utility object
     String inputFile = "cdlib/A";
     FileUtility utility = new FileUtility(inputFile);
-
-    assertTrue(utility.getAst().getCDDefinition().getCDClassesList().get(0).getName().equals("A"));
+    
+    assertEquals("A", utility.getAst().getCDDefinition().getCDClassesList().get(0).getName());
   }
 
   // Test writing an ast of a classdiagram to a file

--- a/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/FindTest.java
+++ b/trafo-library/src/test/java/de/monticore/cdlib/utilityTests/FindTest.java
@@ -1,8 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdlib.utilityTests;
 
-import static org.junit.Assert.*;
-
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
@@ -15,8 +13,10 @@ import de.monticore.generating.templateengine.reporting.commons.ReportingReposit
 import de.monticore.generating.templateengine.reporting.reporter.TransformationReporter;
 import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class TransformationUtility
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class FindTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFailQuick() {
     Log.enableFailQuick(false);
     CD4CodeMill.init();


### PR DESCRIPTION
Although the JUnit version has already been upgraded to version 5 in the dependencies some time ago, most of the tests were still using outdated methods.

- updated all imports to use JUnit 5
- updated all JUnit annotations
- updated assertions if needed