### PR TITLE
feat(cdconf): support for underspecification & attribute type incarnations

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
@@ -291,12 +291,15 @@ public class ConcretizationCompleter {
     @Override
     public MatchingStrategy<ASTCDAttribute> createAttributeIncStrategy(
         ASTCDType concreteType, ASTCDType referenceType) {
-      CompAttributeChecker attributeIncStrategy = new CompAttributeChecker(mapping, typeIncStrategy);
+      CompAttributeChecker attributeIncStrategy = new CompAttributeChecker(
+              mapping, underspecifiedPlaceholderTypeName, typeIncStrategy);
       if (conformanceParams.contains(CDConfParameter.STEREOTYPE_MAPPING)) {
-        attributeIncStrategy.addIncStrategy(new STNamedAttributeChecker(mapping, typeIncStrategy));
+        attributeIncStrategy.addIncStrategy(new STNamedAttributeChecker(
+                mapping, underspecifiedPlaceholderTypeName, typeIncStrategy));
       }
       if (conformanceParams.contains(CDConfParameter.NAME_MAPPING)) {
-        attributeIncStrategy.addIncStrategy(new EqNameAttributeChecker(mapping, typeIncStrategy));
+        attributeIncStrategy.addIncStrategy(new EqNameAttributeChecker(
+                mapping, underspecifiedPlaceholderTypeName, typeIncStrategy));
       }
       attributeIncStrategy.setConcreteType(concreteType);
       attributeIncStrategy.setReferenceType(referenceType);

--- a/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
@@ -291,12 +291,12 @@ public class ConcretizationCompleter {
     @Override
     public MatchingStrategy<ASTCDAttribute> createAttributeIncStrategy(
         ASTCDType concreteType, ASTCDType referenceType) {
-      CompAttributeChecker attributeIncStrategy = new CompAttributeChecker(mapping);
+      CompAttributeChecker attributeIncStrategy = new CompAttributeChecker(mapping, typeIncStrategy);
       if (conformanceParams.contains(CDConfParameter.STEREOTYPE_MAPPING)) {
-        attributeIncStrategy.addIncStrategy(new STNamedAttributeChecker(mapping));
+        attributeIncStrategy.addIncStrategy(new STNamedAttributeChecker(mapping, typeIncStrategy));
       }
       if (conformanceParams.contains(CDConfParameter.NAME_MAPPING)) {
-        attributeIncStrategy.addIncStrategy(new EqNameAttributeChecker(mapping));
+        attributeIncStrategy.addIncStrategy(new EqNameAttributeChecker(mapping, typeIncStrategy));
       }
       attributeIncStrategy.setConcreteType(concreteType);
       attributeIncStrategy.setReferenceType(referenceType);

--- a/cddiff/src/main/java/de/monticore/cdconformance/CDConformanceChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/CDConformanceChecker.java
@@ -6,6 +6,7 @@ import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdbasis._ast.*;
+import de.monticore.cdconcretization.UnderspecifiedPlaceholderType;
 import de.monticore.cdconformance.conf.ConformanceStrategy;
 import de.monticore.cdconformance.conf.association.BasicAssocConfStrategy;
 import de.monticore.cdconformance.conf.association.DeepAssocConfStrategy;
@@ -32,6 +33,7 @@ import java.util.*;
  */
 public class CDConformanceChecker {
   protected Set<CDConfParameter> params;
+  protected String underspecifiedTypeName = UnderspecifiedPlaceholderType.DEFAULT_TYPE_NAME;
   protected CompTypeIncStrategy typeInc;
   protected CompAssocIncStrategy assocInc;
   protected CompAttributeChecker attrInc;
@@ -74,21 +76,21 @@ public class CDConformanceChecker {
     // init incarnation checker
     typeInc = new CompTypeIncStrategy(referenceCD, mapping);
     assocInc = new CompAssocIncStrategy(referenceCD, mapping);
-    attrInc = new CompAttributeChecker(mapping, typeInc);
-    methInc = new CompMethodChecker(mapping, typeInc);
+    attrInc = new CompAttributeChecker(mapping, underspecifiedTypeName, typeInc);
+    methInc = new CompMethodChecker(mapping, underspecifiedTypeName, typeInc);
 
     if (params.contains(STEREOTYPE_MAPPING)) {
       typeInc.addIncStrategy(new STTypeIncStrategy(referenceCD, mapping));
       assocInc.addIncStrategy(new STNamedAssocIncStrategy(referenceCD, mapping));
-      attrInc.addIncStrategy(new STNamedAttributeChecker(mapping, typeInc));
-      methInc.addIncStrategy(new STNamedMethodChecker(mapping, typeInc));
+      attrInc.addIncStrategy(new STNamedAttributeChecker(mapping, underspecifiedTypeName, typeInc));
+      methInc.addIncStrategy(new STNamedMethodChecker(mapping, underspecifiedTypeName, typeInc));
     }
 
     if (params.contains(NAME_MAPPING)) {
       typeInc.addIncStrategy(new EqTypeIncStrategy(referenceCD, mapping));
       assocInc.addIncStrategy(new EqNameAssocIncStrategy(referenceCD, mapping));
-      attrInc.addIncStrategy(new EqNameAttributeChecker(mapping, typeInc));
-      methInc.addIncStrategy(new EqNameMethodChecker(mapping, typeInc));
+      attrInc.addIncStrategy(new EqNameAttributeChecker(mapping, underspecifiedTypeName, typeInc));
+      methInc.addIncStrategy(new EqNameMethodChecker(mapping, underspecifiedTypeName, typeInc));
     }
 
     if (params.contains(SRC_TARGET_ASSOC_MAPPING)) {

--- a/cddiff/src/main/java/de/monticore/cdconformance/CDConformanceChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/CDConformanceChecker.java
@@ -74,20 +74,20 @@ public class CDConformanceChecker {
     // init incarnation checker
     typeInc = new CompTypeIncStrategy(referenceCD, mapping);
     assocInc = new CompAssocIncStrategy(referenceCD, mapping);
-    attrInc = new CompAttributeChecker(mapping);
+    attrInc = new CompAttributeChecker(mapping, typeInc);
     methInc = new CompMethodChecker(mapping, typeInc);
 
     if (params.contains(STEREOTYPE_MAPPING)) {
       typeInc.addIncStrategy(new STTypeIncStrategy(referenceCD, mapping));
       assocInc.addIncStrategy(new STNamedAssocIncStrategy(referenceCD, mapping));
-      attrInc.addIncStrategy(new STNamedAttributeChecker(mapping));
+      attrInc.addIncStrategy(new STNamedAttributeChecker(mapping, typeInc));
       methInc.addIncStrategy(new STNamedMethodChecker(mapping, typeInc));
     }
 
     if (params.contains(NAME_MAPPING)) {
       typeInc.addIncStrategy(new EqTypeIncStrategy(referenceCD, mapping));
       assocInc.addIncStrategy(new EqNameAssocIncStrategy(referenceCD, mapping));
-      attrInc.addIncStrategy(new EqNameAttributeChecker(mapping));
+      attrInc.addIncStrategy(new EqNameAttributeChecker(mapping, typeInc));
       methInc.addIncStrategy(new EqNameMethodChecker(mapping, typeInc));
     }
 

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/CDAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/CDAttributeChecker.java
@@ -8,9 +8,10 @@ public interface CDAttributeChecker
     extends MatchingStrategy<ASTCDAttribute>, ConformanceStrategy<ASTCDAttribute> {
   @Override
   default boolean checkConformance(ASTCDAttribute concrete) {
-    return getMatchedElements(concrete).stream()
-        .allMatch(ref -> ref.getMCType().deepEquals(concrete.getMCType()));
+    return getMatchedElements(concrete).stream().allMatch(ref -> checkConformance(concrete, ref));
   }
+
+  boolean checkConformance(ASTCDAttribute concrete, ASTCDAttribute ref);
 
   ASTCDType getReferenceType();
 

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/AbstractAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/AbstractAttributeChecker.java
@@ -6,18 +6,22 @@ import de.monticore.cdbasis._symboltable.CDTypeSymbol;
 import de.monticore.cdconformance.conf.CDAttributeChecker;
 import de.monticore.cdmatcher.MatchingStrategy;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
+import de.se_rwth.commons.logging.Log;
 
 import java.util.Optional;
 
 public abstract class AbstractAttributeChecker implements CDAttributeChecker {
 
   protected final String mapping;
+  protected final String underspecifiedTypeName;
   protected final MatchingStrategy<ASTCDType> typeMatcher;
-  protected ASTCDType conType;
-  protected ASTCDType refType;
+  protected ASTCDType concreteType;
+  protected ASTCDType referenceType;
 
-  protected AbstractAttributeChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
+  protected AbstractAttributeChecker(String mapping, String underspecifiedTypeName,
+                                     MatchingStrategy<ASTCDType> typeMatcher) {
     this.mapping = mapping;
+    this.underspecifiedTypeName = underspecifiedTypeName;
     this.typeMatcher = typeMatcher;
   }
 
@@ -27,10 +31,18 @@ public abstract class AbstractAttributeChecker implements CDAttributeChecker {
      * An attribute conforms to the reference attribute if one of the following holds:
      * - the concrete attribute has the exact same type as the reference attribute
      * - the concrete attribute type is an incarnation of the reference attribute type
-     * - TODO the reference attribute type is underspecified
+     * - the reference attribute type is underspecified
      */
     ASTMCType conType = concrete.getMCType();
     ASTMCType refType = ref.getMCType();
+    if (refType.printType().equals(underspecifiedTypeName)) {
+      if (conType.printType().equals(underspecifiedTypeName)) {
+        Log.error("The underspecified placeholder type is not allowed as a concrete type.");
+        return false;
+      }
+      // every type is allowed if the reference type is underspecified
+      return true;
+    }
     Optional<Boolean> conReturnType = checkTypeIncarnation(refType, conType);
     if (conReturnType.isPresent()) {
       return conReturnType.get();
@@ -57,21 +69,21 @@ public abstract class AbstractAttributeChecker implements CDAttributeChecker {
 
   @Override
   public ASTCDType getConcreteType() {
-    return conType;
+    return concreteType;
   }
 
   @Override
   public void setConcreteType(ASTCDType conType) {
-    this.conType = conType;
+    this.concreteType = conType;
   }
 
   @Override
   public ASTCDType getReferenceType() {
-    return refType;
+    return referenceType;
   }
 
   @Override
   public void setReferenceType(ASTCDType refType) {
-    this.refType = refType;
+    this.referenceType = refType;
   }
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/AbstractAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/AbstractAttributeChecker.java
@@ -1,0 +1,77 @@
+package de.monticore.cdconformance.conf.attribute;
+
+import de.monticore.cdbasis._ast.ASTCDAttribute;
+import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdbasis._symboltable.CDTypeSymbol;
+import de.monticore.cdconformance.conf.CDAttributeChecker;
+import de.monticore.cdmatcher.MatchingStrategy;
+import de.monticore.types.mcbasictypes._ast.ASTMCType;
+
+import java.util.Optional;
+
+public abstract class AbstractAttributeChecker implements CDAttributeChecker {
+
+  protected final String mapping;
+  protected final MatchingStrategy<ASTCDType> typeMatcher;
+  protected ASTCDType conType;
+  protected ASTCDType refType;
+
+  protected AbstractAttributeChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
+    this.mapping = mapping;
+    this.typeMatcher = typeMatcher;
+  }
+
+  @Override
+  public boolean checkConformance(ASTCDAttribute concrete, ASTCDAttribute ref) {
+    /*
+     * An attribute conforms to the reference attribute if one of the following holds:
+     * - the concrete attribute has the exact same type as the reference attribute
+     * - the concrete attribute type is an incarnation of the reference attribute type
+     * - TODO the reference attribute type is underspecified
+     */
+    ASTMCType conType = concrete.getMCType();
+    ASTMCType refType = ref.getMCType();
+    Optional<Boolean> conReturnType = checkTypeIncarnation(refType, conType);
+    if (conReturnType.isPresent()) {
+      return conReturnType.get();
+    }
+    return conType.deepEquals(refType);
+  }
+
+  protected Optional<Boolean> checkTypeIncarnation(ASTMCType refType, ASTMCType conType) {
+    if (conType.getDefiningSymbol().isPresent()
+            && conType.getDefiningSymbol().get() instanceof CDTypeSymbol
+            && refType.getDefiningSymbol().isPresent()
+            && refType.getDefiningSymbol().get() instanceof CDTypeSymbol) {
+      CDTypeSymbol conCDType = (CDTypeSymbol) conType.getDefiningSymbol().get();
+      CDTypeSymbol refCDType = (CDTypeSymbol) refType.getDefiningSymbol().get();
+      if (conCDType.isPresentAstNode()) {
+        return Optional.of(
+                typeMatcher.getMatchedElements(conCDType.getAstNode()).stream()
+                        .anyMatch(
+                                r -> r.getSymbol().getFullName().equals(refCDType.getFullName())));
+      }
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public ASTCDType getConcreteType() {
+    return conType;
+  }
+
+  @Override
+  public void setConcreteType(ASTCDType conType) {
+    this.conType = conType;
+  }
+
+  @Override
+  public ASTCDType getReferenceType() {
+    return refType;
+  }
+
+  @Override
+  public void setReferenceType(ASTCDType refType) {
+    this.refType = refType;
+  }
+}

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/CompAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/CompAttributeChecker.java
@@ -3,19 +3,17 @@ package de.monticore.cdconformance.conf.attribute;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDType;
 import de.monticore.cdconformance.conf.CDAttributeChecker;
+import de.monticore.cdmatcher.MatchingStrategy;
+
 import java.util.ArrayList;
 import java.util.List;
 
-public class CompAttributeChecker implements CDAttributeChecker {
-  protected String mapping;
-  protected ASTCDType conType;
+public class CompAttributeChecker extends AbstractAttributeChecker {
 
-  protected ASTCDType refType;
+  private final List<CDAttributeChecker> attributeCheckers = new ArrayList<>();
 
-  List<CDAttributeChecker> attributeCheckers = new ArrayList<>();
-
-  public CompAttributeChecker(String mapping) {
-    this.mapping = mapping;
+  public CompAttributeChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, typeMatcher);
   }
 
   public void addIncStrategy(CDAttributeChecker checker) {
@@ -42,19 +40,9 @@ public class CompAttributeChecker implements CDAttributeChecker {
   }
 
   @Override
-  public ASTCDType getReferenceType() {
-    return refType;
-  }
-
-  @Override
   public void setReferenceType(ASTCDType refType) {
     this.refType = refType;
     attributeCheckers.forEach(checker -> checker.setReferenceType(refType));
-  }
-
-  @Override
-  public ASTCDType getConcreteType() {
-    return conType;
   }
 
   @Override

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/CompAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/CompAttributeChecker.java
@@ -12,8 +12,10 @@ public class CompAttributeChecker extends AbstractAttributeChecker {
 
   private final List<CDAttributeChecker> attributeCheckers = new ArrayList<>();
 
-  public CompAttributeChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    super(mapping, typeMatcher);
+  public CompAttributeChecker(String mapping,
+                              String underspecifiedTypeName,
+                              MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, underspecifiedTypeName, typeMatcher);
   }
 
   public void addIncStrategy(CDAttributeChecker checker) {
@@ -41,13 +43,13 @@ public class CompAttributeChecker extends AbstractAttributeChecker {
 
   @Override
   public void setReferenceType(ASTCDType refType) {
-    this.refType = refType;
+    this.referenceType = refType;
     attributeCheckers.forEach(checker -> checker.setReferenceType(refType));
   }
 
   @Override
   public void setConcreteType(ASTCDType conType) {
-    this.conType = conType;
+    this.concreteType = conType;
     attributeCheckers.forEach(checker -> checker.setConcreteType(conType));
   }
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/EqNameAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/EqNameAttributeChecker.java
@@ -3,16 +3,15 @@ package de.monticore.cdconformance.conf.attribute;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDType;
 import de.monticore.cdconformance.conf.CDAttributeChecker;
+import de.monticore.cdmatcher.MatchingStrategy;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class EqNameAttributeChecker implements CDAttributeChecker {
-  protected ASTCDType refType;
-  protected ASTCDType conType;
-  protected String mapping;
+public class EqNameAttributeChecker extends AbstractAttributeChecker {
 
-  public EqNameAttributeChecker(String mapping) {
-    this.mapping = mapping;
+  public EqNameAttributeChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, typeMatcher);
   }
 
   @Override
@@ -25,25 +24,5 @@ public class EqNameAttributeChecker implements CDAttributeChecker {
   @Override
   public boolean isMatched(ASTCDAttribute concrete, ASTCDAttribute ref) {
     return ref.getName().equals(concrete.getName());
-  }
-
-  @Override
-  public ASTCDType getReferenceType() {
-    return refType;
-  }
-
-  @Override
-  public void setReferenceType(ASTCDType refType) {
-    this.refType = refType;
-  }
-
-  @Override
-  public ASTCDType getConcreteType() {
-    return conType;
-  }
-
-  @Override
-  public void setConcreteType(ASTCDType conType) {
-    this.conType = conType;
   }
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/EqNameAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/EqNameAttributeChecker.java
@@ -2,7 +2,6 @@ package de.monticore.cdconformance.conf.attribute;
 
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDType;
-import de.monticore.cdconformance.conf.CDAttributeChecker;
 import de.monticore.cdmatcher.MatchingStrategy;
 
 import java.util.List;
@@ -10,13 +9,14 @@ import java.util.stream.Collectors;
 
 public class EqNameAttributeChecker extends AbstractAttributeChecker {
 
-  public EqNameAttributeChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    super(mapping, typeMatcher);
+  public EqNameAttributeChecker(String mapping, String underspecifiedTypeName,
+                                MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, underspecifiedTypeName, typeMatcher);
   }
 
   @Override
   public List<ASTCDAttribute> getMatchedElements(ASTCDAttribute concrete) {
-    return refType.getCDAttributeList().stream()
+    return referenceType.getCDAttributeList().stream()
         .filter(attr -> isMatched(concrete, attr))
         .collect(Collectors.toList());
   }

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/STNamedAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/STNamedAttributeChecker.java
@@ -2,7 +2,10 @@ package de.monticore.cdconformance.conf.attribute;
 
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdconcretization.util.NameUtil;
 import de.monticore.cdmatcher.MatchingStrategy;
+import de.monticore.symbols.oosymbols._symboltable.FieldSymbol;
+import de.monticore.types.mcbasictypes._ast.ASTMCType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,7 +29,7 @@ public class STNamedAttributeChecker extends AbstractAttributeChecker {
     if (concrete.getModifier().isPresentStereotype()
         && concrete.getModifier().getStereotype().contains(mapping)) {
       String refName = concrete.getModifier().getStereotype().getValue(mapping);
-      return ref.getName().equals(refName);
+      return refType.getSpannedScope().resolveFieldMany(refName).contains(ref.getSymbol());
     }
     return false;
   }

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/STNamedAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/STNamedAttributeChecker.java
@@ -12,14 +12,15 @@ import java.util.stream.Collectors;
 
 public class STNamedAttributeChecker extends AbstractAttributeChecker {
 
-  public STNamedAttributeChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    super(mapping, typeMatcher);
+  public STNamedAttributeChecker(String mapping, String underspecifiedTypeName,
+                                 MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, underspecifiedTypeName, typeMatcher);
   }
 
   @Override
   public List<ASTCDAttribute> getMatchedElements(ASTCDAttribute concrete) {
 
-    return refType.getCDAttributeList().stream()
+    return referenceType.getCDAttributeList().stream()
         .filter(ref -> isMatched(concrete, ref))
         .collect(Collectors.toList());
   }
@@ -29,7 +30,7 @@ public class STNamedAttributeChecker extends AbstractAttributeChecker {
     if (concrete.getModifier().isPresentStereotype()
         && concrete.getModifier().getStereotype().contains(mapping)) {
       String refName = concrete.getModifier().getStereotype().getValue(mapping);
-      return refType.getSpannedScope().resolveFieldMany(refName).contains(ref.getSymbol());
+      return referenceType.getSpannedScope().resolveFieldMany(refName).contains(ref.getSymbol());
     }
     return false;
   }

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/STNamedAttributeChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/attribute/STNamedAttributeChecker.java
@@ -2,17 +2,15 @@ package de.monticore.cdconformance.conf.attribute;
 
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDType;
-import de.monticore.cdconformance.conf.CDAttributeChecker;
+import de.monticore.cdmatcher.MatchingStrategy;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class STNamedAttributeChecker implements CDAttributeChecker {
-  protected String mapping;
-  protected ASTCDType refType;
-  protected ASTCDType conType;
+public class STNamedAttributeChecker extends AbstractAttributeChecker {
 
-  public STNamedAttributeChecker(String mapping) {
-    this.mapping = mapping;
+  public STNamedAttributeChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, typeMatcher);
   }
 
   @Override
@@ -31,25 +29,5 @@ public class STNamedAttributeChecker implements CDAttributeChecker {
       return ref.getName().equals(refName);
     }
     return false;
-  }
-
-  @Override
-  public ASTCDType getReferenceType() {
-    return this.refType;
-  }
-
-  @Override
-  public void setReferenceType(ASTCDType refType) {
-    this.refType = refType;
-  }
-
-  @Override
-  public ASTCDType getConcreteType() {
-    return conType;
-  }
-
-  @Override
-  public void setConcreteType(ASTCDType conType) {
-    this.conType = conType;
   }
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/AbstractMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/AbstractMethodChecker.java
@@ -8,17 +8,22 @@ import de.monticore.cdconformance.conf.ICDMethodChecker;
 import de.monticore.cdmatcher.MatchingStrategy;
 import de.monticore.types.mcbasictypes._ast.ASTMCReturnType;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
+import de.se_rwth.commons.logging.Log;
+
 import java.util.Optional;
 
 public abstract class AbstractMethodChecker implements ICDMethodChecker {
 
   protected final String mapping;
+  protected final String underspecifiedTypeName;
   protected final MatchingStrategy<ASTCDType> typeMatcher;
   protected ASTCDType conType;
   protected ASTCDType refType;
 
-  protected AbstractMethodChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
+  protected AbstractMethodChecker(String mapping, String underspecifiedTypeName,
+                                  MatchingStrategy<ASTCDType> typeMatcher) {
     this.mapping = mapping;
+    this.underspecifiedTypeName = underspecifiedTypeName;
     this.typeMatcher = typeMatcher;
   }
 
@@ -34,6 +39,14 @@ public abstract class AbstractMethodChecker implements ICDMethodChecker {
 
   protected boolean checkParameterConformance(ASTCDParameter conPar, ASTCDParameter refPar) {
     if (conPar.getName().equals(refPar.getName())) {
+      if (refPar.getMCType().printType().equals(underspecifiedTypeName)) {
+        if (conPar.getMCType().printType().equals(underspecifiedTypeName)) {
+          Log.error("The underspecified placeholder type is not allowed as a concrete type.");
+          return false;
+        }
+        // every type is allowed if the reference type is underspecified
+        return true;
+      }
       Optional<Boolean> conParType = checkTypeIncarnation(refPar.getMCType(), conPar.getMCType());
       if (conParType.isPresent()) {
         return conParType.get();
@@ -45,7 +58,19 @@ public abstract class AbstractMethodChecker implements ICDMethodChecker {
 
   protected boolean checkReturnTypeConformance(
       ASTMCReturnType conReturn, ASTMCReturnType refReturn) {
+    if (refReturn.printType().equals(underspecifiedTypeName)) {
+      if (conReturn.printType().equals(underspecifiedTypeName)) {
+        Log.error("The underspecified placeholder type is not allowed as a concrete type.");
+        return false;
+      }
+      // every type is allowed if the reference type is underspecified
+      return true;
+    }
     if (refReturn.printType().equals("void")) {
+      if (conReturn.printType().equals(underspecifiedTypeName)) {
+        Log.error("The underspecified placeholder type is not allowed as a concrete type.");
+        return false;
+      }
       return true;
     }
     Optional<Boolean> conReturnType =

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/AbstractMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/AbstractMethodChecker.java
@@ -52,13 +52,16 @@ public abstract class AbstractMethodChecker implements ICDMethodChecker {
 
   protected Optional<Boolean> checkTypeIncarnation(ASTMCType refType, ASTMCType conType) {
     if (conType.getDefiningSymbol().isPresent()
-        && conType.getDefiningSymbol().get() instanceof CDTypeSymbol) {
+        && conType.getDefiningSymbol().get() instanceof CDTypeSymbol
+        && refType.getDefiningSymbol().isPresent()
+        && refType.getDefiningSymbol().get() instanceof CDTypeSymbol) {
       CDTypeSymbol conCDType = (CDTypeSymbol) conType.getDefiningSymbol().get();
+      CDTypeSymbol refCDType = (CDTypeSymbol) refType.getDefiningSymbol().get();
       if (conCDType.isPresentAstNode()) {
         return Optional.of(
             typeMatcher.getMatchedElements(conCDType.getAstNode()).stream()
                 .anyMatch(
-                    r -> r.getSymbol().getInternalQualifiedName().contains(refType.printType())));
+                    r -> r.getSymbol().getFullName().equals(refCDType.getFullName())));
       }
     }
     return Optional.empty();

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/AbstractMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/AbstractMethodChecker.java
@@ -11,10 +11,16 @@ import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import java.util.Optional;
 
 public abstract class AbstractMethodChecker implements ICDMethodChecker {
-  protected String mapping;
+
+  protected final String mapping;
+  protected final MatchingStrategy<ASTCDType> typeMatcher;
   protected ASTCDType conType;
   protected ASTCDType refType;
-  protected MatchingStrategy<ASTCDType> typeMatcher;
+
+  protected AbstractMethodChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
+    this.mapping = mapping;
+    this.typeMatcher = typeMatcher;
+  }
 
   @Override
   public boolean checkConformance(ASTCDMethod concrete, ASTCDMethod ref) {

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/CompMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/CompMethodChecker.java
@@ -8,11 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CompMethodChecker extends AbstractMethodChecker {
-  List<ICDMethodChecker> methodCheckers = new ArrayList<>();
+  private final List<ICDMethodChecker> methodCheckers = new ArrayList<>();
 
   public CompMethodChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    this.mapping = mapping;
-    this.typeMatcher = typeMatcher;
+    super(mapping, typeMatcher);
   }
 
   public void addIncStrategy(ICDMethodChecker checker) {

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/CompMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/CompMethodChecker.java
@@ -10,8 +10,9 @@ import java.util.List;
 public class CompMethodChecker extends AbstractMethodChecker {
   private final List<ICDMethodChecker> methodCheckers = new ArrayList<>();
 
-  public CompMethodChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    super(mapping, typeMatcher);
+  public CompMethodChecker(String mapping, String underspecifiedTypeName,
+                           MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, underspecifiedTypeName, typeMatcher);
   }
 
   public void addIncStrategy(ICDMethodChecker checker) {

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/EqNameMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/EqNameMethodChecker.java
@@ -8,8 +8,7 @@ import java.util.stream.Collectors;
 
 public class EqNameMethodChecker extends AbstractMethodChecker {
   public EqNameMethodChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    this.mapping = mapping;
-    this.typeMatcher = typeMatcher;
+    super(mapping, typeMatcher);
   }
 
   @Override

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/EqNameMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/EqNameMethodChecker.java
@@ -7,8 +7,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class EqNameMethodChecker extends AbstractMethodChecker {
-  public EqNameMethodChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    super(mapping, typeMatcher);
+  public EqNameMethodChecker(String mapping, String underspecifiedTypeName,
+                             MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, underspecifiedTypeName, typeMatcher);
   }
 
   @Override

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/STNamedMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/STNamedMethodChecker.java
@@ -8,8 +8,7 @@ import java.util.stream.Collectors;
 
 public class STNamedMethodChecker extends AbstractMethodChecker {
   public STNamedMethodChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    this.mapping = mapping;
-    this.typeMatcher = typeMatcher;
+    super(mapping, typeMatcher);
   }
 
   @Override

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/STNamedMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/STNamedMethodChecker.java
@@ -8,8 +8,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class STNamedMethodChecker extends AbstractMethodChecker {
-  public STNamedMethodChecker(String mapping, MatchingStrategy<ASTCDType> typeMatcher) {
-    super(mapping, typeMatcher);
+  public STNamedMethodChecker(String mapping, String underspecifiedTypeName,
+                              MatchingStrategy<ASTCDType> typeMatcher) {
+    super(mapping, underspecifiedTypeName, typeMatcher);
   }
 
   @Override

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/method/STNamedMethodChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/method/STNamedMethodChecker.java
@@ -2,6 +2,7 @@ package de.monticore.cdconformance.conf.method;
 
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdconcretization.util.NameUtil;
 import de.monticore.cdmatcher.MatchingStrategy;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,7 +25,7 @@ public class STNamedMethodChecker extends AbstractMethodChecker {
     if (concrete.getModifier().isPresentStereotype()
         && concrete.getModifier().getStereotype().contains(mapping)) {
       String refName = concrete.getModifier().getStereotype().getValue(mapping);
-      return ref.getName().equals(refName);
+      return refType.getSpannedScope().resolveMethodMany(refName).contains(ref.getSymbol());
     }
     return false;
   }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/association/STNamedAssocIncStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/association/STNamedAssocIncStrategy.java
@@ -1,5 +1,7 @@
 package de.monticore.cdconformance.inc.association;
 
+import de.monticore.cd4code._symboltable.CD4CodeScope;
+import de.monticore.cd4code._symboltable.ICD4CodeScope;
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmatcher.MatchingStrategy;
@@ -29,7 +31,8 @@ public class STNamedAssocIncStrategy implements MatchingStrategy<ASTCDAssociatio
         && concrete.getModifier().getStereotype().contains(mapping)
         && ref.isPresentName()) {
       String refName = concrete.getModifier().getStereotype().getValue(mapping);
-      return ref.getName().equals(refName);
+      return ((ICD4CodeScope) refCD.getEnclosingScope())
+              .resolveCDAssociationDownMany(refName).contains(ref.getSymbol());
     }
     return false;
   }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/AttributeConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/AttributeConcretizationTest.java
@@ -104,13 +104,7 @@ class AttributeConcretizationTest extends AbstractCDConcretizationTest {
 
   @Test
   void testAttributeForEachAttribute() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance. Currently not possible because of any type
-    completer.setCheckConformance(false);
-
-    testConcretizedEqualsExpectedOut(
-        completer,
+    testConcretizedConformsToRefAndExpectedOut(
         "attributes/forEach/ForEachAttributeConc.cd",
         "attributes/forEach/ForEachAttributeRef.cd",
         "attributes/forEach/ForEachAttributeOut.cd");
@@ -118,13 +112,7 @@ class AttributeConcretizationTest extends AbstractCDConcretizationTest {
 
   @Test
   void testAttributeForEachAttributeDifferentName() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance. Currently not possible because of any type
-    completer.setCheckConformance(false);
-
-    testConcretizedEqualsExpectedOut(
-        completer,
+    testConcretizedConformsToRefAndExpectedOut(
         "attributes/forEach/ForEachAttributeDifferentNameConc.cd",
         "attributes/forEach/ForEachAttributeDifferentNameRef.cd",
         "attributes/forEach/ForEachAttributeDifferentNameOut.cd");
@@ -132,13 +120,7 @@ class AttributeConcretizationTest extends AbstractCDConcretizationTest {
 
   @Test
   void testAttributeForEachAttributeDifferentType() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance. Currently not possible because of any type
-    completer.setCheckConformance(false);
-
-    testConcretizedEqualsExpectedOut(
-        completer,
+    testConcretizedConformsToRefAndExpectedOut(
         "attributes/forEach/ForEachAttributeDifferentTypeConc.cd",
         "attributes/forEach/ForEachAttributeDifferentTypeRef.cd",
         "attributes/forEach/ForEachAttributeDifferentTypeOut.cd");
@@ -148,19 +130,13 @@ class AttributeConcretizationTest extends AbstractCDConcretizationTest {
    * We have different names of the 'forEach' annotated attribute and the reference target
    * attribute. Also, we have multiple incarnations of the class with the target attribute.
    * Therefore, the attributes in Builder class get two suffixes, one for the type incarnation and
-   * one for the target attribute incarnation name. TODO If we want to have one Builder incarnation
+   * one for the target attribute incarnation name. If we want to have one Builder incarnation
    * per type incarnation, we need to add an additional <<forEach="DataClass">> to the reference
    * Builder class
    */
   @Test
   void testAttributeForEachAttributeDifferentNameClassMI() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance. Currently not possible because of any type
-    completer.setCheckConformance(false);
-
-    testConcretizedEqualsExpectedOut(
-        completer,
+    testConcretizedConformsToRefAndExpectedOut(
         "attributes/forEach/ForEachAttributeDifferentNameClassMIConc.cd",
         "attributes/forEach/ForEachAttributeDifferentNameRef.cd",
         "attributes/forEach/ForEachAttributeDifferentNameClassMIOut.cd");
@@ -173,13 +149,7 @@ class AttributeConcretizationTest extends AbstractCDConcretizationTest {
   @Disabled("does not work until we have 'matchStructure' or 'optional stereotype")
   @Test
   void testAttributeForEachAttributeNoTargetIncarnations() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance. Currently not possible because of any type
-    completer.setCheckConformance(false);
-
-    testConcretizedEqualsExpectedOut(
-        completer,
+    testConcretizedConformsToRefAndExpectedOut(
         "attributes/forEach/ForEachAttributeNoTargetIncConc.cd",
         "attributes/forEach/ForEachAttributeNoTargetIncRef.cd",
         "attributes/forEach/ForEachAttributeNoTargetIncOut.cd");
@@ -191,14 +161,8 @@ class AttributeConcretizationTest extends AbstractCDConcretizationTest {
    */
   @Test
   void testAttributeTypeUnderspecifiedNoIncarnationError() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance. Currently not possible because of any type
-    completer.setCheckConformance(false);
-
     try {
       parseAndConcretize(
-          completer,
           "attributes/underspecified/AttributeTypeUnderspecifiedNoIncConc.cd",
           "attributes/underspecified/AttributeTypeUnderspecifiedRef.cd");
       fail("Expected CompletionException. But the concretization was successful.");
@@ -209,13 +173,7 @@ class AttributeConcretizationTest extends AbstractCDConcretizationTest {
 
   @Test
   void testAttributeTypeUnderspecifiedDifferentIncarnationTypes() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance. Currently not possible because of any type
-    completer.setCheckConformance(false);
-
-    testConcretizedEqualsExpectedOut(
-        completer,
+    testConcretizedConformsToRefAndExpectedOut(
         "attributes/underspecified/AttributeTypeUnderspecifiedDifferentIncTypesConc.cd",
         "attributes/underspecified/AttributeTypeUnderspecifiedRef.cd",
         "attributes/underspecified/AttributeTypeUnderspecifiedDifferentIncTypesOut.cd");

--- a/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
@@ -79,13 +79,7 @@ public class ConcretizationCompleterTest extends AbstractCDConcretizationTest {
 
   @Test
   void testAttributeTypeMI() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance! Currently not possible because conformance checker only checks for
-    // equal MCType (see #15)
-    completer.setCheckConformance(false);
-    testConcretizedEqualsExpectedOut(
-        completer,
+    testConcretizedConformsToRefAndExpectedOut(
         "multipleIncarnation/AttributeTypeMIConc.cd",
         "multipleIncarnation/AttributeTypeMIRef.cd",
         "multipleIncarnation/AttributeTypeMIOut.cd");

--- a/cddiff/src/test/java/de/monticore/cdconcretization/TypeConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/TypeConcretizationTest.java
@@ -47,13 +47,7 @@ public class TypeConcretizationTest extends AbstractCDConcretizationTest {
 
   @Test
   void testTypeForEachTypeForEachAttribute() {
-    ConcretizationCompleter completer =
-        new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
-    // TODO check conformance. Currently not possible because of any type
-    completer.setCheckConformance(false);
-
-    testConcretizedEqualsExpectedOut(
-        completer,
+    testConcretizedConformsToRefAndExpectedOut(
         "types/forEach/ForEachTypeForEachAttributeConc.cd",
         "types/forEach/ForEachTypeForEachAttributeRef.cd",
         "types/forEach/ForEachTypeForEachAttributeOut.cd");

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -160,6 +160,24 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
   }
 
   @ParameterizedTest
+  @ValueSource(strings = {"Concrete.cd"})
+  public void testAttributeTypeIncarnationValid(String concrete) {
+    parseModels("attributes/typeIncarnation/valid/" + concrete,
+            "attributes/typeIncarnation/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
+    assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref")));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"NotMarkedAsIncarnation.cd"})
+  public void testAttributeTypeIncarnationInvalid(String concrete) {
+    parseModels("attributes/typeIncarnation/invalid/" + concrete,
+            "attributes/typeIncarnation/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
+    assertFalse(checker.checkConformance(conCD, refCD, Set.of("ref")));
+  }
+
+  @ParameterizedTest
   @ValueSource(strings = {"AssocInSuperType.cd", "InhrBothSides.cd", "Valid1.cd"})
   public void testDeepAssocConformanceValid(String concrete) {
     parseModels("associations/valid/" + concrete, "associations/Reference.cd");

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -50,9 +50,10 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
     assertFalse(checker.checkConformance(conCD, refCD, Set.of("ref")));
   }
 
-  @Test
-  public void testMethodConformanceCheck() {
-    parseModels("methods/ValidMethods.cd", "methods/ReferenceMethods.cd");
+  @ParameterizedTest
+  @ValueSource(strings = {"ValidMethods.cd", "FQSTMatchValid.cd"})
+  public void testMethodConformanceCheck(String concrete) {
+    parseModels("methods/" + concrete, "methods/ReferenceMethods.cd");
     checker =
         new CDConformanceChecker(
             Set.of(
@@ -128,7 +129,15 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"EqName.cd", "STName.cd", "composed.cd"})
+  @ValueSource(strings = {"STMatch.cd", "FQSTMatch.cd"})
+  public void testTypeConformanceValid(String concrete) {
+    parseModels("types/valid/" + concrete, "types/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
+    assertTrue(checker.checkConformance(conCD, refCD, "ref"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"EqName.cd", "STName.cd", "composed.cd", "FQSTName.cd"})
   public void testAttributeConformanceValid(String concrete) {
     parseModels("attributes/valid/" + concrete, "attributes/Reference.cd");
     checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
@@ -178,7 +187,8 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"AssocInSuperType.cd", "InhrBothSides.cd", "Valid1.cd"})
+  @ValueSource(strings = {
+          "AssocInSuperType.cd", "InhrBothSides.cd", "Valid1.cd", "STMatch.cd", "FQSTMatch.cd"})
   public void testDeepAssocConformanceValid(String concrete) {
     parseModels("associations/valid/" + concrete, "associations/Reference.cd");
     checker = new CDConformanceChecker(Set.of(INHERITANCE, NAME_MAPPING, STEREOTYPE_MAPPING));

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -79,6 +79,24 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
     assertFalse(checker.checkConformance(conCD, refCD, Set.of("incarnates")));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"PrimitiveTypes.cd", "ClassIncarnation.cd"})
+  public void testMethodUnderspecifiedValid(String concrete) {
+    parseModels("methods/underspecified/valid/" + concrete,
+            "methods/underspecified/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
+    assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref")));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"AnyParamInConcrete.cd", "AnyReturnInConcrete.cd"})
+  public void testMethodypeUnderspecifiedInvalid(String concrete) {
+    parseModels("methods/underspecified/invalid/" + concrete,
+            "methods/underspecified/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
+    assertFalse(checker.checkConformance(conCD, refCD, Set.of("ref")));
+  }
+
   @Test
   public void testConformanceCheckAdapter() {
     parseModels("adapter/GraphAdapter.cd", "adapter/Adapter.cd");
@@ -182,6 +200,24 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
   public void testAttributeTypeIncarnationInvalid(String concrete) {
     parseModels("attributes/typeIncarnation/invalid/" + concrete,
             "attributes/typeIncarnation/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
+    assertFalse(checker.checkConformance(conCD, refCD, Set.of("ref")));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"PrimitiveTypes.cd", "ClassIncarnation.cd"})
+  public void testAttributeTypeUnderspecifiedValid(String concrete) {
+    parseModels("attributes/underspecified/valid/" + concrete,
+            "attributes/underspecified/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
+    assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref")));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"AnyInConcrete.cd"})
+  public void testAttributeTypeUnderspecifiedInvalid(String concrete) {
+    parseModels("attributes/underspecified/invalid/" + concrete,
+            "attributes/underspecified/Reference.cd");
     checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING));
     assertFalse(checker.checkConformance(conCD, refCD, Set.of("ref")));
   }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/valid/FQSTMatch.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/valid/FQSTMatch.cd
@@ -1,0 +1,16 @@
+import java.lang.String;
+
+classdiagram FQSTMatch {
+
+ abstract class AccountTop;
+ abstract class PersonTop;
+
+  class Account extends AccountTop;
+  class BankAccount extends AccountTop;
+
+  class Person  extends PersonTop;
+
+  association belongTo AccountTop    <-> Person[1];
+  <<ref="Reference.access">> association accountAccess   PersonTop     -> Account[*];
+}
+

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/valid/STMatch.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/valid/STMatch.cd
@@ -1,0 +1,16 @@
+import java.lang.String;
+
+classdiagram STMatch {
+
+ abstract class AccountTop;
+ abstract class PersonTop;
+
+  class Account extends AccountTop;
+  class BankAccount extends AccountTop;
+
+  class Person  extends PersonTop;
+
+  association belongTo AccountTop    <-> Person[1];
+  <<ref="access">> association accountAccess   PersonTop     -> Account[*];
+}
+

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/Reference.cd
@@ -1,0 +1,13 @@
+classdiagram Reference {
+
+  class Address {
+    String streetName;
+    String houseNr;
+    String city;
+    String zipCode;
+  }
+
+  class Employee {
+    Address address;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/NotMarkedAsIncarnation.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/NotMarkedAsIncarnation.cd
@@ -1,0 +1,13 @@
+classdiagram Concrete {
+
+  class AddressInfo {
+    String streetName;
+    String houseNr;
+    String city;
+    String zipCode;
+  }
+
+  class Employee {
+    AddressInfo address;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/valid/Concrete.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/valid/Concrete.cd
@@ -1,0 +1,13 @@
+classdiagram Concrete {
+
+  <<ref="Address">> class AddressInfo {
+    String streetName;
+    String houseNr;
+    String city;
+    String zipCode;
+  }
+
+  class Employee {
+    AddressInfo address;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/underspecified/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/underspecified/Reference.cd
@@ -1,0 +1,6 @@
+classdiagram Reference {
+  class Account {
+    any username;
+    any id;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/underspecified/invalid/AnyInConcrete.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/underspecified/invalid/AnyInConcrete.cd
@@ -1,0 +1,6 @@
+classdiagram Concrete {
+  class Account {
+    any username;
+    int id;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/underspecified/valid/ClassIncarnation.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/underspecified/valid/ClassIncarnation.cd
@@ -1,0 +1,10 @@
+import java.lang.String;
+
+classdiagram Concrete {
+  class Account {
+    String username;
+    AccountIdentifier id;
+  }
+
+  class AccountIdentifier;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/underspecified/valid/PrimitiveTypes.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/underspecified/valid/PrimitiveTypes.cd
@@ -1,0 +1,8 @@
+import java.lang.String;
+
+classdiagram Concrete {
+  class Account {
+    String username;
+    int id;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/valid/FQSTName.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/valid/FQSTName.cd
@@ -1,0 +1,9 @@
+import java.lang.String;
+
+classdiagram Concrete {
+  class Account {
+    <<ref="Account.username">> String name;
+    <<ref="Reference.Account.password">> boolean passcode;
+  }
+
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/methods/FQSTMatchValid.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/methods/FQSTMatchValid.cd
@@ -1,0 +1,14 @@
+/* (c) https://github.com/MontiCore/monticore */
+
+import java.lang.String;
+
+classdiagram FQSTMatchValid {
+
+  <<incarnates = "Operator">> class Exec {
+    <<incarnates = "Operator.operation">> boolean execute(String input, Config param);
+    <<incarnates = "ReferenceMethods.Operator.operation">> boolean execute2(String input, Config param);
+  }
+
+  <<incarnates = "Parameter">> class Config;
+
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/Reference.cd
@@ -1,0 +1,8 @@
+import java.lang.String;
+
+classdiagram Reference {
+
+  class Operator {
+    any operation(any input, any param);
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/invalid/AnyParamInConcrete.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/invalid/AnyParamInConcrete.cd
@@ -1,0 +1,8 @@
+import java.lang.String;
+
+classdiagram AnyParamInConcrete {
+
+  class Operator {
+    void operation(String input, any param);
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/invalid/AnyReturnInConcrete.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/invalid/AnyReturnInConcrete.cd
@@ -1,0 +1,8 @@
+import java.lang.String;
+
+classdiagram AnyReturnInConcrete {
+
+  class Operator {
+    any operation(String input, int param);
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/valid/ClassIncarnation.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/valid/ClassIncarnation.cd
@@ -1,0 +1,12 @@
+import java.lang.String;
+
+classdiagram ClassIncarnation {
+
+  class Operator {
+    OperationResult operation(Input input, Parameter param);
+  }
+
+  class Input;
+  class Parameter;
+  class OperationResult;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/valid/PrimitiveTypes.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/methods/underspecified/valid/PrimitiveTypes.cd
@@ -1,0 +1,9 @@
+import java.lang.String;
+
+classdiagram ReferenceMethods {
+
+  class Operator {
+    <<ref="operation">> void operation(String input, int param);
+    <<ref="operation">> String operation2(int input, String param);
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/types/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/types/Reference.cd
@@ -1,0 +1,3 @@
+classdiagram Reference {
+  class Account;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/types/valid/FQSTMatch.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/types/valid/FQSTMatch.cd
@@ -1,0 +1,3 @@
+classdiagram FQSTMatch {
+  <<ref="Reference.Account">> class MyAccount;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/types/valid/STMatch.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/types/valid/STMatch.cd
@@ -1,0 +1,3 @@
+classdiagram STMatch {
+  <<ref="Account">> class MyAccount;
+}


### PR DESCRIPTION
## Added
- A concrete attribute conforms to the reference attribute if its type is an incarnation of the reference attribute type
  - Logic was already implemented in `AbstractMethodChecker`, but was missing for attributes. Added with `AbstractAttributeChecker` 
- Allow full qualified names in incarnation mapping stereotype, e.g., ´BuilderPatternRef.DataClass´
- Support underspecified attribute, method return & parameter types using `any` placeholder type
  - The actual name of the underspecification placeholder type is configurable (same as in the cocnretization tool)