### PR TITLE
Fix (optional) tagging dependency

### DIFF
--- a/cdlang/build.gradle
+++ b/cdlang/build.gradle
@@ -103,7 +103,7 @@ dependencies {
   //dependencies for tagging
   if (withTagGen) {
     taggingGrammar "de.monticore:monticore-grammar:$mc_version" // Tagging Grammars are packed with the main grammar dependency
-    implementation "de.monticore:monticore-grammar-tagging:$mc_version"
+    taggingImplementation "de.monticore:monticore-grammar-tagging:$mc_version"
 
     testImplementation(sourceSets.tagging.output.classesDirs)
     testImplementation "de.monticore:monticore-grammar-tagging:$mc_version"


### PR DESCRIPTION
* Only the tagging sourceset depends on the monticore-grammar-tagging 