### PR TITLE
CDGenTool map imports to classes

### DIFF
--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -188,6 +188,8 @@ public class CDGenTool extends CDGeneratorTool {
           decorated.accept(t);
           // Post-Decorate: make methods in interfaces abstract
           this.makeMethodsInInterfacesAbstract(decorated);
+          // Post-Decorate: map import statements to classes
+          this.mapCD4CImports(ast);
 
           // Post-Decorate: TOP Decorator
           // TODO: #4310 - make this TOP decorator/transformation configurable via the config


### PR DESCRIPTION
This method is part of the deprecated CDGeneratorTool and missing in the new CDGenTool. Without it, the generated java classes are missing the correct import statements.