### PR TITLE
cdconf: collected changes in preparation for OCL adaptation

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationHelper.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationHelper.java
@@ -1,6 +1,8 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconcretization;
 
+import de.monticore.cd.facade.MCQualifiedNameFacade;
+import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cdassociation._ast.ASTCDAssocSide;
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdassociation._symboltable.CDRoleSymbol;
@@ -10,6 +12,9 @@ import de.monticore.cddiff.CDDiffUtil;
 import de.monticore.cdinterfaceandenum._ast.ASTCDEnum;
 import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
 import de.monticore.cdmatcher.BooleanMatchingStrategy;
+import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsScope;
+import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedName;
+import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedType;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -239,6 +244,32 @@ public class ConcretizationHelper {
       }
     }));
     cdDefinition.setCDElementList(elements);
+  }
+  
+  /**
+   * Workaround to create an {@link ASTMCQualifiedType} instance that is already linked
+   * into the symbol table.<br>
+   * <br>
+   * This is required as we sometimes execute the type check for AST elements created by one
+   * completer (e.g. a for each completer) which passes the newly created instanced down to
+   * the Base completer. If we do not link an enclosing scope manually, the type check fails.
+   *
+   * @param scope the scope that should be used as enclosing scope for the type
+   * @param name the name of the type to create, e.g. "com.example.Foo"
+   * @return a new {@link ASTMCQualifiedType} instance with the given name and scope
+   */
+  public static ASTMCQualifiedType createQualifiedTypeInScope(IBasicSymbolsScope scope,
+      String name) {
+    ASTMCQualifiedName mcQualifiedName = MCQualifiedNameFacade.createQualifiedName(name);
+    /*
+     * We have to set the enclosing scope so the type can be resolved if the type check is
+     * used on the cloned method.
+     */
+    mcQualifiedName.setEnclosingScope(scope);
+    ASTMCQualifiedType qualifiedType = CD4CodeMill.mCQualifiedTypeBuilder().setMCQualifiedName(
+        mcQualifiedName).build();
+    qualifiedType.setEnclosingScope(scope);
+    return qualifiedType;
   }
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/UnderspecifiedPlaceholderType.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/UnderspecifiedPlaceholderType.java
@@ -1,7 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconcretization;
 
-import de.monticore.cd4code.CD4CodeMill;
+import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
 import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsGlobalScope;
 import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
 import de.monticore.symboltable.modifiers.AccessModifier;
