### PR TITLE
Output decorated symboltables

### DIFF
--- a/cdlang/src/main/java/de/monticore/CDGeneratorTool.java
+++ b/cdlang/src/main/java/de/monticore/CDGeneratorTool.java
@@ -464,12 +464,14 @@ public class CDGeneratorTool extends CD4CodeTool {
     }
     for (ASTCDInterface cdInterface : ast.getCDDefinition().getCDInterfacesList()) {
       for (ASTMCImportStatement i : imports) {
-        cd4c.addImport(cdInterface, i.getQName());
+        String qName = i.getQName();
+        cd4c.addImport(cdInterface, i.isStar() ? qName + ".*" : qName);
       }
     }
     for (ASTCDEnum cdEnum : ast.getCDDefinition().getCDEnumsList()) {
       for (ASTMCImportStatement i : imports) {
-        cd4c.addImport(cdEnum, i.getQName());
+        String qName = i.getQName();
+        cd4c.addImport(cdEnum, i.isStar() ? qName + ".*" : qName);
       }
     }
   }

--- a/cdlang/src/main/java/de/monticore/cd/codegen/DecoratorConfig.java
+++ b/cdlang/src/main/java/de/monticore/cd/codegen/DecoratorConfig.java
@@ -196,7 +196,7 @@ public class DecoratorConfig {
     }
 
     if (!phases.isEmpty() && phases.get(0).decorators.stream().noneMatch(d->d instanceof ICreator)) {
-      Log.error("0xTODO: Missing creating decorator (such as withCopyCreator())");
+      Log.error("0xCDD10: Missing creating decorator (such as withCopyCreator())");
     }
 
     return phases;
@@ -229,14 +229,14 @@ public class DecoratorConfig {
       String afterAsString = CD4CodeMill.prettyPrint(root, true);
       if (!initialAsString.equals(afterAsString)) {
         Log.error(
-            "0xTODO: A Decorator of phase "
+            "0xCDD30: A Decorator of phase "
                 + phase.decorators
                 + " has modified the original CD instead of the decorated CD");
       }
     }
 
     if (!(decoratorData.getData(ICreator.class) instanceof ICreator.ICreatedData)) {
-      Log.error("0xTODO: Missing creating decorator (such as withCopyCreator())");
+      Log.error("0xCDD11: Missing creating decorator (such as withCopyCreator())");
       return Optional.empty();
     }
 

--- a/cdlang/src/main/java/de/monticore/cd/codegen/decorators/GetterDecorator.java
+++ b/cdlang/src/main/java/de/monticore/cd/codegen/decorators/GetterDecorator.java
@@ -237,24 +237,24 @@ public class GetterDecorator extends AbstractDecorator<AbstractDecorator.NoData>
 
   protected static final String CONTAINS = "public boolean contains%s(Object element);";
   protected static final String CONTAINS_ALL =
-      "public boolean containsAll%s(Collection<?> collection);";
+      "public boolean containsAll%s(java.util.Collection<?> collection);";
   protected static final String IS_EMPTY = "public boolean isEmpty%s();";
-  protected static final String ITERATOR = "public Iterator<%s> iterator%s();";
+  protected static final String ITERATOR = "public java.util.Iterator<%s> iterator%s();";
   protected static final String SIZE = "public int size%s();";
   protected static final String TO_ARRAY = "public %s[] toArray%s(%s[] array);";
   protected static final String TO_ARRAY_ = "public Object[] toArray%s();";
-  protected static final String SPLITERATOR = "public Spliterator<%s> spliterator%s();";
-  protected static final String STREAM = "public Stream<%s> stream%s();";
-  protected static final String PARALLEL_STREAM = "public Stream<%s> parallelStream%s();";
+  protected static final String SPLITERATOR = "public java.util.Spliterator<%s> spliterator%s();";
+  protected static final String STREAM = "public java.util.stream.Stream<%s> stream%s();";
+  protected static final String PARALLEL_STREAM = "public java.util.stream.Stream<%s> parallelStream%s();";
   protected static final String GET = "public %s get%s(int index);";
   protected static final String INDEX_OF = "public int indexOf%s(Object element);";
   protected static final String LAST_INDEX_OF = "public int lastIndexOf%s(Object element);";
   protected static final String EQUALS = "public boolean equals%s(Object o);";
   protected static final String HASHCODE = "public int hashCode%s();";
-  protected static final String LIST_ITERATOR = "public ListIterator<%s> listIterator%s();";
+  protected static final String LIST_ITERATOR = "public java.util.ListIterator<%s> listIterator%s();";
   protected static final String LIST_ITERATOR_ =
