### PR TITLE
Minor fixes for CDConf & CDConc

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/association/BasicAssocConfStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/association/BasicAssocConfStrategy.java
@@ -41,7 +41,17 @@ public class BasicAssocConfStrategy implements ConformanceStrategy<ASTCDAssociat
   }
   
   public boolean checkConformance(ASTCDAssociation concrete, ASTCDAssociation ref) {
-    return check(concrete, ref) || checkReverse(concrete, ref);
+    if (check(concrete, ref)) {
+      warnExplicitRoleNameMissing(concrete.getLeft(), ref.getLeft());
+      warnExplicitRoleNameMissing(concrete.getRight(), ref.getRight());
+      return true;
+    }
+    if (checkReverse(concrete, ref)) {
+      warnExplicitRoleNameMissing(concrete.getLeft(), ref.getRight());
+      warnExplicitRoleNameMissing(concrete.getRight(), ref.getLeft());
+      return true;
+    }
+    return false;
   }
   
   protected boolean check(ASTCDAssociation concrete, ASTCDAssociation ref) {
@@ -112,6 +122,29 @@ public class BasicAssocConfStrategy implements ConformanceStrategy<ASTCDAssociat
     }
     return !ref.isPresentCDCardinality() || concrete.getCDCardinality().deepEquals(ref
         .getCDCardinality());
+  }
+  
+  /**
+   * Warns if the concrete association side does not have an explicit role name although the
+   * matching reference association side has an explicit role name.
+   *
+   * @param concrete the concrete association side
+   * @param reference the reference association side
+   */
+  protected void warnExplicitRoleNameMissing(ASTCDAssocSide concrete, ASTCDAssocSide reference) {
+    if (reference.isPresentCDRole() && !concrete.isPresentCDRole()) {
+      /*
+       * Strategies like ImplicitRoleNameAssocIncStrategy might return matches where no concrete
+       * role name is present, but the implicit name (by convention) is matches the reference
+       * role name.
+       * We warn the user and recommend to provide an explicit concrete role name if there is an
+       * explicit reference role name. There are conventions for the implicit name but better not
+       * rely on having the same convention in mind as the reference modeler.
+       */
+      Log.warn("There is no explicit concrete role name although the matching reference "
+          + "association side has an explicit role name (" + reference.getCDRole().getName()
+          + "). This is not recommended.", concrete.get_SourcePositionStart());
+    }
   }
   
   protected boolean checkReference(String concrete, String ref) {

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/association/ImplicitRoleNameAssocIncStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/association/ImplicitRoleNameAssocIncStrategy.java
@@ -61,8 +61,15 @@ public class ImplicitRoleNameAssocIncStrategy extends MatchCDAssocsBySrcTypeAndT
       }
       else if (reference.isPresentCDRole()) {
         String refRoleName = reference.getCDRole().getName();
-        // If no concrete role is present, it is still a match if the reference role is exactly
-        // the implicit role name.
+        /*
+         * If no concrete role is present, it is still a match if the reference role is exactly
+         * the implicit role name.
+         * However, the conformance checker will warn the user to provide a concrete role name if
+         * there is an explicit reference role name.
+         * See BasicAssocConfStrategy.warnExplicitRoleNameMissing.
+         * NOTE: We should not warn here, because this strategy is not only used for conformance
+         * checking but also during concretization, where we add the missing role name anyway.
+          */
         return refRoleName.equals(implicitRefRoleName);
       }
     }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/AbstractCDConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/AbstractCDConcretizationTest.java
@@ -20,6 +20,8 @@ import de.se_rwth.commons.logging.Log;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+
+import de.se_rwth.commons.logging.LogStub;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -42,8 +44,7 @@ public abstract class AbstractCDConcretizationTest {
   
   @BeforeAll
   public static void setup() {
-    Log.init();
-    Log.enableFailQuick(false);
+    LogStub.init();
   }
   
   @BeforeEach

--- a/cddiff/src/test/java/de/monticore/cdconformance/ConfAbstractTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/ConfAbstractTest.java
@@ -1,16 +1,17 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconformance;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._symboltable.CD4CodeSymbolTableCompleter;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
-import de.se_rwth.commons.logging.Log;
+import de.se_rwth.commons.logging.LogStub;
+import org.junit.jupiter.api.BeforeEach;
+
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class ConfAbstractTest {
   
@@ -24,8 +25,7 @@ public abstract class ConfAbstractTest {
   
   @BeforeEach
   public void setup() {
-    Log.init();
-    Log.enableFailQuick(false);
+    LogStub.init();
     CD4CodeMill.reset();
     CD4CodeMill.init();
     CD4CodeMill.globalScope().clear();

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/Reference.cd
@@ -11,6 +11,13 @@ classdiagram Reference {
 
   class Employee {
     Address address;
+    // NOTE: Not super meaningful here, but we ensure all MCCollection types work
     Set<Address> secondaryAddresses;
+    Optional<Address> invoiceAddress;
+    List<Address> orderedAddresses;
+    Map<String, Address> addressMap;
+    Map<Address, String> addressToStringMap;
+    // ensure we can still process primitive parameters without error
+    Set<int> favoriteNumbers;
   }
 }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/NotMarkedAsIncarnation.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/NotMarkedAsIncarnation.cd
@@ -12,5 +12,10 @@ classdiagram Concrete {
   class Employee {
     AddressInfo address;
     Set<AddressInfo> secondaryAddresses;
+    Optional<AddressInfo> invoiceAddress;
+    List<AddressInfo> orderedAddresses;
+    Map<String, AddressInfo> addressMap;
+    Map<AddressInfo, String> addressToStringMap;
+    Set<int> favoriteNumbers;
   }
 }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/TypeParamNoIncarnation.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/invalid/TypeParamNoIncarnation.cd
@@ -12,6 +12,11 @@ classdiagram Concrete {
   class Employee {
     Address address;
     Set<Foo> secondaryAddresses;
+    Optional<Foo> invoiceAddress;
+    List<Foo> orderedAddresses;
+    Map<String, Foo> addressMap;
+    Map<Foo, String> addressToStringMap;
+    Set<int> favoriteNumbers;
   }
 
   class Foo;

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/valid/Concrete.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/valid/Concrete.cd
@@ -12,5 +12,10 @@ classdiagram Concrete {
   class Employee {
     AddressInfo address;
     Set<AddressInfo> secondaryAddresses;
+    Optional<AddressInfo> invoiceAddress;
+    List<AddressInfo> orderedAddresses;
+    Map<String, AddressInfo> addressMap;
+    Map<AddressInfo, String> addressToStringMap;
+    Set<int> favoriteNumbers;
   }
 }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/valid/Unchanged.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/attributes/typeIncarnation/valid/Unchanged.cd
@@ -12,5 +12,10 @@ classdiagram Concrete {
   class Employee {
     Address address;
     Set<Address> secondaryAddresses;
+    Optional<Address> invoiceAddress;
+    List<Address> orderedAddresses;
+    Map<String, Address> addressMap;
+    Map<Address, String> addressToStringMap;
+    Set<int> favoriteNumbers;
   }
 }


### PR DESCRIPTION
## Tests
- use `LogStub`
- cover type parameter incarnation check for `List`, `Map`, and `Optional` (not only `Set`) 

## Changed
- warn if no explicit concrete role is given but explicit reference role name is present in `ImplicitRoleNameAssocIncStrategy`