@@ -50,9 +50,9 @@ public class UnderspecifiedPlaceholderType {
    */
   private static TypeSymbol createPlaceholderTypeSymbol(String name,
       IBasicSymbolsGlobalScope globalScope) {
-    return CD4CodeMill.typeSymbolBuilder().setName(name).setEnclosingScope(globalScope).setFullName(
-        name).setSpannedScope(CD4CodeMill.scope()).setAccessModifier(AccessModifier.ALL_INCLUSION)
-        .build();
+    return BasicSymbolsMill.typeSymbolBuilder().setName(name).setEnclosingScope(globalScope)
+        .setFullName(name).setSpannedScope(BasicSymbolsMill.scope()).setAccessModifier(
+            AccessModifier.ALL_INCLUSION).build();
   }
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/UnderspecifiedPlaceholderType.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/UnderspecifiedPlaceholderType.java
@@ -2,8 +2,8 @@
 package de.monticore.cdconcretization;
 
 import de.monticore.cd4code.CD4CodeMill;
+import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsGlobalScope;
 import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
-import de.monticore.symbols.oosymbols._symboltable.IOOSymbolsGlobalScope;
 import de.monticore.symboltable.modifiers.AccessModifier;
 
 /**
@@ -17,7 +17,7 @@ public class UnderspecifiedPlaceholderType {
   
   /**
    * The default name of the underspecified placeholder type.<br>
-   * used when calling {@link #addPlaceholderType(IOOSymbolsGlobalScope)}.
+   * used when calling {@link #addPlaceholderType(IBasicSymbolsGlobalScope)}.
    */
   public static final String DEFAULT_TYPE_NAME = "any";
   
@@ -31,26 +31,28 @@ public class UnderspecifiedPlaceholderType {
    *
    * @param globalScope the global scope to add the placeholder type to
    */
-  public static void addPlaceholderType(IOOSymbolsGlobalScope globalScope) {
+  public static void addPlaceholderType(IBasicSymbolsGlobalScope globalScope) {
     addPlaceholderType(globalScope, DEFAULT_TYPE_NAME);
   }
   
-  public static void addPlaceholderType(IOOSymbolsGlobalScope globalScope, String typeName) {
-    globalScope.add(createPlaceholderTypeSymbol(typeName));
+  public static void addPlaceholderType(IBasicSymbolsGlobalScope globalScope, String typeName) {
+    globalScope.add(createPlaceholderTypeSymbol(typeName, globalScope));
   }
   
   /**
    * Creates a type symbol for an underspecified placeholder type.<br>
-   * Prefer using {@link #addPlaceholderType(IOOSymbolsGlobalScope)} to add the type to the global
+   * Prefer using {@link #addPlaceholderType(IBasicSymbolsGlobalScope)} to add the type to the
+   * global
    * scope.
    *
    * @param name the name of the type
    * @return the type symbol
    */
-  private static TypeSymbol createPlaceholderTypeSymbol(String name) {
-    return CD4CodeMill.typeSymbolBuilder().setName(name).setEnclosingScope(CD4CodeMill
-        .globalScope()).setFullName(name).setSpannedScope(CD4CodeMill.scope()).setAccessModifier(
-            AccessModifier.ALL_INCLUSION).build();
+  private static TypeSymbol createPlaceholderTypeSymbol(String name,
+      IBasicSymbolsGlobalScope globalScope) {
+    return CD4CodeMill.typeSymbolBuilder().setName(name).setEnclosingScope(globalScope).setFullName(
+        name).setSpannedScope(CD4CodeMill.scope()).setAccessModifier(AccessModifier.ALL_INCLUSION)
+        .build();
   }
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/type/attribute/BaseAttributeInTypeCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/type/attribute/BaseAttributeInTypeCompleter.java
@@ -85,6 +85,9 @@ public class BaseAttributeInTypeCompleter extends AbstractAttributeInTypeComplet
       if (typeIncarnations.size() > 1) {
         // if we have more than one type incarnation, we need to add a suffix to the new attributes
         attributeIncarnation.setName(referenceAttribute.getName() + "_" + cAttributeType.getName());
+        // since name changed we also need to add a stereotype mapping
+        StereotypeUtil.addStereotype(attributeIncarnation.getModifier(), context.getMappingName(),
+            referenceAttribute.getSymbol().getFullName());
       }
       
       // 2. set type of incarnation
@@ -92,9 +95,6 @@ public class BaseAttributeInTypeCompleter extends AbstractAttributeInTypeComplet
       attributeIncarnation.setMCType(CD4CodeMill.mCQualifiedTypeBuilder().setMCQualifiedName(
           MCQualifiedNameFacade.createQualifiedName(cAttributeType.getSymbol()
               .getInternalQualifiedName())).build());
-      
-      StereotypeUtil.addStereotype(attributeIncarnation.getModifier(), context.getMappingName(),
-          referenceAttribute.getSymbol().getFullName());
       
       concreteType.addCDMember(attributeIncarnation);
     }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/type/method/BaseMethodInTypeCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/type/method/BaseMethodInTypeCompleter.java
@@ -3,12 +3,12 @@ package de.monticore.cdconcretization.type.method;
 
 import com.google.common.collect.Lists;
 import de.monticore.cd._symboltable.CDSymbolTables;
-import de.monticore.cd.facade.MCQualifiedNameFacade;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code.typescalculator.FullSynthesizeFromCD4Code;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cd4codebasis._ast.ASTCDParameter;
 import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdconcretization.ConcretizationHelper;
 import de.monticore.cdconcretization.stereotype.StereotypeUtil;
 import de.monticore.cdconcretization.type.TypeCompletionContext;
 import de.monticore.cdconcretization.util.MethodSignatureString;
@@ -107,9 +107,9 @@ public class BaseMethodInTypeCompleter extends AbstractMethodInTypeCompleter {
     else {
       List<ASTMCType> typeIncarnationsList = new ArrayList<>();
       for (ASTCDType typeIncarnation : typeIncarnations) {
-        typeIncarnationsList.add(CD4CodeMill.mCQualifiedTypeBuilder().setMCQualifiedName(
-            MCQualifiedNameFacade.createQualifiedName(typeIncarnation.getSymbol()
-                .getInternalQualifiedName())).build());
+        typeIncarnationsList.add(ConcretizationHelper.createQualifiedTypeInScope(context
+            .getConcreteType().getSpannedScope(), typeIncarnation.getSymbol()
+                .getInternalQualifiedName()));
       }
       return typeIncarnationsList;
     }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/type/method/ForEachMethodCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/type/method/ForEachMethodCompleter.java
@@ -1,7 +1,6 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconcretization.type.method;
 
-import de.monticore.cd.facade.MCQualifiedNameFacade;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cd4codebasis._ast.ASTCDParameter;
@@ -17,15 +16,15 @@ import de.monticore.cdconcretization.util.NameUtil;
 import de.monticore.cdconcretization.util.SymbolUtil;
 import de.monticore.cdconformance.CDConfParameter;
 import de.monticore.cdconformance.inc.MethodOverloadingCDIncBindings;
-import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsScope;
-import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedName;
-import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedType;
 import de.se_rwth.commons.Names;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static de.monticore.cdconcretization.ConcretizationHelper.createQualifiedTypeInScope;
 
 public class ForEachMethodCompleter extends AbstractMethodInTypeCompleter {
   
@@ -244,20 +243,6 @@ public class ForEachMethodCompleter extends AbstractMethodInTypeCompleter {
       cloneParameter.setMCType(originalParameter.getMCType());
     }
     return clone;
-  }
-  
-  private static ASTMCQualifiedType createQualifiedTypeInScope(IBasicSymbolsScope scope,
-      String name) {
-    ASTMCQualifiedName mcQualifiedName = MCQualifiedNameFacade.createQualifiedName(name);
-    /*
-     * We have to set the enclosing scope so the type can be resolved if the type check is
-     * used on the cloned method.
-     */
-    mcQualifiedName.setEnclosingScope(scope);
-    ASTMCQualifiedType qualifiedType = CD4CodeMill.mCQualifiedTypeBuilder().setMCQualifiedName(
-        mcQualifiedName).build();
-    qualifiedType.setEnclosingScope(scope);
-    return qualifiedType;
   }
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconcretization/util/SymbolUtil.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/util/SymbolUtil.java
@@ -17,34 +17,17 @@ public class SymbolUtil {
   
   private SymbolUtil() {}
   
-  public static TypeSymbol getDeclaringTypeSymbol(FieldSymbol fieldSymbol) {
-    IScope enclosingScope = fieldSymbol.getEnclosingScope();
+  public static TypeSymbol getDeclaringTypeSymbol(ISymbol iSymbol) {
+    IScope enclosingScope = iSymbol.getEnclosingScope();
     if (!enclosingScope.isPresentSpanningSymbol()) {
-      throw new IllegalStateException("FieldSymbol without enclosing scope: " + fieldSymbol
-          .getFullName());
+      throw new IllegalStateException("Symbol without enclosing scope: " + iSymbol.getFullName());
     }
     IScopeSpanningSymbol symbol = enclosingScope.getSpanningSymbol();
     if (symbol instanceof TypeSymbol) {
       return (TypeSymbol) symbol;
     }
     else {
-      throw new IllegalStateException("FieldSymbol not enclosed in a type symbol: " + fieldSymbol
-          .getFullName());
-    }
-  }
-  
-  public static TypeSymbol getDeclaringTypeSymbol(MethodSymbol methodSymbol) {
-    IScope enclosingScope = methodSymbol.getEnclosingScope();
-    if (!enclosingScope.isPresentSpanningSymbol()) {
-      throw new IllegalStateException("MethodSymbol without enclosing scope: " + methodSymbol
-          .getFullName());
-    }
-    IScopeSpanningSymbol symbol = enclosingScope.getSpanningSymbol();
-    if (symbol instanceof TypeSymbol) {
-      return (TypeSymbol) symbol;
-    }
-    else {
-      throw new IllegalStateException("MethodSymbol not enclosed in a type symbol: " + methodSymbol
+      throw new IllegalStateException("Symbol not enclosed in a type symbol: " + iSymbol
           .getFullName());
     }
   }

--- a/cddiff/src/main/java/de/monticore/cdconformance/CDConformanceChecker.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/CDConformanceChecker.java
@@ -209,4 +209,13 @@ public class CDConformanceChecker {
   
   public CDIncarnationMapping getIncarnationMapping() { return incMapping; }
   
+  /**
+   * Sets the name of the underspecified placeholder type.
+   *
+   * @param underspecifiedTypeName the name of the underspecified placeholder type
+   */
+  public void setUnderspecifiedTypeName(String underspecifiedTypeName) {
+    this.underspecifiedTypeName = underspecifiedTypeName;
+  }
+  
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
@@ -144,12 +144,16 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
             compSubTypeIncStrategy, concreteCD, referenceCD));
         compAssocIncStrategy.addIncStrategy(new RolePrefixIfPresentIncStrategy(
             compSubTypeIncStrategy, concreteCD, referenceCD));
+        compAssocIncStrategy.addIncStrategy(new ImplicitRoleNameAssocIncStrategy(
+            compSubTypeIncStrategy, concreteCD, referenceCD, mapping));
       }
       else {
         compAssocIncStrategy.addIncStrategy(new RolePrefixInNavDirIncStrategy(compTypeIncStrategy,
             concreteCD, referenceCD));
         compAssocIncStrategy.addIncStrategy(new RolePrefixIfPresentIncStrategy(compTypeIncStrategy,
             concreteCD, referenceCD));
+        compAssocIncStrategy.addIncStrategy(new ImplicitRoleNameAssocIncStrategy(
+            compTypeIncStrategy, concreteCD, referenceCD, mapping));
       }
     }
     

--- a/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
@@ -11,6 +11,7 @@ import de.monticore.cdconformance.inc.attribute.CompAttributeIncStrategy;
 import de.monticore.cdconformance.inc.attribute.EqNameAttributeIncStrategy;
 import de.monticore.cdconformance.inc.attribute.STAttributeIncStrategy;
 import de.monticore.cdconformance.inc.mctype.MCTypeMatchingStrategy;
+import de.monticore.cdconformance.inc.mctype.TypeCheckMCTypeMatchingStrategy;
 import de.monticore.cdconformance.inc.method.*;
 import de.monticore.cdconformance.inc.type.CompTypeIncStrategy;
 import de.monticore.cdconformance.inc.type.EqTypeIncStrategy;
@@ -81,8 +82,9 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
     CompAttributeIncStrategy compAttributeIncStrategy = new CompAttributeIncStrategy();
     CompMethodIncStrategy compMethodIncStrategy = new CompMethodIncStrategy();
     
-    MCTypeMatchingStrategy mcTypeMatcher = new MCTypeMatchingStrategy(
-        underspecifiedPlaceholderTypeName, compTypeIncStrategy::isMatched);
+    MCTypeMatchingStrategy compMcTypeMatcher = new TypeCheckMCTypeMatchingStrategy(
+        underspecifiedPlaceholderTypeName);
+    compMcTypeMatcher.setCDTypeMatcher(compTypeIncStrategy);
     
     /*
      * We configure the matching strategies depending on the conformance checker parameter as we
@@ -99,7 +101,7 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
       compAssocIncStrategy.addIncStrategy(new EqNameAssocIncStrategy(referenceCD, mapping));
       compAttributeIncStrategy.addIncStrategy(new EqNameAttributeIncStrategy());
       if (conformanceParams.contains(CDConfParameter.METHOD_OVERLOADING)) {
-        compMethodIncStrategy.addIncStrategy(new EqSignatureMethodIncStrategy(mcTypeMatcher,
+        compMethodIncStrategy.addIncStrategy(new EqSignatureMethodIncStrategy(compMcTypeMatcher,
             conformanceParams.contains(CDConfParameter.STRICT_PARAMETER_ORDER)));
       }
       else {
@@ -160,7 +162,7 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
     return new DefaultCDConformanceContext(concreteCD, referenceCD, mapping,
         underspecifiedPlaceholderTypeName, conformanceParams, compTypeIncStrategy,
         compSubTypeIncStrategy, compAssocIncStrategy, compAttributeIncStrategy,
-        compMethodIncStrategy, mcTypeMatcher);
+        compMethodIncStrategy, compMcTypeMatcher);
   }
   
   /**
@@ -196,7 +198,7 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
     CachedMultiMatches<ASTCDType> cachedTypeIncStrategy = new CachedMultiMatches<>(CDSynDiffMatches
         .computeMultiMatching(concTypes, context.getTypeIncStrategy()));
     
-    context.getMCTypeIncStrategy().setTypeMatcher(context.getTypeIncStrategy());
+    context.getMCTypeIncStrategy().setCDTypeMatcher(context.getTypeIncStrategy());
     
     CachedMultiMatches<ASTCDType> cachedSubtypeIncStrategy = new CachedMultiMatches<>(
         CDSynDiffMatches.computeMultiMatching(concTypes, context

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/type/DeepTypeConfStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/type/DeepTypeConfStrategy.java
@@ -47,15 +47,12 @@ public class DeepTypeConfStrategy extends BasicTypeConfStrategy {
   
   @Override
   protected boolean checkAssocIncarnation(ASTCDType concrete, ASTCDType ref) {
-    
     Set<ASTCDAssociation> conAssocSet = CDDiffUtil.getAllSuperTypes(concrete, conCD
         .getCDDefinition()).stream().flatMap(supertype -> CDDiffUtil.getReferencingAssociations(
             supertype, conCD).stream().filter(assoc -> supertype.getSymbol()
                 .getInternalQualifiedName().contains(assoc.getLeftQualifiedName().getQName())
                 || supertype.getSymbol().getInternalQualifiedName().contains(assoc
                     .getRightQualifiedName().getQName()))).collect(Collectors.toSet());
-    
-    conAssocSet.addAll(CDDiffUtil.getReferencingAssociations(concrete, conCD));
     
     return checkAssocIncarnation(conAssocSet, CDDiffUtil.getReferencingAssociations(ref, refCD));
   }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/CDIncarnationBindings.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/CDIncarnationBindings.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconformance.inc;
 
+import com.google.common.collect.SetMultimap;
 import de.monticore.cdassociation._symboltable.CDAssociationSymbol;
 import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
 import de.monticore.symbols.oosymbols._symboltable.FieldSymbol;
@@ -309,5 +310,17 @@ public interface CDIncarnationBindings {
       Set<CDAssociationSymbol> conAssociations) {
     addBinding(computeSymbolKey(contextSymbol), refAssociation, conAssociations);
   }
+  
+  SetMultimap<String, TypeSymbol> getTypeBindings(IScope concreteScope);
+  
+  SetMultimap<String, TypeSymbol> getTypeBindings(ISymbol contextSymbol);
+  
+  SetMultimap<String, FieldSymbol> getFieldBindings(IScope concreteScope);
+  
+  SetMultimap<String, FieldSymbol> getFieldBindings(ISymbol contextSymbol);
+  
+  SetMultimap<String, MethodSymbol> getMethodBindings(IScope concreteScope);
+  
+  SetMultimap<String, MethodSymbol> getMethodBindings(ISymbol contextSymbol);
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/CDIncarnationBindings.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/CDIncarnationBindings.java
@@ -262,6 +262,19 @@ public interface CDIncarnationBindings {
   }
   
   /**
+   * Adds a method binding for the given context symbol.
+   *
+   * @param contextSymbol the symbol at which the binding is added
+   * @param referenceMethod the reference method for which a binding is added
+   * @param concreteMethod the concrete method to which the reference method is bound to in the
+   * context
+   */
+  default void addBinding(ISymbol contextSymbol, MethodSymbol referenceMethod,
+      MethodSymbol concreteMethod) {
+    addBinding(contextSymbol, referenceMethod, Set.of(concreteMethod));
+  }
+  
+  /**
    * Returns all concrete methods that are bound to the given reference method at the given context
    * symbol.<br>
    * <b>Note:</b> If no bindings are found, the method returns an empty set. This does not mean that

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/CDIncarnationMapping.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/CDIncarnationMapping.java
@@ -186,6 +186,11 @@ public interface CDIncarnationMapping extends CDIncarnationBindings {
    */
   Set<ASTCDAttribute> getIncarnations(IScope scope, ASTCDAttribute referenceAttribute);
   
+  default Set<FieldSymbol> getIncarnations(FieldSymbol referenceElement) {
+    return getIncarnations(SymbolUtil.cdAttributeFromFieldSymbol(referenceElement)).stream().map(
+        ASTCDAttribute::getSymbol).collect(Collectors.toSet());
+  }
+  
   // --------------------------
   // ----- Method Mapping -----
   // --------------------------

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/DefaultCDIncarnationBindings.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/DefaultCDIncarnationBindings.java
@@ -77,6 +77,34 @@ public class DefaultCDIncarnationBindings implements CDIncarnationBindings {
     throw new NotImplementedException();
   }
   
+  public SetMultimap<String, TypeSymbol> getTypeBindings(IScope concreteScope) {
+    if (concreteScope instanceof IGlobalScope) {
+      // no enclosing scope, return empty set
+      return HashMultimap.create();
+    }
+    if (!concreteScope.isPresentSpanningSymbol()) {
+      // ignore the scope and jump one level higher
+      return getTypeBindings(concreteScope.getEnclosingScope());
+    }
+    // collect all bindings starting from the spanning symbol of the scope
+    return getTypeBindings(concreteScope.getSpanningSymbol());
+  }
+  
+  public SetMultimap<String, TypeSymbol> getTypeBindings(ISymbol contextSymbol) {
+    String symbolName = computeSymbolKey(contextSymbol);
+    Log.debug("Checking for type incarnations in context of symbol: " + symbolName, LOG_NAME);
+    
+    SetMultimap<String, TypeSymbol> allTypeBindings = HashMultimap.create();
+    SetMultimap<String, TypeSymbol> localTypeMapping = typeBindings.get(symbolName);
+    if (localTypeMapping != null) {
+      // add the local type mapping to the result
+      allTypeBindings.putAll(localTypeMapping);
+    }
+    // search higher in the scope hierarchy
+    allTypeBindings.putAll(getTypeBindings(contextSymbol.getEnclosingScope()));
+    return allTypeBindings;
+  }
+  
   @Override
   public Set<TypeSymbol> getBindings(IScope concreteScope, TypeSymbol referenceType) {
     if (concreteScope instanceof IGlobalScope) {
@@ -158,6 +186,34 @@ public class DefaultCDIncarnationBindings implements CDIncarnationBindings {
     }
   }
   
+  public SetMultimap<String, FieldSymbol> getFieldBindings(IScope concreteScope) {
+    if (concreteScope instanceof IGlobalScope) {
+      // no enclosing scope, return empty set
+      return HashMultimap.create();
+    }
+    if (!concreteScope.isPresentSpanningSymbol()) {
+      // ignore the scope and jump one level higher
+      return getFieldBindings(concreteScope.getEnclosingScope());
+    }
+    // collect all bindings starting from the spanning symbol of the scope
+    return getFieldBindings(concreteScope.getSpanningSymbol());
+  }
+  
+  public SetMultimap<String, FieldSymbol> getFieldBindings(ISymbol contextSymbol) {
+    String symbolName = computeSymbolKey(contextSymbol);
+    Log.debug("Checking for type incarnations in context of symbol: " + symbolName, LOG_NAME);
+    
+    SetMultimap<String, FieldSymbol> allBindings = HashMultimap.create();
+    SetMultimap<String, FieldSymbol> localMapping = fieldBindings.get(symbolName);
+    if (localMapping != null) {
+      // add the local type mapping to the result
+      allBindings.putAll(localMapping);
+    }
+    // search higher in the scope hierarchy
+    allBindings.putAll(getFieldBindings(contextSymbol.getEnclosingScope()));
+    return allBindings;
+  }
+  
   @Override
   public Set<MethodSymbol> getBindings(IScope concreteScope, MethodSymbol referenceMethod) {
     if (concreteScope instanceof IGlobalScope) {
@@ -206,6 +262,34 @@ public class DefaultCDIncarnationBindings implements CDIncarnationBindings {
       // no declaring type incarnations, return all method incarnations
       return methodIncarnations;
     }
+  }
+  
+  public SetMultimap<String, MethodSymbol> getMethodBindings(IScope concreteScope) {
+    if (concreteScope instanceof IGlobalScope) {
+      // no enclosing scope, return empty set
+      return HashMultimap.create();
+    }
+    if (!concreteScope.isPresentSpanningSymbol()) {
+      // ignore the scope and jump one level higher
+      return getMethodBindings(concreteScope.getEnclosingScope());
+    }
+    // collect all bindings starting from the spanning symbol of the scope
+    return getMethodBindings(concreteScope.getSpanningSymbol());
+  }
+  
+  public SetMultimap<String, MethodSymbol> getMethodBindings(ISymbol contextSymbol) {
+    String symbolName = computeSymbolKey(contextSymbol);
+    Log.debug("Checking for type incarnations in context of symbol: " + symbolName, LOG_NAME);
+    
+    SetMultimap<String, MethodSymbol> allBindings = HashMultimap.create();
+    SetMultimap<String, MethodSymbol> localMapping = methodBindings.get(symbolName);
+    if (localMapping != null) {
+      // add the local type mapping to the result
+      allBindings.putAll(localMapping);
+    }
+    // search higher in the scope hierarchy
+    allBindings.putAll(getMethodBindings(contextSymbol.getEnclosingScope()));
+    return allBindings;
   }
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/DefaultCDIncarnationMapping.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/DefaultCDIncarnationMapping.java
@@ -347,13 +347,13 @@ public class DefaultCDIncarnationMapping implements CDIncarnationMapping {
   
   @Override
   public boolean isIncarnation(ASTMCType conType, ASTMCType refType) {
-    mcTypeIncStrategy.setTypeMatcher(this::isIncarnation);
+    mcTypeIncStrategy.setCDTypeMatcher(this::isIncarnation);
     return mcTypeIncStrategy.isMatched(conType, refType);
   }
   
   @Override
   public boolean isIncarnation(ISymbol contextSymbol, ASTMCType conType, ASTMCType refType) {
-    mcTypeIncStrategy.setTypeMatcher((conCDType, refCDType) -> isIncarnation(contextSymbol,
+    mcTypeIncStrategy.setCDTypeMatcher((conCDType, refCDType) -> isIncarnation(contextSymbol,
         conCDType, refCDType));
     return mcTypeIncStrategy.isMatched(conType, refType);
   }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/DefaultCDIncarnationMapping.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/DefaultCDIncarnationMapping.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconformance.inc;
 
+import com.google.common.collect.SetMultimap;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdassociation._symboltable.CDAssociationSymbol;
@@ -355,6 +356,36 @@ public class DefaultCDIncarnationMapping implements CDIncarnationMapping {
     mcTypeIncStrategy.setTypeMatcher((conCDType, refCDType) -> isIncarnation(contextSymbol,
         conCDType, refCDType));
     return mcTypeIncStrategy.isMatched(conType, refType);
+  }
+  
+  @Override
+  public SetMultimap<String, TypeSymbol> getTypeBindings(IScope concreteScope) {
+    return bindings.getTypeBindings(concreteScope);
+  }
+  
+  @Override
+  public SetMultimap<String, TypeSymbol> getTypeBindings(ISymbol contextSymbol) {
+    return bindings.getTypeBindings(contextSymbol);
+  }
+  
+  @Override
+  public SetMultimap<String, FieldSymbol> getFieldBindings(IScope concreteScope) {
+    return bindings.getFieldBindings(concreteScope);
+  }
+  
+  @Override
+  public SetMultimap<String, FieldSymbol> getFieldBindings(ISymbol contextSymbol) {
+    return bindings.getFieldBindings(contextSymbol);
+  }
+  
+  @Override
+  public SetMultimap<String, MethodSymbol> getMethodBindings(IScope concreteScope) {
+    return bindings.getMethodBindings(concreteScope);
+  }
+  
+  @Override
+  public SetMultimap<String, MethodSymbol> getMethodBindings(ISymbol contextSymbol) {
+    return bindings.getMethodBindings(contextSymbol);
   }
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/ForEachBindingDerivingVisitor.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/ForEachBindingDerivingVisitor.java
@@ -23,6 +23,7 @@ import de.se_rwth.commons.logging.Log;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -87,21 +88,25 @@ public class ForEachBindingDerivingVisitor implements CDBasisVisitor2, CD4CodeBa
   @Override
   public void visit(ASTCDType concreteType) {
     deriveBindings(concreteType.getEnclosingScope(), concreteType, concreteType.getSymbol(),
-        incMapping.getReferenceElements(concreteType), ASTCDType::getModifier, ASTCDType::getName);
+        incMapping.getReferenceElements(concreteType), ASTCDType::getModifier, ASTCDType::getName, (
+            refElement) -> incMapping.addBinding(concreteType.getSymbol(), refElement.getSymbol(),
+                concreteType.getSymbol()));
   }
   
   @Override
   public void visit(ASTCDAttribute concreteAttribute) {
     deriveBindings(concreteAttribute.getEnclosingScope(), concreteAttribute, concreteAttribute
         .getSymbol(), incMapping.getReferenceElements(concreteAttribute),
-        ASTCDAttribute::getModifier, ASTCDAttribute::getName);
+        ASTCDAttribute::getModifier, ASTCDAttribute::getName, (refElement) -> incMapping.addBinding(
+            concreteAttribute.getSymbol(), refElement.getSymbol(), concreteAttribute.getSymbol()));
   }
   
   @Override
   public void visit(ASTCDMethod concreteMethod) {
     deriveBindings(concreteMethod.getEnclosingScope(), concreteMethod, concreteMethod.getSymbol(),
         incMapping.getReferenceElements(concreteMethod), ASTCDMethod::getModifier,
-        ASTCDMethod::getName);
+        ASTCDMethod::getName, (refElement) -> incMapping.addBinding(concreteMethod.getSymbol(),
+            refElement.getSymbol(), concreteMethod.getSymbol()));
   }
   
   /**
@@ -117,7 +122,8 @@ public class ForEachBindingDerivingVisitor implements CDBasisVisitor2, CD4CodeBa
    */
   protected <T extends ASTCDBasisNode> void deriveBindings(ICDBasisScope enclosingScope,
       ASTCDBasisNode concreteElement, ISymbol concreteSymbol, Set<T> referenceElements,
-      Function<T, ASTModifier> getModifierFun, Function<T, String> getName) {
+      Function<T, ASTModifier> getModifierFun, Function<T, String> getName,
+      Consumer<T> addBindingForRefElement) {
     BindingHintsVisitor bindingHintsVisitor = null;
     
     // we are only interested in elements where the reference element is annotated with "forEach"
@@ -130,6 +136,10 @@ public class ForEachBindingDerivingVisitor implements CDBasisVisitor2, CD4CodeBa
           bindingHintsVisitor = new BindingHintsVisitor(incMapping);
           bindingHintsVisitor.collectHints(concreteElement);
         }
+        
+        // Add binding refElement=concreteElement to the concrete element. We expect the incarnations
+        // of a forEach-annotated element to be independent of each other.
+        addBindingForRefElement.accept(refElement);
         
         CDRefSymbolHandlerDelegator<RuntimeException> delegator =
             new CDRefSymbolHandlerDelegator<>();

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/association/ImplicitRoleNameAssocIncStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/association/ImplicitRoleNameAssocIncStrategy.java
@@ -1,0 +1,72 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.cdconformance.inc.association;
+
+import de.monticore.cdassociation._ast.ASTCDAssocSide;
+import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
+import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdmatcher.ExternalCandidatesMatchingStrategy;
+import de.monticore.cdmatcher.MatchCDAssocsBySrcTypeAndTgtRole;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
+
+/**
+ * This strategy matches associations by source type and target role, but takes the implicit role
+ * names derived from the target type into account.<br>
+ * This means, if one of the role names is not present (concrete/reference) the other role name
+ * has to be exactly the implicit role name.
+ * If both role names are present, they have to be exactly the implicit role names.
+ *
+ * For example, lets assume the target type of a reference association is name is "Person",
+ * and the role is exactly the implicit role name "person". Further, we assume there is a concrete
+ * type "Employee" that is an incarnation of "Person". Then, a concrete association with
+ * source/target type "Employee" and role "employee" matches the reference association.
+ */
+public class ImplicitRoleNameAssocIncStrategy extends MatchCDAssocsBySrcTypeAndTgtRole {
+  
+  protected String mapping;
+  
+  public ImplicitRoleNameAssocIncStrategy(ExternalCandidatesMatchingStrategy<ASTCDType> typeMatcher,
+      ASTCDCompilationUnit srcCD, ASTCDCompilationUnit tgtCD, String mapping) {
+    super(typeMatcher, srcCD, tgtCD);
+    this.mapping = mapping;
+  }
+  
+  @Override
+  protected boolean checkRole(ASTCDAssocSide concrete, ASTCDAssocSide reference) {
+    Optional<ASTCDType> conType = resolveConcreteCDTyp(concrete.getMCQualifiedType()
+        .getMCQualifiedName().getQName());
+    Optional<ASTCDType> refType = resolveReferenceCDTyp(reference.getMCQualifiedType()
+        .getMCQualifiedName().getQName());
+    
+    if (conType.isPresent() && refType.isPresent() && typeMatcher.isMatched(conType.get(), refType
+        .get())) {
+      String implicitRefRoleName = StringUtils.uncapitalize(reference.getName());
+      String implicitConRoleName = StringUtils.uncapitalize(concrete.getName());
+      
+      if (concrete.isPresentCDRole()) {
+        String conRoleName = concrete.getCDRole().getName();
+        if (reference.isPresentCDRole()) {
+          String refRoleName = reference.getCDRole().getName();
+          // If both, the reference and concrete roles are present, both names have to be exactly
+          // the implicit role names derived from the target type.
+          // (If con type name == ref type name, this implies con role name == ref role name)
+          return refRoleName.equals(implicitRefRoleName) && conRoleName.equals(implicitConRoleName);
+        }
+        else {
+          // If no reference role is present, the concrete role must be exactly the implicit role
+          // name, if it is present.
+          return conRoleName.equals(implicitConRoleName);
+        }
+      }
+      else if (reference.isPresentCDRole()) {
+        String refRoleName = reference.getCDRole().getName();
+        // If no concrete role is present, it is still a match if the reference role is exactly
+        // the implicit role name.
+        return refRoleName.equals(implicitRefRoleName);
+      }
+    }
+    return false;
+  }
+  
+}

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/IncMappingAwareSymTypeCompatibilityCalculator.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/IncMappingAwareSymTypeCompatibilityCalculator.java
@@ -1,0 +1,55 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.cdconformance.inc.mctype;
+
+import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdbasis._symboltable.CDTypeSymbol;
+import de.monticore.cdmatcher.BooleanMatchingStrategy;
+import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
+import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types3.generics.bounds.Bound;
+import de.monticore.types3.generics.bounds.UnsatisfiableBound;
+import de.monticore.types3.util.SymTypeCompatibilityCalculator;
+import de.se_rwth.commons.logging.Log;
+
+import java.util.Collections;
+import java.util.List;
+
+public class IncMappingAwareSymTypeCompatibilityCalculator extends SymTypeCompatibilityCalculator {
+  
+  private BooleanMatchingStrategy<ASTCDType> cdTypeMatcher;
+  
+  @Override
+  protected List<Bound> objectConstrainSameType(SymTypeExpression typeA, SymTypeExpression typeB) {
+    // return empty array list for "compatible"
+    if (typeA.hasTypeInfo() && typeB.hasTypeInfo()) {
+      TypeSymbol typeSymbolA = typeA.getTypeInfo();
+      TypeSymbol typeSymbolB = typeB.getTypeInfo();
+      
+      if (typeSymbolA instanceof CDTypeSymbol && typeSymbolB instanceof CDTypeSymbol) {
+        CDTypeSymbol cdTypeA = (CDTypeSymbol) typeSymbolA;
+        CDTypeSymbol cdTypeB = (CDTypeSymbol) typeSymbolB;
+        if (cdTypeA.isPresentAstNode() && cdTypeB.isPresentAstNode()) {
+          // we assume typeA is the concrete type and typeB is the reference type
+          // this has to be considered when calling constrainSameType(typeA, typeB)
+          if (cdTypeMatcher.isMatched(cdTypeA.getAstNode(), cdTypeB.getAstNode())) {
+            return Collections.emptyList();
+          }
+          else {
+            return Collections.singletonList(new UnsatisfiableBound(typeA.printFullName()
+                + " is not an incarnation of " + typeB.printFullName()));
+          }
+        }
+        else {
+          Log.warn("The concrete type or the reference type does not have an AST node. "
+              + "Incarnation mapping is only defined for CDTypeSymbol with AST nodes.");
+        }
+      }
+    }
+    return super.objectConstrainSameType(typeA, typeB);
+  }
+  
+  public void setCDTypeMatcher(BooleanMatchingStrategy<ASTCDType> typeMatcher) {
+    this.cdTypeMatcher = typeMatcher;
+  }
+  
+}

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/MCTypeMatchingStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/MCTypeMatchingStrategy.java
@@ -2,77 +2,22 @@
 package de.monticore.cdconformance.inc.mctype;
 
 import de.monticore.cdbasis._ast.ASTCDType;
-import de.monticore.cdbasis._symboltable.CDTypeSymbol;
 import de.monticore.cdmatcher.BooleanMatchingStrategy;
-import de.monticore.symboltable.ISymbol;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
-import de.se_rwth.commons.logging.Log;
 
-public class MCTypeMatchingStrategy {
-  
-  private final String underspecifiedTypeName;
-  private BooleanMatchingStrategy<ASTCDType> typeMatcher;
-  
-  public MCTypeMatchingStrategy(String underspecifiedTypeName,
-      BooleanMatchingStrategy<ASTCDType> typeMatcher) {
-    this.underspecifiedTypeName = underspecifiedTypeName;
-    this.typeMatcher = typeMatcher;
-  }
+public interface MCTypeMatchingStrategy extends BooleanMatchingStrategy<ASTMCType> {
   
   /**
-   * Two types are matched if one of the following holds:
-   * <ol>
-   * <li>Both are no CDType and have exactly the same name</li>
-   * <li>Both are CDTypes and the concrete type is an incarnation of the reference type
-   * (note: any CDType is considered an incarnation if the reference type is underspecified!)
-   * </li>
-   * </ol>
+   * Returns if the given concrete type is an incarnation of the given reference type.
    *
    * @param conType the concrete type
    * @param refType the reference type
    * @return true if the types are matched, false otherwise
    */
-  public boolean isMatched(ASTMCType conType, ASTMCType refType) {
-    if (MCTypeUtil.isUnderspecified(underspecifiedTypeName, refType)) {
-      if (MCTypeUtil.isUnderspecified(underspecifiedTypeName, conType)) {
-        Log.error("The underspecified placeholder type is not allowed as a concrete type.");
-        return false;
-      }
-      // every type is allowed if the reference type is underspecified
-      return true;
-    }
-    if (conType.getDefiningSymbol().isPresent() && refType.getDefiningSymbol().isPresent()) {
-      ISymbol conTypeSymbol = conType.getDefiningSymbol().get();
-      ISymbol refTypeSymbol = refType.getDefiningSymbol().get();
-      if (conTypeSymbol instanceof CDTypeSymbol && refTypeSymbol instanceof CDTypeSymbol) {
-        CDTypeSymbol conCDType = (CDTypeSymbol) conTypeSymbol;
-        CDTypeSymbol refCDType = (CDTypeSymbol) refTypeSymbol;
-        if (conCDType.isPresentAstNode() && refCDType.isPresentAstNode()) {
-          // the concrete type is an incarnation of the reference type
-          return typeMatcher.isMatched(conCDType.getAstNode(), refCDType.getAstNode());
-        }
-        else {
-          Log.warn("The concrete type or the reference type does not have an AST node. "
-              + "Incarnation mapping is only defined for CDTypeSymbol with AST nodes.");
-        }
-      }
-      else if (conTypeSymbol.getFullName().equals(refTypeSymbol.getFullName())) {
-        /*
-         * ONLY if the types are NO CDTypeSymbols, we allow the same types to match!
-         * CDTypes may not be a match even if their name is exactly the same, as the reference
-         * type not exist in the concrete CD!
-         */
-        return true;
-      }
-    }
-    /*
-     * we need this as fallback for all types that are not CDTypes,  e.g., primitives, String etc.
-     */
-    return conType.deepEquals(refType);
-  }
+  boolean isMatched(ASTMCType conType, ASTMCType refType);
   
-  public void setTypeMatcher(BooleanMatchingStrategy<ASTCDType> typeMatcher) {
-    this.typeMatcher = typeMatcher;
+  default void setCDTypeMatcher(BooleanMatchingStrategy<ASTCDType> cdTypeMatcher) {
+    // Can be overridden if implementation needs access to the matching of CDTypes
   }
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/TypeCheckMCTypeMatchingStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/TypeCheckMCTypeMatchingStrategy.java
@@ -1,0 +1,84 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.cdconformance.inc.mctype;
+
+import de.monticore.cd4code.typescalculator.FullSynthesizeFromCD4Code;
+import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdmatcher.BooleanMatchingStrategy;
+import de.monticore.types.check.ISynthesize;
+import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types.mcbasictypes._ast.ASTMCType;
+import de.monticore.types3.generics.bounds.Bound;
+import de.se_rwth.commons.logging.Log;
+
+import java.util.List;
+
+/**
+ * A matching strategy for {@link ASTMCType}s that used the MontiCore type check mechanism to
+ * check if a concrete type is an incarnation of a reference type.<br>
+ * This enabled us to use the full generics support of MontiCore and still respect the incarnation
+ * mapping for (nested) type parameters.<br>
+ * <br>
+ * See {@link IncMappingAwareSymTypeCompatibilityCalculator} for how we extend the original type
+ * relations to support incarnations.
+ */
+public class TypeCheckMCTypeMatchingStrategy implements MCTypeMatchingStrategy {
+  
+  protected String underspecifiedTypeName;
+  protected ISynthesize typeCalculator; // TODO Use TypeCheck3 once available
+  protected IncMappingAwareSymTypeCompatibilityCalculator compatibilityCalculator;
+  
+  public TypeCheckMCTypeMatchingStrategy(String underspecifiedTypeName) {
+    this.underspecifiedTypeName = underspecifiedTypeName;
+    this.typeCalculator = new FullSynthesizeFromCD4Code();
+    this.compatibilityCalculator = new IncMappingAwareSymTypeCompatibilityCalculator();
+  }
+  
+  /**
+   * Returns if the given concrete type is an incarnation of the given reference type.
+   *
+   * @param conType the concrete type
+   * @param refType the reference type
+   * @return true if the types are matched, false otherwise
+   */
+  public boolean isMatched(ASTMCType conType, ASTMCType refType) {
+    if (MCTypeUtil.isUnderspecified(underspecifiedTypeName, refType)) {
+      if (MCTypeUtil.isUnderspecified(underspecifiedTypeName, conType)) {
+        Log.error("The underspecified placeholder type is not allowed as a concrete type.");
+        return false;
+      }
+      // every type is allowed if the reference type is underspecified
+      return true;
+    }
+    // TODO Use TypeCheck3
+    SymTypeExpression concreteType = typeCalculator.synthesizeType(conType).getResult();
+    SymTypeExpression referenceType = typeCalculator.synthesizeType(refType).getResult();
+    /*
+     * Compatibility calculator knows the incarnation mapping and checks if the concrete
+     * type is an incarnation of the reference type.if both are CDTypeSymbols.
+     * As a result, we get full generics support and respect the incarnation mapping even
+     * in nested generic typ parameters.
+     */
+    // TODO check if all incarnations used as type parameters in the concrete type are conflict
+    //  free. i.e.
+    //  1. not two different incarnations of the same reference type in the same type
+    //  2. no conflicting bindings attached to one of the type parameters
+    //  (can be solved with a simple visitor once we have the "Binding" infrastructure from OCL
+    //   available here)
+    List<Bound> result = compatibilityCalculator.constrainSameType(concreteType, referenceType);
+    /*
+     * IMPORTANT: Do NOT log an error here if it is no match! Conformance checking code might call
+     * this for multiple candidate where only one is expected to match. If we log an error
+     * here this results in a failure in the end. Even info/debug logs will result in confusion
+     * for users/developers, as they will see invalid matches for the other candidates.
+     * It is the responsibility of the conformance checking code to report errors if no match is
+     * found for any candidate.
+     */
+    return result.isEmpty();
+  }
+  
+  @Override
+  public void setCDTypeMatcher(BooleanMatchingStrategy<ASTCDType> cdTypeMatcher) {
+    compatibilityCalculator.setCDTypeMatcher(cdTypeMatcher);
+  }
+  
+}

--- a/cddiff/src/main/java/de/monticore/cdmatcher/MatchCDAssocsBySrcTypeAndTgtRole.java
+++ b/cddiff/src/main/java/de/monticore/cdmatcher/MatchCDAssocsBySrcTypeAndTgtRole.java
@@ -90,15 +90,21 @@ public class MatchCDAssocsBySrcTypeAndTgtRole implements
   
   /** We check if the referenced types match using the provided type-matcher. */
   protected boolean checkReference(String srcElem, String tgtElem) {
-    Optional<CDTypeSymbol> srcTypeSymbol = srcCD.getEnclosingScope().resolveCDTypeDown(srcElem);
-    Optional<CDTypeSymbol> tgtTypeSymbol = tgtCD.getEnclosingScope().resolveCDTypeDown(tgtElem);
+    Optional<ASTCDType> srcType = resolveConcreteCDTyp(srcElem);
+    Optional<ASTCDType> tgtType = resolveReferenceCDTyp(tgtElem);
     
-    if (srcTypeSymbol.isPresent() && tgtTypeSymbol.isPresent()) {
-      ASTCDType srcType = srcTypeSymbol.get().getAstNode();
-      ASTCDType tgtType = tgtTypeSymbol.get().getAstNode();
-      return typeMatcher.isMatched(srcType, tgtType);
+    if (srcType.isPresent() && tgtType.isPresent()) {
+      return typeMatcher.isMatched(srcType.get(), tgtType.get());
     }
     return false;
+  }
+  
+  protected Optional<ASTCDType> resolveConcreteCDTyp(String qName) {
+    return srcCD.getEnclosingScope().resolveCDTypeDown(qName).map(CDTypeSymbol::getAstNode);
+  }
+  
+  protected Optional<ASTCDType> resolveReferenceCDTyp(String qName) {
+    return tgtCD.getEnclosingScope().resolveCDTypeDown(qName).map(CDTypeSymbol::getAstNode);
   }
   
   protected boolean checkRole(ASTCDAssocSide srcElem, ASTCDAssocSide tgtElem) {

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -4,6 +4,7 @@ package de.monticore.cdconcretization;
 import de.monticore.cdconformance.CDConfParameter;
 import de.monticore.cdconformance.CDConformanceChecker;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
@@ -118,6 +119,24 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
         "evaluation/cross-references/MicroserviceConc.cd",
         "evaluation/cross-references/MicroserviceRef.cd",
         "evaluation/cross-references/MicroserviceOut.cd");
+  }
+  
+  @Nested
+  class Banking {
+    
+    @Test
+    void singleInc() {
+      testConcretizedConformsToRefAndExpectedOut("evaluation/banking/singleInc/BankingConc.cd",
+          "evaluation/banking/BankingRef.cd", "evaluation/banking/singleInc/BankingOut.cd");
+    }
+    
+    @Test
+    void usageByExtension() {
+      testConcretizedConformsToRefAndExpectedOut(
+          "evaluation/banking/usageByExtension/BankingConc.cd", "evaluation/banking/BankingRef.cd",
+          "evaluation/banking/usageByExtension/BankingOut.cd");
+    }
+    
   }
   
 }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -130,6 +130,17 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
           "evaluation/banking/BankingRef.cd", "evaluation/banking/singleInc/BankingOut.cd");
     }
     
+    /*
+     * Should be resolved when using new incarnation mapping/binding abstractions.
+     * See https://git.rwth-aachen.de/se-student/theses/ma-jorden/master-theses/-/issues/68
+     */
+    @Disabled("currently not working because 'bind' is not considered when completing associations")
+    @Test
+    void multiInc() {
+      testConcretizedConformsToRefAndExpectedOut("evaluation/banking/multiInc/BankingConc.cd",
+          "evaluation/banking/BankingRef.cd", "evaluation/banking/multiInc/BankingOut.cd");
+    }
+    
     @Test
     void usageByExtension() {
       testConcretizedConformsToRefAndExpectedOut(

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -3,6 +3,7 @@ package de.monticore.cdconcretization;
 
 import de.monticore.cdconformance.CDConfParameter;
 import de.monticore.cdconformance.CDConformanceChecker;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
@@ -92,6 +93,31 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
         "ConcreteVisitable", "InnerNode");
     assertTypeBindingExists(checker, resolveConMethod("NodeVisitor.visit(RootNode)"),
         "ConcreteVisitable", "RootNode");
+  }
+  
+  /**
+   * This test shows a limitation of the current incarnation binding concept. Currently,
+   * incarnations are completely independent of each other.
+   * For each incarnation C of a reference type R we attach a binding R=C to C. This is useful,
+   * e.g., in the Getter/Setter example where we want to limit the attribute incarnations to only
+   * these within the specific type incarnation.<br>
+   * <br>
+   * FUTURE work: To implement cross-incarnation-references, we need add a variant of the forEach
+   * stereotype that considers all incarnation independently of the current binding context, e.g.:
+   * <pre>
+   * &lt;&lt;forEachGlobal="Microservice as OtherService"&gt;&gt; void sendToOtherService(...)
+   * </pre>
+   * (see thesis for details).
+   */
+  @Test
+  @Disabled("shows limitation of current concept")
+  void testCrossReferences() {
+    // TODO Remove once we have explicit support for 'forEach' conformance check
+    confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
+    CDConformanceChecker checker = testConcretizedConformsToRefAndExpectedOut(
+        "evaluation/cross-references/MicroserviceConc.cd",
+        "evaluation/cross-references/MicroserviceRef.cd",
+        "evaluation/cross-references/MicroserviceOut.cd");
   }
   
 }

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -141,7 +141,7 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
   }
   
   @ParameterizedTest
-  @ValueSource(strings = { "Concrete.cd" })
+  @ValueSource(strings = { "Concrete.cd", "Unchanged.cd" })
   public void testAttributeTypeIncarnationValid(String concrete) {
     parseModels("attributes/typeIncarnation/valid/" + concrete,
         "attributes/typeIncarnation/Reference.cd");
@@ -150,7 +150,7 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
   }
   
   @ParameterizedTest
-  @ValueSource(strings = { "NotMarkedAsIncarnation.cd" })
+  @ValueSource(strings = { "NotMarkedAsIncarnation.cd", "TypeParamNoIncarnation.cd" })
   public void testAttributeTypeIncarnationInvalid(String concrete) {
     parseModels("attributes/typeIncarnation/invalid/" + concrete,
         "attributes/typeIncarnation/Reference.cd");

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -249,4 +249,24 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
     assertFalse(checker.checkConformance(conCD, refCD, "ref"));
   }
   
+  @ParameterizedTest
+  @ValueSource(strings = { "Valid1.cd" })
+  public void testAssocImplicitRoleNameValid(String concrete) {
+    parseModels("associations/implicit_role_name/valid/" + concrete,
+        "associations/implicit_role_name/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(INHERITANCE, NAME_MAPPING, STEREOTYPE_MAPPING,
+        SRC_TARGET_ASSOC_MAPPING));
+    assertTrue(checker.checkConformance(conCD, refCD, "ref"));
+  }
+  
+  @ParameterizedTest
+  @ValueSource(strings = { "Valid1.cd" })
+  public void testAssocRoleNameDerivedFromTypeValid(String concrete) {
+    parseModels("associations/role_name_derived_from_type/valid/" + concrete,
+        "associations/role_name_derived_from_type/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(INHERITANCE, NAME_MAPPING, STEREOTYPE_MAPPING,
+        SRC_TARGET_ASSOC_MAPPING));
+    assertTrue(checker.checkConformance(conCD, refCD, "ref"));
+  }
+  
 }

--- a/cddiff/src/test/java/de/monticore/cdconformance/ConfAbstractTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/ConfAbstractTest.java
@@ -47,10 +47,9 @@ public abstract class ConfAbstractTest {
       else {
         fail("Could not parse CDs.");
       }
-      
     }
     catch (IOException e) {
-      fail(e.getMessage());
+      fail(e);
     }
   }
   

--- a/cddiff/src/test/java/de/monticore/cdconformance/ConfAbstractTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/ConfAbstractTest.java
@@ -7,7 +7,7 @@ import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._symboltable.CD4CodeSymbolTableCompleter;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
-import de.se_rwth.commons.logging.LogStub;
+import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +24,8 @@ public abstract class ConfAbstractTest {
   
   @BeforeEach
   public void setup() {
-    LogStub.init();
+    Log.init();
+    Log.enableFailQuick(false);
     CD4CodeMill.reset();
     CD4CodeMill.init();
     CD4CodeMill.globalScope().clear();

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/BankingRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/BankingRef.cd
@@ -1,0 +1,33 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram Banking {
+
+  class Bank {
+    String id;
+    double overallBalance; // money of all accounts together
+  }
+
+  class Account {
+    String id;
+    double balance; // money in the account
+  }
+
+  class Customer {
+    String name;
+    String address;
+    String phoneNumber;
+  }
+
+  // sends money from sourceAccount to targetAccount
+  class Transaction {
+    Account sourceAccount;
+    Account targetAccount;
+    double amount;
+  }
+
+  association Bank -> Account [*];
+  association Bank -> Customer [*];
+  association [*] Account <-> Customer [*];
+  association Account -> Transaction [*] <<ordered>>;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/multiInc/BankingConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/multiInc/BankingConc.cd
@@ -1,0 +1,22 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram Banking {
+
+  <<ref="Bank">> class SEPABank {
+    <<ref="id">> String bic;
+    <<ref="overallBalance", bind="Account=PrivateAccount">> double privateAccountsOverallBalance;
+    <<ref="overallBalance", bind="Account=BusinessAccount">> double businessAccountsOverallBalance;
+  }
+
+  <<ref="Account", bind="Customer=PrivateCustomer">> class PrivateAccount {
+    <<ref="id">> String iban;
+  }
+
+  <<ref="Account", bind="Customer=BusinessCustomer">> class BusinessAccount {
+    <<ref="id">> String iban;
+  }
+
+  <<ref="Customer">> class PrivateCustomer;
+  <<ref="Customer">> class BusinessCustomer;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/multiInc/BankingOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/multiInc/BankingOut.cd
@@ -1,0 +1,49 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram Banking {
+
+  <<ref="Bank">> class SEPABank {
+    <<ref="id">> String bic;
+    <<ref="overallBalance", bind="Account=PrivateAccount">> double privateAccountsOverallBalance;
+    <<ref="overallBalance", bind="Account=BusinessAccount">> double businessAccountsOverallBalance;
+  }
+
+  <<ref="Account", bind="Customer=PrivateCustomer">> class PrivateAccount {
+    <<ref="id">> String iban;
+    double balance; // money in the account
+  }
+
+  <<ref="Account", bind="Customer=BusinessCustomer">> class BusinessAccount {
+    <<ref="id">> String iban;
+    double balance; // money in the account
+  }
+
+  <<ref="Customer">> class PrivateCustomer {
+    String name;
+    String address;
+    String phoneNumber;
+  }
+
+  <<ref="Customer">> class BusinessCustomer {
+    String name;
+    String address;
+    String phoneNumber;
+  }
+
+  // sends money from sourceAccount to targetAccount
+  class Transaction {
+    PrivateAccount sourceAccount;
+    PrivateAccount targetAccount;
+    double amount;
+  }
+
+  association SEPABank -> PrivateAccount [*];
+  association SEPABank -> BusinessAccount [*];
+  association SEPABank -> PrivateCustomer [*];
+  association SEPABank -> BusinessCustomer [*];
+  association [*] PrivateAccount <-> PrivateCustomer [*];
+  association [*] BusinessAccount <-> BusinessCustomer [*];
+  association PrivateAccount -> Transaction [*] <<ordered>>;
+  association BusinessAccount -> Transaction [*] <<ordered>>;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/singleInc/BankingConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/singleInc/BankingConc.cd
@@ -1,0 +1,14 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram Banking {
+
+  <<ref="Bank">> class SEPABank {
+    <<ref="id">> String bic;
+    <<ref="overallBalance">> double totalMoney; // money of all accounts together
+  }
+
+  <<ref="Account">> class BankAccount {
+    <<ref="id">> String iban;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/singleInc/BankingOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/singleInc/BankingOut.cd
@@ -1,0 +1,33 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram Banking {
+
+  <<ref="Bank">> class SEPABank {
+    <<ref="id">> String bic;
+    <<ref="overallBalance">> double totalMoney; // money of all accounts together
+  }
+
+  <<ref="Account">> class BankAccount {
+    <<ref="id">> String iban;
+    double balance; // money in the account
+  }
+
+  class Customer {
+    String name;
+    String address;
+    String phoneNumber;
+  }
+
+  // sends money from sourceAccount to targetAccount
+  class Transaction {
+    BankAccount sourceAccount;
+    BankAccount targetAccount;
+    double amount;
+  }
+
+  association SEPABank -> BankAccount [*];
+  association SEPABank -> Customer [*];
+  association [*] BankAccount <-> Customer [*];
+  association BankAccount -> Transaction [*] <<ordered>>;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/usageByExtension/BankingConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/usageByExtension/BankingConc.cd
@@ -1,0 +1,17 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram Banking {
+
+  <<ref="Bank">> class SEPABank {
+    <<ref="id">> String bic;
+    <<ref="overallBalance">> double totalMoney; // money of all accounts together
+  }
+
+  <<ref="Account">> class BankAccount {
+    <<ref="id">> String iban;
+  }
+
+  class PrivateAccount extends BankAccount;
+  class BusinessAccount extends BankAccount;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/usageByExtension/BankingOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking/usageByExtension/BankingOut.cd
@@ -1,0 +1,36 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram Banking {
+
+  <<ref="Bank">> class SEPABank {
+    <<ref="id">> String bic;
+    <<ref="overallBalance">> double totalMoney; // money of all accounts together
+  }
+
+  <<ref="Account">> class BankAccount {
+    <<ref="id">> String iban;
+    double balance; // money in the account
+  }
+
+  class PrivateAccount extends BankAccount;
+  class BusinessAccount extends BankAccount;
+
+  class Customer {
+    String name;
+    String address;
+    String phoneNumber;
+  }
+
+  // sends money from sourceAccount to targetAccount
+  class Transaction {
+    BankAccount sourceAccount;
+    BankAccount targetAccount;
+    double amount;
+  }
+
+  association SEPABank -> BankAccount [*];
+  association SEPABank -> Customer [*];
+  association [*] BankAccount <-> Customer [*];
+  association BankAccount -> Transaction [*] <<ordered>>;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/cross-references/MicroserviceConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/cross-references/MicroserviceConc.cd
@@ -1,0 +1,6 @@
+classdiagram MicroserviceConc {
+  <<ref="Microservice">> class UserService;
+  <<ref="Microservice">> class OrderService;
+  <<ref="Microservice">> class ProductService;
+  <<ref="Microservice">> class InvoiceService;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/cross-references/MicroserviceOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/cross-references/MicroserviceOut.cd
@@ -1,0 +1,31 @@
+import java.lang.String;
+
+classdiagram MicroserviceConc {
+  <<ref="Microservice">> class UserService {
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToUserService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToOrderService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToProductService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToInvoiceService(String message);
+  }
+
+  <<ref="Microservice">> class OrderService {
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToUserService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToOrderService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToProductService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToInvoiceService(String message);
+  }
+
+  <<ref="Microservice">> class ProductService {
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToUserService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToOrderService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToProductService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToInvoiceService(String message);
+  }
+
+  <<ref="Microservice">> class InvoiceService {
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToUserService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToOrderService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToProductService(String message);
+    <<ref="MicroserviceRef.Microservice.sendToMicroservice">> void sendToInvoiceService(String message);
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/cross-references/MicroserviceRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/cross-references/MicroserviceRef.cd
@@ -1,0 +1,7 @@
+import java.lang.String;
+
+classdiagram MicroserviceRef {
+  class Microservice {
+    <<forEach="Microservice">> void sendToMicroservice(String message);
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/implicit_role_name/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/implicit_role_name/Reference.cd
@@ -1,0 +1,10 @@
+import java.lang.String;
+
+classdiagram Reference {
+  class Account;
+
+  class Person ;
+
+  association Account (account) -> (person)  Person[1];
+  association Person  -> Account[*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/implicit_role_name/valid/Valid1.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/implicit_role_name/valid/Valid1.cd
@@ -1,0 +1,10 @@
+import java.lang.String;
+
+classdiagram Reference {
+  class Account;
+
+  class Person;
+
+  association Account -> Person[1];
+  association Person  (person) -> (account) Account[*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/role_name_derived_from_type/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/role_name_derived_from_type/Reference.cd
@@ -1,0 +1,10 @@
+import java.lang.String;
+
+classdiagram Reference {
+  class Account;
+
+  class Person ;
+
+  association Account (account) -> (person)  Person[1];
+  association Person  (person)  -> (account) Account[*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/role_name_derived_from_type/valid/Valid1.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/role_name_derived_from_type/valid/Valid1.cd
@@ -1,0 +1,10 @@
+import java.lang.String;
+
+classdiagram Reference {
+  <<ref="Account">> class BankAccount;
+
+  <<ref="Person">> class User;
+
+  association BankAccount (bankAccount) -> (user)  User[1];
+  association User  (user)  -> (bankAccount) BankAccount[*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/Reference.cd
@@ -1,3 +1,5 @@
+import java.lang.String;
+
 classdiagram Reference {
 
   class Address {
@@ -9,5 +11,6 @@ classdiagram Reference {
 
   class Employee {
     Address address;
+    Set<Address> secondaryAddresses;
   }
 }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/NotMarkedAsIncarnation.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/NotMarkedAsIncarnation.cd
@@ -1,3 +1,5 @@
+import java.lang.String;
+
 classdiagram Concrete {
 
   class AddressInfo {
@@ -9,5 +11,6 @@ classdiagram Concrete {
 
   class Employee {
     AddressInfo address;
+    Set<AddressInfo> secondaryAddresses;
   }
 }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/TypeParamNoIncarnation.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/TypeParamNoIncarnation.cd
@@ -2,7 +2,7 @@ import java.lang.String;
 
 classdiagram Concrete {
 
-  <<ref="Address">> class AddressInfo {
+  class Address {
     String streetName;
     String houseNr;
     String city;
@@ -10,7 +10,9 @@ classdiagram Concrete {
   }
 
   class Employee {
-    AddressInfo address;
-    Set<AddressInfo> secondaryAddresses;
+    Address address;
+    Set<Foo> secondaryAddresses;
   }
+
+  class Foo;
 }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/valid/Unchanged.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/valid/Unchanged.cd
@@ -2,7 +2,7 @@ import java.lang.String;
 
 classdiagram Concrete {
 
-  <<ref="Address">> class AddressInfo {
+  class Address {
     String streetName;
     String houseNr;
     String city;
@@ -10,7 +10,7 @@ classdiagram Concrete {
   }
 
   class Employee {
-    AddressInfo address;
-    Set<AddressInfo> secondaryAddresses;
+    Address address;
+    Set<Address> secondaryAddresses;
   }
 }


### PR DESCRIPTION
## Added
- New association incarnation strategy: `ImplicitRoleNameAssocIncStrategy` is based on "source type and target role strategy" that respects implicit role names without explicit mapping stereotype. e.g. role "employee" is allowed as incarnation of "person" if the related target types are "Employee" in concrete CD and "Person" in reference CD && "Employee" incarnates "Person"
- Add query methods for all bindings of a certain symbol kind (type, field, method) to `CDIncarnationBindings`
- Incarnation mapping support for generic types, e.g. `Set<Foo>` incarnates `Set<Bar>` if `Foo` incarnates `Bar`

## Fixes
- Use `BasicSymbolsMill` instead of `CD4CodeMill` so `UnderspecifiedPlaceholderType` is not coupled to CD4A (required or OCL)
- Always add a binding for the parameter element of a "forEach" annotated element when deriving bindings (at the moment incarnations of forEach-annotated elements are always independent and the parameter element is fixed to a single incarnation). For limitations of this, check the added "cross-references" test case.

## Tests
- Added disabled test cases showing a limitation of the current concept (incarnations are non-overlapping)