-      "public ListIterator<%s> listIterator%s(int index);";
-  protected static final String SUBLIST = "public List<%s> subList%s(int start, int end);";
+      "public java.util.ListIterator<%s> listIterator%s(int index);";
+  protected static final String SUBLIST = "public java.util.List<%s> subList%s(int start, int end);";
 
   protected void updateModifier(ASTCDAttribute attribute) {
     var decoratedModifier = decoratorData.getAsDecorated(attribute).getModifier();

--- a/cdlang/src/main/java/de/monticore/cd/codegen/decorators/NavigableSetterDecorator.java
+++ b/cdlang/src/main/java/de/monticore/cd/codegen/decorators/NavigableSetterDecorator.java
@@ -58,7 +58,7 @@ public class NavigableSetterDecorator extends AbstractDecorator<AbstractDecorato
       var otherClassDec = decoratorData.getAsDecorated(otherClassOrig);
 
       if (MCTypeFacade.getInstance().isBooleanType(attribute.getMCType())) {
-        Log.error("0xTODO: Unable to have a navigable assoc to a boolean", role.getSourcePosition());
+        Log.error("0xCDD60: Unable to have a navigable assoc to a boolean", role.getSourcePosition());
       } else if (MCCollectionSymTypeRelations.isList(attribute.getSymbol().getType())) {
         Log.warn("0xTODO: WIP List NavSetter ", role.getSourcePosition());
       } else if (MCCollectionSymTypeRelations.isSet(attribute.getSymbol().getType())) {

--- a/cdlang/src/main/java/de/monticore/cd/codegen/decorators/data/DecoratorData.java
+++ b/cdlang/src/main/java/de/monticore/cd/codegen/decorators/data/DecoratorData.java
@@ -30,6 +30,8 @@ import java.util.function.Supplier;
 
 public class DecoratorData {
 
+  public final static String INTERNAL_ERROR_CODE = "0xCDD00";
+
   // TODO: If not found, walk upwards up to IDecorator
   public Map<Class<? extends IDecorator>, Object> decoratorDataMap = new IdentityHashMap<>();
   public Map<FieldSymbol, CDRoleSymbol> fieldToRoles; // Assoc -> Field
@@ -145,7 +147,7 @@ public class DecoratorData {
       result = matchCDCU((ASTCDCompilationUnit) node, matcherData);
     } else {
       Log.error(
-        "0xTODO: Unable add to parent of unknown type " + node.getClass().getName(),
+        INTERNAL_ERROR_CODE + ": Unable add to parent of unknown type " + node.getClass().getName(),
         node.get_SourcePositionStart());
       throw new IllegalStateException(
         "Unable add to parent of unknown type " + node.getClass().getName());

--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -215,7 +215,7 @@ public class CDGenTool extends CDGeneratorTool {
           var decorated = decSetup.decorate(ast, roleTrafo.getFieldToRoles(), Optional.of(glex));
 
           if (decorated.isEmpty()) {
-            Log.error("0xTODO: Failed generation for " + ast.getCDDefinition().getName());
+            Log.error("0xCDD12: Failed generation for " + ast.getCDDefinition().getName());
             continue;
           }
 

--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -2,19 +2,27 @@
 package de.monticore.cdgen;
 
 import de.monticore.CDGeneratorTool;
+import de.monticore.cd._visitor.CDElementVisitor;
 import de.monticore.cd.codegen.CDGenerator;
 import de.monticore.cd.codegen.CdUtilsPrinter;
 import de.monticore.cd.codegen.DecoratorConfig;
 import de.monticore.cd.codegen.trafo.DefaultVisibilityPublicTrafo;
 import de.monticore.cd.codegen.trafo.TOPTrafo;
+import de.monticore.cd.facade.MCQualifiedNameFacade;
+import de.monticore.cd.methodtemplates.CD4C;
 import de.monticore.cd4analysis.trafo.CDAssociationCreateFieldsFromAllRoles;
 import de.monticore.cd4analysis.trafo.CDAssociationCreateFieldsFromNavigableRoles;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._symboltable.ICD4CodeArtifactScope;
 import de.monticore.cd4code._visitor.CD4CodeTraverser;
 import de.monticore.cdbasis.CDBasisMill;
+import de.monticore.cdbasis._ast.ASTCDClass;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
+import de.monticore.cdbasis._ast.ASTCDElement;
+import de.monticore.cdbasis._ast.ASTCDType;
 import de.monticore.cdbasis.trafo.CDBasisDefaultPackageTrafo;
+import de.monticore.cdinterfaceandenum._ast.ASTCDEnum;
+import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
 import de.monticore.generating.GeneratorSetup;
 import de.monticore.generating.templateengine.GlobalExtensionManagement;
 import de.monticore.generating.templateengine.TemplateController;
@@ -22,6 +30,8 @@ import de.monticore.generating.templateengine.TemplateHookPoint;
 import de.monticore.io.paths.MCPath;
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
 import de.monticore.types.MCTypeFacade;
+import de.monticore.types.mcbasictypes.MCBasicTypesMill;
+import de.monticore.types.mcbasictypes._ast.ASTMCImportStatement;
 import de.monticore.types.mccollectiontypes.types3.MCCollectionSymTypeRelations;
 import de.se_rwth.commons.Names;
 import de.se_rwth.commons.logging.Log;
@@ -192,7 +202,7 @@ public class CDGenTool extends CDGeneratorTool {
 
         hpp.processValue(tc, configTemplateArgs);
 
-        if (cmd.hasOption("s")) {
+        if (cmd.hasOption("sd")) {
           // Prepare the global scope for decorated symbol table
           this.initDecoratedGlobalScope(c2mc);
         }
@@ -221,9 +231,9 @@ public class CDGenTool extends CDGeneratorTool {
           // The following imports (cf. Imports.ftl) have to be added
           decorated.get().addMCImportStatement(CDBasisMill.mCImportStatementBuilder().setMCQualifiedName(MCTypeFacade.getInstance().createQualifiedName("java.util")).setStar(true).build());
 
-          if (cmd.hasOption("s")) {
+          if (cmd.hasOption("sd")) {
             // If required, we also output the symbol table of the *decorated* AST
-            this.createAndExportDecoratedSymbolTable(decorated.get(), cmd.getOptionValue("s"));
+            this.createAndExportDecoratedSymbolTable(decorated.get(), cmd.getOptionValue("sd"));
           }
 
           // Post-Decorate: TOP Decorator
@@ -342,6 +352,13 @@ public class CDGenTool extends CDGeneratorTool {
             .argName("fqn:key[=value]")
             .build());
 
+    options.addOption(org.apache.commons.cli.Option.builder("sd")
+      .longOpt("symboltabledecorated")
+      .argName("file")
+      .hasArg()
+      .desc("Serializes the decorated symbol table of the given artifact.")
+      .build());
+
     return options;
   }
 
@@ -372,5 +389,33 @@ public class CDGenTool extends CDGeneratorTool {
     t.add4UMLModifier(new DefaultVisibilityPublicTrafo());
     asts.forEach(ast -> ast.accept(t));
     return asts;
+  }
+
+  /**
+   * Updates the map of cd types to import statement in the given cd4c object, adding the imports
+   * for each cd type (classes, enums, and interfaces) defined in the given ast.
+   *
+   * @param ast the input ast
+   */
+  public void mapCD4CImports(ASTCDCompilationUnit ast) {
+    CD4C cd4c = CD4C.getInstance();
+    List<ASTMCImportStatement> imports = ast.getMCImportStatementList();
+
+    for (ASTCDClass cdClass : ast.getCDDefinition().getCDClassesList()) {
+      for (ASTMCImportStatement i : imports) {
+        String qName = i.getQName();
+        cd4c.addImport(cdClass, i.isStar() ? qName + ".*" : qName);
+      }
+    }
+    for (ASTCDInterface cdInterface : ast.getCDDefinition().getCDInterfacesList()) {
+      for (ASTMCImportStatement i : imports) {
+        cd4c.addImport(cdInterface, i.getQName());
+      }
+    }
+    for (ASTCDEnum cdEnum : ast.getCDDefinition().getCDEnumsList()) {
+      for (ASTMCImportStatement i : imports) {
+        cd4c.addImport(cdEnum, i.getQName());
+      }
+    }
   }
 }

--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -409,12 +409,14 @@ public class CDGenTool extends CDGeneratorTool {
     }
     for (ASTCDInterface cdInterface : ast.getCDDefinition().getCDInterfacesList()) {
       for (ASTMCImportStatement i : imports) {
-        cd4c.addImport(cdInterface, i.getQName());
+        String qName = i.getQName();
+        cd4c.addImport(cdInterface, i.isStar() ? qName + ".*" : qName);
       }
     }
     for (ASTCDEnum cdEnum : ast.getCDDefinition().getCDEnumsList()) {
       for (ASTMCImportStatement i : imports) {
-        cd4c.addImport(cdEnum, i.getQName());
+        String qName = i.getQName();
+        cd4c.addImport(cdEnum, i.isStar() ? qName + ".*" : qName);
       }
     }
   }

--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -23,6 +23,7 @@ import de.monticore.io.paths.MCPath;
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
 import de.monticore.types.MCTypeFacade;
 import de.monticore.types.mccollectiontypes.types3.MCCollectionSymTypeRelations;
+import de.se_rwth.commons.Names;
 import de.se_rwth.commons.logging.Log;
 import java.io.File;
 import java.nio.file.Path;
@@ -105,6 +106,13 @@ public class CDGenTool extends CDGeneratorTool {
           this.parse(".cd", this.createModelPath(cmd).getEntries());
       Log.enableFailQuick(true);
 
+      // Run CoCos
+      if (cmd.hasOption("c")) {
+        Log.enableFailQuick(false);
+        asts.forEach(this::runBeforeSTCoCos);
+        Log.enableFailQuick(true);
+      }
+
       // apply trafos needed for symbol table creation
       asts = this.trafoBeforeSymtab(asts);
 
@@ -124,10 +132,18 @@ public class CDGenTool extends CDGeneratorTool {
         this.completeSymbolTable(ast);
       }
 
+      // Run CoCos
       if (cmd.hasOption("c")) {
         Log.enableFailQuick(false);
         asts.forEach(this::runCoCos);
         Log.enableFailQuick(true);
+      }
+
+      // Export original symbol table
+      if (cmd.hasOption("s")) {
+        for (ICD4CodeArtifactScope scope : scopes) {
+          this.storeSymTab(scope, cmd.getOptionValue("s"));
+        }
       }
 
       if (cmd.hasOption("o")) {
@@ -176,6 +192,11 @@ public class CDGenTool extends CDGeneratorTool {
 
         hpp.processValue(tc, configTemplateArgs);
 
+        if (cmd.hasOption("s")) {
+          // Prepare the global scope for decorated symbol table
+          this.initDecoratedGlobalScope(c2mc);
+        }
+
         List<ASTCDCompilationUnit> decoratedASTs = new ArrayList<>();
         for (ASTCDCompilationUnit ast : asts) {
           // Prepare
@@ -195,10 +216,18 @@ public class CDGenTool extends CDGeneratorTool {
           // Post-Decorate: make methods in interfaces abstract
           this.makeMethodsInInterfacesAbstract(decorated.get());
           // Post-Decorate: map import statements to classes
-          this.mapCD4CImports(ast);
+          this.mapCD4CImports(decorated.get());
+
+          // The following imports (cf. Imports.ftl) have to be added
+          decorated.get().addMCImportStatement(CDBasisMill.mCImportStatementBuilder().setMCQualifiedName(MCTypeFacade.getInstance().createQualifiedName("java.util")).setStar(true).build());
+
+          if (cmd.hasOption("s")) {
+            // If required, we also output the symbol table of the *decorated* AST
+            this.createAndExportDecoratedSymbolTable(decorated.get(), cmd.getOptionValue("s"));
+          }
 
           // Post-Decorate: TOP Decorator
-          // TODO: #4310 - make this TOP decorator/transformation configurable via the config
+          // TODO: #4310 - make this TOP transformation configurable via the config
           // template
           TOPTrafo topTransformer = new TOPTrafo(setup.getHandcodedPath());
           t = CD4CodeMill.inheritanceTraverser();
@@ -206,40 +235,6 @@ public class CDGenTool extends CDGeneratorTool {
           decorated.get().accept(t);
 
           generator.generate(decorated.get());
-
-          decoratedASTs.add(decorated.get());
-
-          // The following imports (cf. Imports.ftl) have to be added
-          decorated.get().addMCImportStatement(CDBasisMill.mCImportStatementBuilder().setMCQualifiedName(MCTypeFacade.getInstance().createQualifiedName("java.util")).setStar(true).build());
-
-        }
-        if (cmd.hasOption("s")) {
-          // TODO: Move before generator trafos (such as TOP)
-          // If required, we also output the symbol table of the *decorated* AST
-          if (!c2mc) {
-            // Without Class2MC we must add fake-symbols for field, arg and return types used during decoration
-            for (Class<?> c : Arrays.asList(List.class, Set.class,
-              Collection.class, Iterator.class,
-              Spliterator.class, Stream.class, Optional.class)) {
-              CDBasisMill.globalScope().add(
-                CDBasisMill.typeSymbolBuilder()
-                  .setName(c.getSimpleName())
-                  .setFullName(c.getName())
-                  .setSpannedScope(CDBasisMill.scope())
-                  .setEnclosingScope(CDBasisMill.globalScope())
-                  .build());
-            }
-          }
-          for (var decorated : decoratedASTs) {
-            // Create the symbol-table (symbol table creation phase 1)
-            var decoratedScope = this.createSymbolTable(decorated, true);
-
-            // Complete the symbol-table (symbol table creation phase 2)
-            this.completeSymbolTable(decorated);
-
-            // Store the decorated symbol table
-            this.storeSymTab(decoratedScope, cmd.getOptionValue("s"));
-          }
         }
       }
     } catch (ParseException e) {
@@ -247,6 +242,46 @@ public class CDGenTool extends CDGeneratorTool {
       Log.error("0xA7105 Could not process parameters: " + e.getMessage());
     }
     CD4CodeMill.globalScope().clear();
+  }
+
+  /**
+   * Without Class2MC, we have to load symbols used in the generated CD
+   * @param c2mc whether Class2MC was loaded
+   */
+  public void initDecoratedGlobalScope(boolean c2mc) {
+    if (!c2mc) {
+      // Without Class2MC we must add fake-symbols for field, arg and return types used during decoration
+      // Load these symbols from an exported symbol table
+      for (Class<?> c : Arrays.asList(List.class, Set.class,
+        Collection.class, Iterator.class,
+        Spliterator.class, Stream.class, Optional.class)) {
+        CDBasisMill.globalScope().add(
+          CDBasisMill.typeSymbolBuilder()
+            .setName(c.getSimpleName())
+            .setFullName(c.getName())
+            .setSpannedScope(CDBasisMill.scope())
+            .setEnclosingScope(CDBasisMill.globalScope())
+            .build());
+      }
+    }
+  }
+
+  /**
+   * Create, complete, and export the symbol table of a decorated CD
+   * @param decorated the CD
+   * @param symbolOutPath the directory into which the ST is exported
+   */
+  public void createAndExportDecoratedSymbolTable(ASTCDCompilationUnit decorated, String symbolOutPath) {
+    // Create the symbol-table (symbol table creation phase 1)
+    var decoratedScope = this.createSymbolTable(decorated, true);
+
+    // Complete the symbol-table (symbol table creation phase 2)
+    this.completeSymbolTable(decorated);
+
+    // Store the decorated symbol table
+    this.storeSymbols(
+      decoratedScope,
+      Paths.get(symbolOutPath, Names.getPathFromPackage(decoratedScope.getFullName()) + ".deccdsym").toString());
   }
 
   /**
@@ -311,9 +346,19 @@ public class CDGenTool extends CDGeneratorTool {
   }
 
   /**
-   * checks all cocos on the current ast
+   * checks all cocos on the original ast before the symbol table is created
    *
-   * @param ast the current ast
+   * @param ast the original ast, without ST
+   */
+  public void runBeforeSTCoCos(ASTCDCompilationUnit ast) {
+    // Nothing yet, decide how we expose them
+  }
+
+
+  /**
+   * checks all cocos on the original ast
+   *
+   * @param ast the original ast
    */
   public void runCoCos(ASTCDCompilationUnit ast) {
     super.runCoCos(ast);

--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -12,6 +12,7 @@ import de.monticore.cd4analysis.trafo.CDAssociationCreateFieldsFromNavigableRole
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._symboltable.ICD4CodeArtifactScope;
 import de.monticore.cd4code._visitor.CD4CodeTraverser;
+import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.trafo.CDBasisDefaultPackageTrafo;
 import de.monticore.generating.GeneratorSetup;
@@ -20,6 +21,7 @@ import de.monticore.generating.templateengine.TemplateController;
 import de.monticore.generating.templateengine.TemplateHookPoint;
 import de.monticore.io.paths.MCPath;
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.monticore.types.MCTypeFacade;
 import de.monticore.types.mccollectiontypes.types3.MCCollectionSymTypeRelations;
 import de.se_rwth.commons.logging.Log;
 import java.io.File;
@@ -27,11 +29,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.cli.*;
 
 /**
  * This class is a further development of the {@link CDGeneratorTool} and meant as a replacement. It
- * provides configurable decorator functionality in addition to generation
+ * provides configurable decorator functionality in addition to generation.
+ * This tool is tested via the CDGenGradlePluginTest:
+ * cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
  */
 public class CDGenTool extends CDGeneratorTool {
 
@@ -124,12 +130,6 @@ public class CDGenTool extends CDGeneratorTool {
         Log.enableFailQuick(true);
       }
 
-      if (cmd.hasOption("s")) {
-        for (ICD4CodeArtifactScope scope : scopes) {
-          this.storeSymTab(scope, cmd.getOptionValue("s"));
-        }
-      }
-
       if (cmd.hasOption("o")) {
         GlobalExtensionManagement glex = new GlobalExtensionManagement();
         glex.setGlobalValue("cdPrinter", new CdUtilsPrinter());
@@ -176,6 +176,7 @@ public class CDGenTool extends CDGeneratorTool {
 
         hpp.processValue(tc, configTemplateArgs);
 
+        List<ASTCDCompilationUnit> decoratedASTs = new ArrayList<>();
         for (ASTCDCompilationUnit ast : asts) {
           // Prepare
           glex.setGlobalValue("cdPrinter", new CdUtilsPrinter());
@@ -205,9 +206,42 @@ public class CDGenTool extends CDGeneratorTool {
           decorated.get().accept(t);
 
           generator.generate(decorated.get());
+
+          decoratedASTs.add(decorated.get());
+
+          // The following imports (cf. Imports.ftl) have to be added
+          decorated.get().addMCImportStatement(CDBasisMill.mCImportStatementBuilder().setMCQualifiedName(MCTypeFacade.getInstance().createQualifiedName("java.util")).setStar(true).build());
+
+        }
+        if (cmd.hasOption("s")) {
+          // TODO: Move before generator trafos (such as TOP)
+          // If required, we also output the symbol table of the *decorated* AST
+          if (!c2mc) {
+            // Without Class2MC we must add fake-symbols for field, arg and return types used during decoration
+            for (Class<?> c : Arrays.asList(List.class, Set.class,
+              Collection.class, Iterator.class,
+              Spliterator.class, Stream.class, Optional.class)) {
+              CDBasisMill.globalScope().add(
+                CDBasisMill.typeSymbolBuilder()
+                  .setName(c.getSimpleName())
+                  .setFullName(c.getName())
+                  .setSpannedScope(CDBasisMill.scope())
+                  .setEnclosingScope(CDBasisMill.globalScope())
+                  .build());
+            }
+          }
+          for (var decorated : decoratedASTs) {
+            // Create the symbol-table (symbol table creation phase 1)
+            var decoratedScope = this.createSymbolTable(decorated, true);
+
+            // Complete the symbol-table (symbol table creation phase 2)
+            this.completeSymbolTable(decorated);
+
+            // Store the decorated symbol table
+            this.storeSymTab(decoratedScope, cmd.getOptionValue("s"));
+          }
         }
       }
-
     } catch (ParseException e) {
       CD4CodeMill.globalScope().clear();
       Log.error("0xA7105 Could not process parameters: " + e.getMessage());

--- a/cdtool/cdgradle/build.gradle
+++ b/cdtool/cdgradle/build.gradle
@@ -16,9 +16,10 @@ dependencies {
   cdTool group: 'de.monticore.lang', name: 'cd4analysis', version: mc_version
   compileOnly(project(":cdlang")) // As the main/cdtool dependency does not have an api dependency to cdlang
 
-  testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
-  testImplementation "org.junit.vintage:junit-vintage-engine:$junit_version"
+  testImplementation "org.junit.jupiter:junit-jupiter:$junit_version"
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
   testImplementation gradleTestKit()
+  testImplementation(project(":cdlang")) // For symbol table tests, etc.
 }
 
 

--- a/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenGradlePlugin.java
+++ b/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenGradlePlugin.java
@@ -61,7 +61,8 @@ public class CDGenGradlePlugin implements Plugin<Project> {
 
                             genTask.getInput().from(cdSrcDirSet.getSourceDirectories());
                             genTask.getOutputDir().set(cdSrcDirSet.getDestinationDirectory());
-                            genTask.getSymbolOutput().set(project.getLayout().getBuildDirectory().dir("cdgensymbols/" + sourceSet.getName()));
+                            genTask.getOriginalSymbolOutput().set(project.getLayout().getBuildDirectory().dir("cdgensymbols/" + sourceSet.getName() + "/original"));
+                            genTask.getDecoratedSymbolOutput().set(project.getLayout().getBuildDirectory().dir("cdgensymbols/" + sourceSet.getName() + "/decorated"));
 
                             sourceSet.getJava().srcDir(genTask.getOutputDir());
                             genTask

--- a/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenGradlePlugin.java
+++ b/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenGradlePlugin.java
@@ -61,6 +61,7 @@ public class CDGenGradlePlugin implements Plugin<Project> {
 
                             genTask.getInput().from(cdSrcDirSet.getSourceDirectories());
                             genTask.getOutputDir().set(cdSrcDirSet.getDestinationDirectory());
+                            genTask.getSymbolOutput().set(project.getLayout().getBuildDirectory().dir("cdgensymbols/" + sourceSet.getName()));
 
                             sourceSet.getJava().srcDir(genTask.getOutputDir());
                             genTask

--- a/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenTask.java
+++ b/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenTask.java
@@ -3,17 +3,19 @@ package de.monticore.cdgen.gradleplugin;
 
 import de.monticore.gradle.common.AToolAction;
 import de.monticore.gradle.common.MCAllFilesTask;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFiles;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Gradle Task of the {@link de.monticore.cdgen.CDGenTool} It is an all-files task, as -i A.cd -i
@@ -34,6 +36,7 @@ public abstract class CDGenTask extends MCAllFilesTask {
 
   /**
    * Whether CoCos should be checked, default is true
+   *
    * @return property
    */
   @Optional
@@ -42,6 +45,7 @@ public abstract class CDGenTask extends MCAllFilesTask {
 
   /**
    * If present, the symbol tables will be exported into this directory
+   *
    * @return property
    */
   @Optional
@@ -83,5 +87,21 @@ public abstract class CDGenTask extends MCAllFilesTask {
   @Override
   protected Consumer<String[]> getRunMethod() {
     return CDGenToolInvoker::run;
+  }
+
+  /**
+   * @return a lazy, but live {@link FileCollection} of the exported decorated symbol tables
+   */
+  @OutputFiles
+  public FileCollection getDecoratedSymbolFiles() {
+    return this.getSymbolOutput().getAsFileTree().filter(f -> f.getName().endsWith(".deccdsym"));
+  }
+
+  /**
+   * @return a lazy, but live {@link FileCollection} of the exported original symbol tables
+   */
+  @OutputFiles
+  public FileCollection getOriginalSymbolFiles() {
+    return this.getSymbolOutput().getAsFileTree().filter(f -> f.getName().endsWith(".cdsym"));
   }
 }

--- a/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenTask.java
+++ b/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenTask.java
@@ -7,10 +7,13 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
 
 /**
  * Gradle Task of the {@link de.monticore.cdgen.CDGenTool} It is an all-files task, as -i A.cd -i
@@ -29,6 +32,22 @@ public abstract class CDGenTask extends MCAllFilesTask {
   @Input
   abstract Property<Boolean> getClass2MC();
 
+  /**
+   * Whether CoCos should be checked, default is true
+   * @return property
+   */
+  @Optional
+  @Input
+  abstract Property<Boolean> getCoCos();
+
+  /**
+   * If present, the symbol tables will be exported into this directory
+   * @return property
+   */
+  @Optional
+  @OutputDirectory
+  abstract DirectoryProperty getSymbolOutput();
+
   @Override
   protected List<String> createArgList(Function<Path, String> handlePath) {
     var list = super.createArgList(handlePath);
@@ -38,6 +57,13 @@ public abstract class CDGenTask extends MCAllFilesTask {
     }
     if (getClass2MC().isPresent() && getClass2MC().get()) {
       list.add("--class2mc");
+    }
+    if (getCoCos().getOrElse(true)) {
+      list.add("--checkcococs");
+    }
+    if (getSymbolOutput().isPresent()) {
+      list.add("-s");
+      list.add(getSymbolOutput().get().getAsFile().getAbsolutePath());
     }
     return list;
   }

--- a/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenTask.java
+++ b/cdtool/cdgradle/src/main/java/de/monticore/cdgen/gradleplugin/CDGenTask.java
@@ -44,13 +44,22 @@ public abstract class CDGenTask extends MCAllFilesTask {
   abstract Property<Boolean> getCoCos();
 
   /**
-   * If present, the symbol tables will be exported into this directory
+   * If present, the original symbol tables will be exported into this directory
    *
    * @return property
    */
   @Optional
   @OutputDirectory
-  abstract DirectoryProperty getSymbolOutput();
+  abstract DirectoryProperty getOriginalSymbolOutput();
+
+  /**
+   * If present, the decorated symbol tables will be exported into this directory
+   *
+   * @return property
+   */
+  @Optional
+  @OutputDirectory
+  abstract DirectoryProperty getDecoratedSymbolOutput();
 
   @Override
   protected List<String> createArgList(Function<Path, String> handlePath) {
@@ -65,9 +74,15 @@ public abstract class CDGenTask extends MCAllFilesTask {
     if (getCoCos().getOrElse(true)) {
       list.add("--checkcococs");
     }
-    if (getSymbolOutput().isPresent()) {
+    // We have to use two separate directories for the symbol outputs
+    // to avoid: 0xA1294 The following entries for the file `MyCD\..*sym` are ambiguous
+    if (getOriginalSymbolOutput().isPresent()) {
       list.add("-s");
-      list.add(getSymbolOutput().get().getAsFile().getAbsolutePath());
+      list.add(getOriginalSymbolOutput().get().getAsFile().getAbsolutePath());
+    }
+    if (getDecoratedSymbolOutput().isPresent()) {
+      list.add("-sd");
+      list.add(getDecoratedSymbolOutput().get().getAsFile().getAbsolutePath());
     }
     return list;
   }
@@ -87,21 +102,5 @@ public abstract class CDGenTask extends MCAllFilesTask {
   @Override
   protected Consumer<String[]> getRunMethod() {
     return CDGenToolInvoker::run;
-  }
-
-  /**
-   * @return a lazy, but live {@link FileCollection} of the exported decorated symbol tables
-   */
-  @OutputFiles
-  public FileCollection getDecoratedSymbolFiles() {
-    return this.getSymbolOutput().getAsFileTree().filter(f -> f.getName().endsWith(".deccdsym"));
-  }
-
-  /**
-   * @return a lazy, but live {@link FileCollection} of the exported original symbol tables
-   */
-  @OutputFiles
-  public FileCollection getOriginalSymbolFiles() {
-    return this.getSymbolOutput().getAsFileTree().filter(f -> f.getName().endsWith(".cdsym"));
   }
 }

--- a/cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
+++ b/cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
@@ -126,7 +126,9 @@ public class CDGenGradlePluginTest {
     CD4CodeMill.globalScope().loadDiagram("MyCD");
 
     CD4CodeMill.globalScope().resolveMethod("MyCD.MyCD.CanBeObserved.getName");
-    CD4CodeMill.globalScope().resolveMethod("MyCD.MyCD.IncompleteATOP.getName"); // TODO: check for IncompleteA (without TOP)
+    // Check for a method within a class, which is TOPed
+    // We explicitly expect the method to be resolvable via IncompleteA
+    CD4CodeMill.globalScope().resolveMethod("MyCD.MyCD.IncompleteA.getName");
     CD4CodeMill.globalScope().resolveType("MyCD.MyCD.BBuilder");
 
     Assertions.assertEquals(0, LogStub.getFindingsCount());

--- a/cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
+++ b/cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
@@ -113,8 +113,11 @@ public class CDGenGradlePluginTest {
     assertEquals(TaskOutcome.SUCCESS, result.task(":generateClassDiagrams").getOutcome());
     assertEquals(TaskOutcome.SUCCESS, result.task(":compileJava").getOutcome());
 
-    File symbolsOut = new File(testProjectDir, "build/cdgensymbols/main/MyCD.cdsym");
-    assertTrue(symbolsOut.exists(), "Exported symbols missing");
+    File origSymbolsOut = new File(testProjectDir, "build/cdgensymbols/main/original/MyCD.cdsym");
+    assertTrue(origSymbolsOut.exists(), "Exported original symbols missing");
+
+    File symbolsOut = new File(testProjectDir, "build/cdgensymbols/main/original/MyCD.cdsym");
+    assertTrue(symbolsOut.exists(), "Exported decorated symbols missing");
 
     // Test if we can successfully resolve a decorated function
     LogStub.initPlusLog();

--- a/cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
+++ b/cdtool/cdgradle/src/test/java/de/monticore/cdgen/CDGenGradlePluginTest.java
@@ -10,9 +10,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import javax.annotation.Nullable;
+
+import de.monticore.cd4code.CD4CodeMill;
+import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.se_rwth.commons.logging.LogStub;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -107,6 +112,26 @@ public class CDGenGradlePluginTest {
             .build();
     assertEquals(TaskOutcome.SUCCESS, result.task(":generateClassDiagrams").getOutcome());
     assertEquals(TaskOutcome.SUCCESS, result.task(":compileJava").getOutcome());
+
+    File symbolsOut = new File(testProjectDir, "build/cdgensymbols/main/MyCD.cdsym");
+    assertTrue(symbolsOut.exists(), "Exported symbols missing");
+
+    // Test if we can successfully resolve a decorated function
+    LogStub.initPlusLog();
+    CD4CodeMill.init();
+    BasicSymbolsMill.initializePrimitives();
+    BasicSymbolsMill.initializeString();
+    // Load the (freshly generated) CD-sym
+    CD4CodeMill.globalScope().getSymbolPath().addEntry(symbolsOut.getParentFile().toPath());
+    CD4CodeMill.globalScope().loadDiagram("MyCD");
+
+    CD4CodeMill.globalScope().resolveMethod("MyCD.MyCD.CanBeObserved.getName");
+    CD4CodeMill.globalScope().resolveMethod("MyCD.MyCD.IncompleteATOP.getName"); // TODO: check for IncompleteA (without TOP)
+    CD4CodeMill.globalScope().resolveType("MyCD.MyCD.BBuilder");
+
+    Assertions.assertEquals(0, LogStub.getFindingsCount());
+
+    CD4CodeMill.reset();
   }
 
   @Test

--- a/cdtool/cdgradle/src/test/resources/MyCD.cd
+++ b/cdtool/cdgradle/src/test/resources/MyCD.cd
@@ -36,8 +36,8 @@ classdiagram MyCD {
     public boolean doStuffInPublic();
   }
 
-   <<needsTOP="TOP required: %s">>
-    public class IncompleteA {
-      public String name;
-    }
+  <<needsTOP="TOP required: %s">>
+  public class IncompleteA {
+    public String name;
+  }
 }


### PR DESCRIPTION
* [X] Export the symbol table of the decorated ASTs
* [X] Complete the symbol tables
   * Without class2mc (e..g, missing dependency), we have to simulate the symbols
   * Future: import symbols from an exported symboltable
* [x] Create the symbol tables just before the TOPTrafo is applied    
   * Idea/discussion: Add type-symbols for the TOPing class (`A extends ATOP`) without an AST node   
       * Result: Wait for tools using the STs for their requirements.
   * [x] Use a different file extension (`.cddecoratedsym` ?) for this symbol table
* https://github.com/MontiCore/cd4analysis/pull/31#issuecomment-2866457298 Differentiate Structure + Implementation   
   * For now, the complete symbol table is exported
      * In the feature (with feedback from symbol tabe consuming developers) we may want to consider only exporting partial STs
      *   Either by exporting multiple STs or by adding additional attributes ot symbols, which allow some sort of filtering (e.g. the "Implementation details"). Other tools may need these symbols, which is why filtering might be done on the consuming-tool's side
      *   See (internal) #4607
   * the idea of transformations "during" decoration (e.g., changing a previously decorated element) should be considered in the future
  
@JohannesLeurs just fyi