### PR TITLE
Fix: Make NavigableSetterDecorator application deactivatable

### DIFF
--- a/cdlang/src/main/java/de/monticore/cd/codegen/decorators/NavigableSetterDecorator.java
+++ b/cdlang/src/main/java/de/monticore/cd/codegen/decorators/NavigableSetterDecorator.java
@@ -37,43 +37,45 @@ public class NavigableSetterDecorator extends AbstractDecorator<AbstractDecorato
         || attribute.getModifier().isReadonly()
         || attribute.getModifier().isFinal()) return;
 
-    // For every attribute, for which the SetterDecorator has created methods:
-    var methods = decoratorData.getDecoratorData(SetterDecorator.class).methods.get(attribute);
-    if (methods == null || methods.isEmpty()) return;
+    if (decoratorData.shouldDecorate(this.getClass(), attribute)) {
+      // For every attribute, for which the SetterDecorator has created methods:
+      var methods = decoratorData.getDecoratorData(SetterDecorator.class).methods.get(attribute);
+      if (methods == null || methods.isEmpty()) return;
 
-    var role = this.decoratorData.fieldToRoles.get(attribute.getSymbol());
+      var role = this.decoratorData.fieldToRoles.get(attribute.getSymbol());
 
-    // And for which a role symbol was present (before being transformed away) and which is
-    // navigable in both directions
-    if (role == null
+      // And for which a role symbol was present (before being transformed away) and which is
+      // navigable in both directions
+      if (role == null
         || !role.isIsDefinitiveNavigable()
         || !role.getOtherSide().isIsDefinitiveNavigable()) return;
 
-    var otherClassOrig = (ASTCDClass) role.getOtherSide().getEnclosingScope().getAstNode();
-    var otherClassDec = decoratorData.getAsDecorated(otherClassOrig);
+      var otherClassOrig = (ASTCDClass) role.getOtherSide().getEnclosingScope().getAstNode();
+      var otherClassDec = decoratorData.getAsDecorated(otherClassOrig);
 
-    if (MCTypeFacade.getInstance().isBooleanType(attribute.getMCType())) {
-      Log.error("0xTODO: Unable to have a navigable assoc to a boolean", role.getSourcePosition());
-    } else if (MCCollectionSymTypeRelations.isList(attribute.getSymbol().getType())) {
-      Log.warn("0xTODO: WIP List NavSetter ", role.getSourcePosition());
-    } else if (MCCollectionSymTypeRelations.isSet(attribute.getSymbol().getType())) {
-      Log.warn("0xTODO: WIP Set NavSetter ", role.getSourcePosition());
-    } else if (MCCollectionSymTypeRelations.isOptional(attribute.getSymbol().getType())) {
-      Log.warn("0xTODO: WIP Optional NavSetter", role.getSourcePosition());
-    } else {
-      // Add set${role}Local method
-      decorateMandatoryLocal(otherClassDec, role.getOtherSide());
-      // Call ${role}.set${otherRole}Local when updating
-      methods.forEach(
-          m ->
-              glexOpt.ifPresent(
-                  g ->
-                      g.addAfterTemplate(
-                          "methods.Set",
-                          m,
-                          new TemplateHookPoint(
-                              "methods.CallLocal", role.getOtherSide().getName()))));
-      // TODO: Unset old?
+      if (MCTypeFacade.getInstance().isBooleanType(attribute.getMCType())) {
+        Log.error("0xTODO: Unable to have a navigable assoc to a boolean", role.getSourcePosition());
+      } else if (MCCollectionSymTypeRelations.isList(attribute.getSymbol().getType())) {
+        Log.warn("0xTODO: WIP List NavSetter ", role.getSourcePosition());
+      } else if (MCCollectionSymTypeRelations.isSet(attribute.getSymbol().getType())) {
+        Log.warn("0xTODO: WIP Set NavSetter ", role.getSourcePosition());
+      } else if (MCCollectionSymTypeRelations.isOptional(attribute.getSymbol().getType())) {
+        Log.warn("0xTODO: WIP Optional NavSetter", role.getSourcePosition());
+      } else {
+        // Add set${role}Local method
+        decorateMandatoryLocal(otherClassDec, role.getOtherSide());
+        // Call ${role}.set${otherRole}Local when updating
+        methods.forEach(
+            m ->
+                glexOpt.ifPresent(
+                    g ->
+                        g.addAfterTemplate(
+                            "methods.Set",
+                            m,
+                            new TemplateHookPoint(
+                                "methods.CallLocal", role.getOtherSide().getName()))));
+        // TODO: Unset old?
+      }
     }
   }
 


### PR DESCRIPTION
In contrast to other decorations added by [cd2java.init.CD2Pojo.ftl](https://github.com/MontiCore/cd4analysis/blob/c004505d0b48097fb38d6faf83753cdb21cd9dd6/cdlang/src/main/resources/cd2java/init/CD2Pojo.ftl#L4) ( [GetterDecorator](https://github.com/MontiCore/cd4analysis/blob/c004505d0b48097fb38d6faf83753cdb21cd9dd6/cdlang/src/main/java/de/monticore/cd/codegen/decorators/GetterDecorator.java), [SetterDecorator](https://github.com/MontiCore/cd4analysis/blob/c004505d0b48097fb38d6faf83753cdb21cd9dd6/cdlang/src/main/java/de/monticore/cd/codegen/decorators/SetterDecorator.java), etc.), [NavigableSetterDecorator](https://github.com/MontiCore/cd4analysis/blob/c004505d0b48097fb38d6faf83753cdb21cd9dd6/cdlang/src/main/java/de/monticore/cd/codegen/decorators/NavigableSetterDecorator.java) can not be deactivated via custom configuration templates, as it misses the check whether it should be applied.

This leads to an especially bizarre situation when attempting to deactivate both `SetterDecorator` and `NavigableSetterDecorator`: NavigableSetterDecorator errornously wants to execute and requests the decorator data that it expects to be left behind by SetterDecorator. As the latter did not run, as it was deactivated, a null value is produced and, in consequence, a NullPointerException is thrown.
```java
var methods = decoratorData.getDecoratorData(SetterDecorator.class).methods.get(attribute);
```

This merge request adds the check for applicability to the NavigableSetterDecorator.

The inserted check is the same as, for example, in [SetterDecorator](https://github.com/MontiCore/cd4analysis/blob/c004505d0b48097fb38d6faf83753cdb21cd9dd6/cdlang/src/main/java/de/monticore/cd/codegen/decorators/GetterDecorator.java#L38):
```java
if (decoratorData.shouldDecorate(this.getClass(), attribute)) { //...
```