### PR TITLE
Support trafo application between sym tab and cocos

### DIFF
--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -118,6 +118,8 @@ public class CDGenTool extends CDGeneratorTool {
         this.completeSymbolTable(ast);
       }
 
+      asts = this.trafoBeforeCoCos(asts);
+
       if (cmd.hasOption("c")) {
         Log.enableFailQuick(false);
         asts.forEach(this::runCoCos);
@@ -287,6 +289,18 @@ public class CDGenTool extends CDGeneratorTool {
     var t = CD4CodeMill.inheritanceTraverser();
     t.add4UMLModifier(new DefaultVisibilityPublicTrafo());
     asts.forEach(ast -> ast.accept(t));
+    return asts;
+  }
+
+  /**
+   * Applies the transformations (trafos) between symbol table creation and coco
+   * checking. Trafos are applied in place, that is, the input asts are mutated.
+   *
+   * @param asts The asts to be transformed
+   * @return The transformed asts
+   */
+  public Collection<ASTCDCompilationUnit> trafoBeforeCoCos(Collection<ASTCDCompilationUnit> asts) {
+    // TODO: see above: #4310
     return asts;
   }
 }


### PR DESCRIPTION
Currently, it is impossible with the [CDGenTool](https://github.com/MontiCore/cd4analysis/blob/c004505d0b48097fb38d6faf83753cdb21cd9dd6/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java) to perform trafos between symbol table creation and coco checking.
My use case for this is the addition of a constructor with args for all fields, _including inherited ones_. Example:
```
classdiagram X {
  class Foo {
    String f1;
    String f2;

   /*
     Implicit constructor:
     Foo(String f1, String f2);
   */
  }

  class Bar extends Foo {
    String b1;
    String b2;

   /*
     Implicit constructor:
     Bar(String  f1, String f2, String b1, String b2);
   */
  }
}
```
This constructor should already be present in exported symbol tables. Hence the `trafoBeforeCodegen` hook is called too late (it is actually not even called anymore at all in the CDGenTool – I guess this is an error). On the other side, we need symbol information to resolve all super types of the class to-be-transformed. Hence, the symbol table must already be built. Hence, the `trafoBeforeSymtab` hook is called too early.