### PR TITLE
feat(cdconc): unified adaptation of forEach parameter names

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
@@ -63,6 +63,12 @@ public class ConcretizationCompleter {
   private boolean reorderElements = true;
 
   /**
+   * If true, the name of the parameter element is replaced with its incarnation name in reference
+   * elements annotated with 'forEach'.
+   */
+  private boolean forEachNameAdaptationEnabled = true;
+
+  /**
    * Name of the placeholder type that is used to mark underspecified types in the reference CD. See
    * {@link UnderspecifiedPlaceholderType}.
    */
@@ -161,6 +167,10 @@ public class ConcretizationCompleter {
    */
   public void setUnderspecifiedPlaceholderTypeName(String underspecifiedPlaceholderTypeName) {
     this.underspecifiedPlaceholderTypeName = underspecifiedPlaceholderTypeName;
+  }
+
+  public void setForEachNameAdaptationEnabled(boolean forEachNameAdaptationEnabled) {
+    this.forEachNameAdaptationEnabled = forEachNameAdaptationEnabled;
   }
 
   /***
@@ -266,6 +276,11 @@ public class ConcretizationCompleter {
     @Override
     public String getUnderspecifiedPlaceholderTypeName() {
       return underspecifiedPlaceholderTypeName;
+    }
+
+    @Override
+    public boolean isForEachNameAdaptationEnabled() {
+      return forEachNameAdaptationEnabled;
     }
 
     @Override

--- a/cddiff/src/main/java/de/monticore/cdconcretization/cd/CDCompletionContext.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/cd/CDCompletionContext.java
@@ -45,6 +45,8 @@ public interface CDCompletionContext {
   /** Parameters for the conformance checker, that also influence the completion behavior. */
   Set<CDConfParameter> getConformanceParams();
 
+  boolean isForEachNameAdaptationEnabled();
+
   /**
    * @return the incarnation strategy that can be used to find incarnations of types in the current
    * context.

--- a/cddiff/src/main/java/de/monticore/cdconcretization/cd/TypeDetailsCDCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/cd/TypeDetailsCDCompleter.java
@@ -99,6 +99,11 @@ public class TypeDetailsCDCompleter extends AbstractCDCompleter {
     }
 
     @Override
+    public boolean isForEachNameAdaptationEnabled() {
+      return parentContext.isForEachNameAdaptationEnabled();
+    }
+
+    @Override
     public Set<CDConfParameter> getConformanceParams() {
       return parentContext.getConformanceParams();
     }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/cd/type/ForEachTypeInCDCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/cd/type/ForEachTypeInCDCompleter.java
@@ -71,21 +71,23 @@ public class ForEachTypeInCDCompleter extends AbstractTypeInCDCompleter {
     Log.debug("Found type incarnations for " + paramType.getName() + ": " + paramTypeIncarnations, LOG_NAME);
 
     for (ASTCDType paramTypeInc : paramTypeIncarnations) {
-      // if we have more than one type incarnation, we need to add a suffix to the new type
-      String paramIncName = SymbolUtil.getFullNameWithoutCD(paramTypeInc.getSymbol());
-      String typeSuffix = paramTypeIncarnations.size() > 1
-              ? "_" + NameUtil.escapeQualifiedNameAsIdentifier(paramIncName)
-              : "";
-
       ASTCDType newType = referenceType.deepClone();
 
-      // TODO maybe introduce convention for type names (issue 33)
-      // e.g., if the param type name is a substring of the reference type name, we replace it
-      // otherwise we append it with a suffix
-      newType.setName(referenceType.getName() + typeSuffix);
+      // 1. decide name of the new type
+      Optional<String> adaptedName = NameUtil.adaptTemplatedName(
+              referenceType.getName(), paramType.getName(), paramTypeInc.getName());
+      if (context.isForEachNameAdaptationEnabled() && adaptedName.isPresent()) {
+        newType.setName(adaptedName.get());
+      } else {
+        // Default: add the param incarnation name as suffix
+        String paramIncName = SymbolUtil.getFullNameWithoutCD(paramTypeInc.getSymbol());
+        String typeSuffix = paramTypeIncarnations.size() > 1
+                ? "_" + NameUtil.escapeQualifiedNameAsIdentifier(paramIncName)
+                : "";
+        newType.setName(referenceType.getName() + typeSuffix);
+      }
 
-      // remove forEach stereotype from concrete attribute but add a reference to the
-      // original attribute
+      // remove forEach stereotype from concrete type but add a reference to the original type
       StereotypeUtil.removeForEachStereotype(newType.getModifier());
       StereotypeUtil.addStereotype(
           newType.getModifier(), context.getMappingName(), referenceType.getSymbol().getFullName());
@@ -98,7 +100,7 @@ public class ForEachTypeInCDCompleter extends AbstractTypeInCDCompleter {
           .getScopedIncarnationBindings()
           .addTypeBinding(newTypeFullName, paramType.getSymbol(), paramTypeInc.getSymbol());
 
-      // 4. pass the new attribute to the next completer
+      // 4. pass the new type to the next completer
       super.completeTypeInCD(context.getConcreteCD().getCDDefinition(), newType, context);
     }
   }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/type/attribute/ForEachAttributeInTypeCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/type/attribute/ForEachAttributeInTypeCompleter.java
@@ -108,20 +108,22 @@ public class ForEachAttributeInTypeCompleter extends AbstractAttributeInTypeComp
       for (ASTCDAttribute paramAttributeInc : paramAttributeIncarnations) {
         // now we have a specific incarnation of the parameter attribute in the concrete CD.
         // we can now construct a new attribute based on this incarnation for the concrete type
-
-        // if we have more than one declaring type incarnation, we need to add a suffix to the
-        // new attributes
-        String attributeSuffix = paramAttributeIncarnations.size() > 1 ? "_" + paramAttributeInc.getName() : "";
-
         ASTCDAttribute newAttribute = referenceAttribute.deepClone();
 
         // 1. decide name of the new attribute
-        if (referenceAttribute.getName().equals(paramAttribute.getName())) {
-          // Convention: If the param attribute name matches the reference attribute name
-          // -> Use the param incarnation name without a suffix (but still a type suffix)
-          newAttribute.setName(paramAttributeInc.getName() + declaringTypeSuffix);
+        Optional<String> adaptedName = NameUtil.adaptTemplatedName(
+                        referenceAttribute.getName(),
+                        paramAttribute.getName(),
+                        paramAttributeInc.getName());
+        if (context.isForEachNameAdaptationEnabled() && adaptedName.isPresent()) {
+          newAttribute.setName(adaptedName.get() + declaringTypeSuffix);
         } else {
           // Default: add the param incarnation name as suffix
+          // if we have more than one declaring type incarnation, we need to add a suffix to the
+          // new attributes
+          String attributeSuffix = paramAttributeIncarnations.size() > 1
+                  ? "_" + paramAttributeInc.getName()
+                  : "";
           newAttribute.setName(
                   referenceAttribute.getName() + declaringTypeSuffix + attributeSuffix);
         }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/util/NameUtil.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/util/NameUtil.java
@@ -2,8 +2,10 @@ package de.monticore.cdconcretization.util;
 
 import de.monticore.cd.facade.MCQualifiedNameFacade;
 import de.se_rwth.commons.Names;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 public class NameUtil {
 
@@ -30,5 +32,51 @@ public class NameUtil {
    */
   public static String escapeQualifiedNameAsIdentifier(String qualifiedName) {
     return qualifiedName.replace('.', '_');
+  }
+
+  /**
+   * Adapts a template name in a given name with a certain value. This function can handle type names
+   * as well as variable names (attributes, parameters) and method names. It uses the following
+   * rules:
+   * <ul>
+   *   <li>
+   *     If the name contains the template, it replaces it with the value. e.g., if name is
+   *     'DataClassBuilder', template 'DataClass' and value 'Employee', the output is
+   *     'EmployeeBuilder'.
+   *   </li>
+   *   <li>
+   *     If the name starts with the uncapitalized template, it replaces it with the uncapitalized
+   *     value. e.g., if name is 'dataClass', template is 'DataClass', and value 'Employee', the
+   *     output is 'employee'.
+   *   </li>
+   *   <li>
+   *     If the name contains the capitalized template, it replaces it with the capitalized value.
+   *     e.g., if name is 'hasModifiedAttribute', template is 'attribute', and value is 'firstName',
+   *     the output is 'hasModifiedFirstName'.
+   *   </li>
+   * </ul>
+   *
+   * @param name the name to be modified.
+   * @param template the template to be replaced.
+   * @param value the value to replace the template with.
+   * @return an Optional containing the modified name if the template was found and replaced, or an
+   * empty Optional if the template was not found in the name.
+   */
+  public static Optional<String> adaptTemplatedName(String name, String template, String value) {
+    if (name.contains(template)) {
+      String newName = name.replace(template, value);
+      return Optional.of(newName);
+    } else if (name.startsWith(StringUtils.uncapitalize(template))) {
+      // e.g., if variable name is "dataClass" and template is "DataClass", we want to replace
+      // "dataClass" with "employee" if paramType is "Employee"
+      String newName = name.replaceFirst(StringUtils.uncapitalize(template), StringUtils.uncapitalize(value));
+      return Optional.of(newName);
+    } else  if (name.contains(StringUtils.capitalize(template))) {
+      // e.g., if variable name is "modifiedAttribute" and template is "attribute", we want to replace
+      // "Attribute" with "FirstName" if value is "firstName"
+      String newName = name.replace(StringUtils.capitalize(template), StringUtils.capitalize(value));
+      return Optional.of(newName);
+    }
+    return  Optional.empty();
   }
 }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/TypeConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/TypeConcretizationTest.java
@@ -32,6 +32,29 @@ public class TypeConcretizationTest extends AbstractCDConcretizationTest {
         "types/forEach/ForEachTypeOut.cd");
   }
 
