### PR TITLE
Fix: imports are not transferred from model to generated code

### DIFF
--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -194,7 +194,7 @@ public class CDGenTool extends CDGeneratorTool {
           // Post-Decorate: make methods in interfaces abstract
           this.makeMethodsInInterfacesAbstract(decorated.get());
           // Post-Decorate: map import statements to classes
-          this.mapCD4CImports(decorated);
+          this.mapCD4CImports(decorated.get());
 
           // Post-Decorate: TOP Decorator
           // TODO: #4310 - make this TOP decorator/transformation configurable via the config

--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -194,7 +194,7 @@ public class CDGenTool extends CDGeneratorTool {
           // Post-Decorate: make methods in interfaces abstract
           this.makeMethodsInInterfacesAbstract(decorated.get());
           // Post-Decorate: map import statements to classes
-          this.mapCD4CImports(ast);
+          this.mapCD4CImports(decorated);
 
           // Post-Decorate: TOP Decorator
           // TODO: #4310 - make this TOP decorator/transformation configurable via the config

--- a/cdlang/src/test/java/de/monticore/cdgen/CDGenToolTest.java
+++ b/cdlang/src/test/java/de/monticore/cdgen/CDGenToolTest.java
@@ -1,0 +1,97 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.cdgen;
+
+import de.monticore.cd4code.CD4CodeMill;
+import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.se_rwth.commons.Names;
+import de.se_rwth.commons.logging.LogStub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class CDGenToolTest {
+
+  @TempDir
+  Path inputDir;
+
+  @TempDir
+  Path outputDir;
+
+  @BeforeEach
+  public void before() {
+    CD4CodeMill.globalScope().clear();
+    CD4CodeMill.reset();
+    BasicSymbolsMill.reset();
+    LogStub.init();
+  }
+
+  @Test
+  void testTransfersImportStatements() {
+    // Given
+    String packageName = "P";
+    String diagramName = "D";
+    String className = "C";
+
+    String importStatement = "import java.nio.file.Path;";
+
+    String model = String.format(
+      "package %s;" +
+        "%s" +
+        "classdiagram %s {" +
+        "  class %s { }" +
+        "}", packageName, importStatement, diagramName, className);
+
+    createModelInInputDir(model, packageName, diagramName);
+
+    CDGenTool tool = new CDGenTool();
+
+    // When
+    tool.run(new String[]{
+      "-i", inputDir.toAbsolutePath().toString(),
+      "-o", outputDir.toAbsolutePath().toString(),
+      "-c2mc"
+    });
+
+    // Then
+    Path diagramTgtPath =
+      outputDir.toAbsolutePath()
+        .resolve(Names.getPathFromPackage(packageName))
+        .resolve(diagramName)
+        .resolve(className + ".java");
+
+    assertTrue(diagramTgtPath.toFile().isFile());
+
+    try {
+      String generated = Files.readString(diagramTgtPath, StandardCharsets.UTF_8);
+      assertTrue(generated.contains(importStatement), () -> "Missing import in: " + generated);
+    } catch (IOException e) {
+      fail(e.getMessage());
+    }
+  }
+
+  protected void createModelInInputDir(String model, String packageName, String diagramName) {
+    Path packagePath = inputDir.resolve(Path.of(Names.getPathFromPackage(packageName)));
+    Path diagramPath = inputDir.resolve(packagePath.resolve(diagramName + ".cd"));
+
+    packagePath.toFile().mkdirs();
+    try {
+      Files.writeString(
+        diagramPath,
+        model,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE
+      );
+    } catch (IOException e) {
+      fail(e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
There is a bug in https://github.com/MontiCore/cd4analysis/pull/25 
Imports are not prepared for the decorated CDs, which are the basis for generation, but on the original ASTs. As a consequence, the imports are not transferred from the original models to the generated code.

(Registering the imports of the original AST puts the original AST and its imports in a map. However, during generation, that Map is queried with the decorated AST and its imports. As they are different objects, the Map look-up fails)

I added a test case for demonstration purposes and to assert that the fix works