### PR TITLE
refactor(refmodel): rename handwritten TOP classes to 'Base'

### DIFF
--- a/cddiff/src/main/java/de/monticore/symbols/basicsymbols/refmodel/BasicSymbolsBindings.java
+++ b/cddiff/src/main/java/de/monticore/symbols/basicsymbols/refmodel/BasicSymbolsBindings.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class BasicSymbolsBindings extends BasicSymbolsBindingsTOP {
+public class BasicSymbolsBindings extends BasicSymbolsBindingsBase {
   
   protected BasicSymbolsBindings(Bindings<TypeSymbol> typeBindings,
       Bindings<VariableSymbol> variableBindings, Bindings<FunctionSymbol> functionBindings) {

--- a/cddiff/src/main/java/de/monticore/symbols/basicsymbols/refmodel/BasicSymbolsBindingsBase.java
+++ b/cddiff/src/main/java/de/monticore/symbols/basicsymbols/refmodel/BasicSymbolsBindingsBase.java
@@ -12,28 +12,33 @@ import de.se_rwth.commons.logging.Log;
 import java.util.Optional;
 import java.util.Set;
 
-public class BasicSymbolsBindingsTOP implements IBasicSymbolsBindings {
-  
-  /*
-   * NOTE: This class can be generated and developers can override methods to add additional checks
-   * for conflicts.
-   * For example, addFieldBinding to additionally check if it conflicts with type bindings,
-   * or addFunctionBinding to check if a parameter type of the function is already bound to
-   * something else
-   */
+/**
+ * Basic implementation of {@link IBasicSymbolsBindings}.<br>
+ * <br>
+ * <b>NOTE:</b> This class is intended to be GENERATED in the future! Therefore, only apply changes
+ * which are systematic and can be automatically derived from the language grammar.<br>
+ * <br>
+ * Developers can customize the semantic relations between different symbols, e.g. by overriding
+ * the {@code getXXXImpliedBindings}.
+ */
+/*
+ * TODO If this class is generated, remove the 'Base' suffix as MontiCore will automatically name
+ *   it TOP in case there is a handwritten implementation.
+ */
+public class BasicSymbolsBindingsBase implements IBasicSymbolsBindings {
   
   private final Bindings<TypeSymbol> typeBindings;
   private final Bindings<VariableSymbol> variableBindings;
   private final Bindings<FunctionSymbol> functionBindings;
   
-  protected BasicSymbolsBindingsTOP(Bindings<TypeSymbol> typeBindings,
+  protected BasicSymbolsBindingsBase(Bindings<TypeSymbol> typeBindings,
       Bindings<VariableSymbol> variableBindings, Bindings<FunctionSymbol> functionBindings) {
     this.typeBindings = typeBindings;
     this.variableBindings = variableBindings;
     this.functionBindings = functionBindings;
   }
   
-  public BasicSymbolsBindingsTOP() {
+  public BasicSymbolsBindingsBase() {
     this(new Bindings<>(), new Bindings<>(), new Bindings<>());
   }
   

--- a/cddiff/src/main/java/de/monticore/symbols/oosymbols/refmodel/OOSymbolsBindings.java
+++ b/cddiff/src/main/java/de/monticore/symbols/oosymbols/refmodel/OOSymbolsBindings.java
@@ -17,7 +17,7 @@ import de.monticore.symboltable.ISymbol;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class OOSymbolsBindings extends OOSymbolsBindingsTOP {
+public class OOSymbolsBindings extends OOSymbolsBindingsBase {
   
   public OOSymbolsBindings() {
     super();

--- a/cddiff/src/main/java/de/monticore/symbols/oosymbols/refmodel/OOSymbolsBindingsBase.java
+++ b/cddiff/src/main/java/de/monticore/symbols/oosymbols/refmodel/OOSymbolsBindingsBase.java
@@ -17,8 +17,20 @@ import de.se_rwth.commons.logging.Log;
 import java.util.Optional;
 import java.util.Set;
 
-// NOTE: Could be generated
-public class OOSymbolsBindingsTOP implements IOOSymbolsBindings {
+/**
+ * Basic implementation of {@link IOOSymbolsBindings}.<br>
+ * <br>
+ * <b>NOTE:</b> This class is intended to be GENERATED in the future! Therefore, only apply changes
+ * which are systematic and can be automatically derived from the language grammar.<br>
+ * <br>
+ * Developers can customize the semantic relations between different symbols, e.g. by overriding
+ * the {@code getXXXImpliedBindings}.
+ */
+/*
+ * TODO If this class is generated, remove the 'Base' suffix as MontiCore will automatically name
+ *   it TOP in case there is a handwritten implementation.
+ */
+public class OOSymbolsBindingsBase implements IOOSymbolsBindings {
   
   // ========== Symbol bindings from languages extended by OOSymbols ==========
   
@@ -33,11 +45,11 @@ public class OOSymbolsBindingsTOP implements IOOSymbolsBindings {
   private final Bindings<FieldSymbol> fieldBindings;
   private final Bindings<MethodSymbol> methodBindings;
   
-  public OOSymbolsBindingsTOP() {
+  public OOSymbolsBindingsBase() {
     this(new BasicSymbolsBindings(), new Bindings<>(), new Bindings<>(), new Bindings<>());
   }
   
-  protected OOSymbolsBindingsTOP(IBasicSymbolsBindings basicSymbolsBindings,
+  protected OOSymbolsBindingsBase(IBasicSymbolsBindings basicSymbolsBindings,
       Bindings<OOTypeSymbol> ooTypeBindings, Bindings<FieldSymbol> fieldBindings,
       Bindings<MethodSymbol> methodBindings) {
     this.basicSymbolsBindings = basicSymbolsBindings;


### PR DESCRIPTION
## Changed
Rename handwritten `TOP` classes to `Base` suffix and add comment explaining that they are intended to be generated in the future