+  @Test
+  void testTypeForEachTypeWithInfixReplacement() {
+    testConcretizedConformsToRefAndExpectedOut(
+            "types/forEach/ForEachTypeInfixReplaceConc.cd",
+            "types/forEach/ForEachTypeInfixReplaceRef.cd",
+            "types/forEach/ForEachTypeInfixReplaceOut.cd");
+  }
+
+  /**
+   * The reference model would allow for infix replacement of the forEach annotated type. However,
+   * we disable the feature.
+   */
+  @Test
+  void testTypeForEachTypeWithInfixReplacementDisabled() {
+    ConcretizationCompleter completer = new ConcretizationCompleter("ref", DEFAULT_CONFORMANCE_PARAMS);
+    completer.setForEachNameAdaptationEnabled(false);
+    testConcretizedEqualsExpectedOut(
+            completer,
+            "types/forEach/ForEachTypeInfixReplaceConc.cd",
+            "types/forEach/ForEachTypeInfixReplaceRef.cd",
+            "types/forEach/ForEachTypeInfixReplaceDisabledOut.cd");
+  }
+
   /**
    * We have no incarnation of the target type in the concrete CD. However, the default behavior is
    * to add the target type to the concrete CD if there is no incarnation. Thus, the forEach loop

--- a/cddiff/src/test/java/de/monticore/cdconcretization/util/NameUtilTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/util/NameUtilTest.java
@@ -1,0 +1,30 @@
+package de.monticore.cdconcretization.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NameUtilTest {
+
+  @ParameterizedTest
+  @MethodSource
+  void testAdaptTemplatedName(String name, String template, String value, Optional<String> expected) {
+    assertEquals(expected, NameUtil.adaptTemplatedName(name, template, value));
+  }
+
+  private static Stream<Arguments> testAdaptTemplatedName() {
+    return Stream.of(
+        Arguments.of("DataClassBuilder", "DataClass", "Employee", Optional.of("EmployeeBuilder")),
+        Arguments.of("DataClassBuilder", "NonExistingTemplate", "Employee", Optional.empty()),
+        Arguments.of("dataClass", "DataClass", "Employee", Optional.of("employee")),
+        Arguments.of("hasModifiedAttribute", "attribute", "firstName", Optional.of("hasModifiedFirstName")),
+        // An infix is only replaced if it matches the template exactly or capitalized, but NOT uncapitalized!
+        Arguments.of("testForlowercaseinfix", "LowerCaseInfix", "willNotBeUsed", Optional.empty())
+    );
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/forEach/ForEachAttributeDifferentTypeOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/forEach/ForEachAttributeDifferentTypeOut.cd
@@ -9,9 +9,9 @@ classdiagram ForEachAttributeDifferentTypeConc {
   }
 
   class Builder {
-    <<ref="ForEachAttributeDifferentTypeRef.Builder.hasModifiedAttribute">> boolean hasModifiedAttribute_firstName;
-    <<ref="ForEachAttributeDifferentTypeRef.Builder.hasModifiedAttribute">> boolean hasModifiedAttribute_lastName;
-    <<ref="ForEachAttributeDifferentTypeRef.Builder.hasModifiedAttribute">> boolean hasModifiedAttribute_number;
-    <<ref="ForEachAttributeDifferentTypeRef.Builder.hasModifiedAttribute">> boolean hasModifiedAttribute_salary;
+    <<ref="ForEachAttributeDifferentTypeRef.Builder.hasModifiedAttribute">> boolean hasModifiedFirstName;
+    <<ref="ForEachAttributeDifferentTypeRef.Builder.hasModifiedAttribute">> boolean hasModifiedLastName;
+    <<ref="ForEachAttributeDifferentTypeRef.Builder.hasModifiedAttribute">> boolean hasModifiedNumber;
+    <<ref="ForEachAttributeDifferentTypeRef.Builder.hasModifiedAttribute">> boolean hasModifiedSalary;
   }
 }

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/types/forEach/ForEachTypeInfixReplaceConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/types/forEach/ForEachTypeInfixReplaceConc.cd
@@ -1,0 +1,7 @@
+classdiagram ForEachTypeInfixReplaceConc {
+  <<ref="DataClass">> class Employee;
+
+  <<ref="DataClass">> class Department;
+
+  <<ref="DataClass">> class Company;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/types/forEach/ForEachTypeInfixReplaceDisabledOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/types/forEach/ForEachTypeInfixReplaceDisabledOut.cd
@@ -1,0 +1,19 @@
+classdiagram ForEachTypeInfixReplaceConc {
+  <<ref="DataClass">> class Employee;
+
+  <<ref="DataClass">> class Department;
+
+  <<ref="DataClass">> class Company;
+
+  <<ref="ForEachTypeRef.DataClassBuilder">> class DataClassBuilder_Employee {
+
+  }
+
+  <<ref="ForEachTypeRef.DataClassBuilder">> class DataClassBuilder_Department {
+
+  }
+
+  <<ref="ForEachTypeRef.DataClassBuilder">> class DataClassBuilder_Company{
+
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/types/forEach/ForEachTypeInfixReplaceOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/types/forEach/ForEachTypeInfixReplaceOut.cd
@@ -1,0 +1,19 @@
+classdiagram ForEachTypeInfixReplaceConc {
+  <<ref="DataClass">> class Employee;
+
+  <<ref="DataClass">> class Department;
+
+  <<ref="DataClass">> class Company;
+
+  <<ref="ForEachTypeRef.DataClassBuilder">> class EmployeeBuilder {
+
+  }
+
+  <<ref="ForEachTypeRef.DataClassBuilder">> class DepartmentBuilder {
+
+  }
+
+  <<ref="ForEachTypeRef.DataClassBuilder">> class CompanyBuilder {
+
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/types/forEach/ForEachTypeInfixReplaceRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/types/forEach/ForEachTypeInfixReplaceRef.cd
@@ -1,0 +1,11 @@
+classdiagram ForEachTypeRef {
+  class DataClass {
+
+  }
+
+  // DataClass is an infix of 'DataClassBuilder'. Therefore, 'DataClass' is replaced with the
+  // incarnation name of 'DataClass' in the output
+  <<forEach="DataClass">> class DataClassBuilder {
+
+  }
+}


### PR DESCRIPTION
## Added
`NameUtil.adaptTemplatedName(...)` provides shared logic for adapting reference model names annotated with forEach (currently only types & attributes)
- We replace:
  - infixes with exact match with the incarnation name
  - prefixes that match the decapitalized template name with decapitalized incarnation name
  - infixes that match the capitalized template name with the capitalized incarnation name
- name adaptation can be disabled if desired (maybe I'll refactor configuration parameters to something similar as `CDConfParameters` enum later on)
 - see test cases for examples