### PR TITLE
fix: getReferencingAssociations check type equality using symbols names

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/type/BasicTypeConfStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/type/BasicTypeConfStrategy.java
@@ -165,6 +165,16 @@ public class BasicTypeConfStrategy implements ConformanceStrategy<ASTCDType> {
         .getReferencingAssociations(refType, refCD));
   }
   
+  /**
+   * Checks if all reference associations are incarnated by one of the given concrete associations
+   * at least once.<br>
+   * If the reference association is annotated with the stereotype <code>optional</code>, it is not
+   * required to be incarnated.
+   *
+   * @param con the concrete associations
+   * @param ref the reference associations
+   * @return true if all required reference associations are incarnated, false otherwise
+   */
   protected boolean checkAssocIncarnation(Set<ASTCDAssociation> con, Set<ASTCDAssociation> ref) {
     return ref.stream().allMatch(refAssoc -> (refAssoc.getModifier().isPresentStereotype()
         && refAssoc.getModifier().getStereotype().contains("optional")) || con.stream().anyMatch(

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/type/DeepTypeConfStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/type/DeepTypeConfStrategy.java
@@ -50,10 +50,7 @@ public class DeepTypeConfStrategy extends BasicTypeConfStrategy {
     
     Set<ASTCDAssociation> conAssocSet = CDDiffUtil.getAllSuperTypes(concrete, conCD
         .getCDDefinition()).stream().flatMap(supertype -> CDDiffUtil.getReferencingAssociations(
-            supertype, conCD).stream().filter(assoc -> supertype.getSymbol()
-                .getInternalQualifiedName().contains(assoc.getLeftQualifiedName().getQName())
-                || supertype.getSymbol().getInternalQualifiedName().contains(assoc
-                    .getRightQualifiedName().getQName()))).collect(Collectors.toSet());
+            supertype, conCD).stream()).collect(Collectors.toSet());
     
     conAssocSet.addAll(CDDiffUtil.getReferencingAssociations(concrete, conCD));
     

--- a/cddiff/src/main/java/de/monticore/cddiff/CDDiffUtil.java
+++ b/cddiff/src/main/java/de/monticore/cddiff/CDDiffUtil.java
@@ -5,6 +5,7 @@ import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._symboltable.CD4CodeSymbolTableCompleter;
 import de.monticore.cd4code._symboltable.ICD4CodeArtifactScope;
 import de.monticore.cd4code._visitor.CD4CodeTraverser;
+import de.monticore.cd4code.typescalculator.FullSynthesizeFromCD4Code;
 import de.monticore.cdassociation._ast.ASTCDAssocSide;
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdbasis._ast.*;
@@ -17,6 +18,7 @@ import de.monticore.od4report.OD4ReportMill;
 import de.monticore.od4report._parser.OD4ReportParser;
 import de.monticore.odbasis._ast.ASTODArtifact;
 import de.monticore.symboltable.ImportStatement;
+import de.monticore.types.check.ISynthesize;
 import de.monticore.types.check.SymTypeExpression;
 import de.monticore.types.mcbasictypes._ast.ASTMCObjectType;
 import de.se_rwth.commons.logging.Log;
@@ -316,10 +318,25 @@ public class CDDiffUtil {
   /** A helper function to compute all associations in cd that reference astcdType. */
   public static Set<ASTCDAssociation> getReferencingAssociations(ASTCDType astcdType,
       ASTCDCompilationUnit cd) {
-    return cd.getCDDefinition().getCDAssociationsList().stream().filter(rAssoc -> astcdType
-        .getSymbol().getInternalQualifiedName().contains(rAssoc.getLeftQualifiedName().getQName())
-        || astcdType.getSymbol().getInternalQualifiedName().contains(rAssoc.getRightQualifiedName()
-            .getQName())).collect(Collectors.toSet());
+    // TODO Use TypeCheck3
+    ISynthesize typeSynthesizer = new FullSynthesizeFromCD4Code();
+    
+    String typeFullName = astcdType.getSymbol().getFullName();
+    return cd.getCDDefinition().getCDAssociationsList().stream().filter(rAssoc -> {
+      SymTypeExpression leftType = typeSynthesizer.synthesizeType(rAssoc.getLeft()
+          .getMCQualifiedType()).getResult();
+      SymTypeExpression rightType = typeSynthesizer.synthesizeType(rAssoc.getRight()
+          .getMCQualifiedType()).getResult();
+      if (!leftType.hasTypeInfo() || !rightType.hasTypeInfo()) {
+        Log.error("Could not get type for association sides" + CD4CodeMill.prettyPrint(rAssoc,
+            false));
+        return false;
+      }
+      else {
+        return leftType.getTypeInfo().getFullName().equals(typeFullName) || rightType.getTypeInfo()
+            .getFullName().equals(typeFullName);
+      }
+    }).collect(Collectors.toSet());
   }
   
   public static List<ASTCDType> getAllCDTypes(ASTCDCompilationUnit cd) {

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -186,7 +186,7 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
   }
   
   @ParameterizedTest
-  @ValueSource(strings = { "FalseDirection.cd", "FalseCard.cd" })
+  @ValueSource(strings = { "FalseDirection.cd", "FalseCard.cd", "MissingAssocInc.cd" })
   public void testDeepAssocConformanceInvalid(String concrete) {
     parseModels("associations/invalid/" + concrete, "associations/Reference.cd");
     checker = new CDConformanceChecker(Set.of(INHERITANCE, NAME_MAPPING, STEREOTYPE_MAPPING));

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/invalid/MissingAssocInc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/invalid/MissingAssocInc.cd
@@ -1,0 +1,23 @@
+import java.lang.String;
+
+classdiagram MissingAssocInc {
+
+ abstract class AccountTop;
+ abstract class PersonTop;
+
+  class Account extends AccountTop;
+  <<ref="Account">>class BankAccount extends AccountTop;
+
+  class Person  extends PersonTop;
+
+  association belongTo AccountTop    -> Person[1];
+  association access   PersonTop     -> Account[*];
+
+  /*
+   * There is no association between BankAccount and Person matching the "access" reference assoc.
+   * Either we have to add a dedicated association for "bankAccountAccess" (see Valid1.cd) or
+   * change 'Account' to 'AccountTop' as it is a common superclass of both 'Account' and
+   * 'BankAccount'.
+   */
+}
+

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/valid/InhrBothSides.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/valid/InhrBothSides.cd
@@ -11,5 +11,5 @@ abstract  class PersonTop;
   class Person  extends PersonTop;
 
   association belongTo AccountTop    -> Person[1];
-  association access   PersonTop     -> Account[*];
+  association access   PersonTop     -> AccountTop[*];
 }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/valid/Valid1.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/valid/Valid1.cd
@@ -12,5 +12,6 @@ classdiagram Valid1 {
 
   association belongTo AccountTop    -> Person[1];
   association access   PersonTop     -> Account[*];
+  <<ref="access">> association bankAccountAccess PersonTop -> BankAccount[*];
 }
 


### PR DESCRIPTION
## What?
Properly compare the given type and association left/right types using symbol table in `CDDiffUtil.getReferencingAssociations`. 
This is exactly what the method should do: Find all associations where the type is either used on the left or right side.

## Why?
Before, a wrong comparison was used to check for equality of the type without using the type check
```
astcdType
        .getSymbol().getInternalQualifiedName().contains(rAssoc.getLeftQualifiedName().getQName()
```
What is the issue here? Consider the following CD:
```
classdiagram UserManagement {
  class User;
  class Role;
  class UserRole extends Role ;
  
  association [1]  User  -> (sessions) Session[1..*] ;
}
```
When we call `CDDiffUtil.getReferencingAssociations` for class `UserManagement.UserRole`, the left type of the association is `User`, which is a substring of `UserManagement.UserRole` ! Even if the name would be fully qualified, e.g. `UserManagement.User` this would still be a match, although it is complete nonsense 🥲 

## Tests
- adjusted test case conformance check which was actually invalid but successful because of the bug
- added invalid test case to ensure we not introduce the bug again