### PR TITLE
CD Concretization: More Evaluation, Fixes & Type Parameter Adaptation Support

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/ConcretizationCompleter.java
@@ -48,7 +48,7 @@ import java.util.Set;
  */
 public class ConcretizationCompleter {
   
-  private final String mapping;
+  private String mapping;
   
   /**
    * If true, the conformance checker is used to check the conformance of the concretization result.
@@ -163,6 +163,8 @@ public class ConcretizationCompleter {
     // perform the actual concretization
     completerChainBuilder.build().complete(concreteCD, referenceCD, context);
   }
+  
+  public void setMapping(String mapping) { this.mapping = mapping; }
   
   /**
    * Configures if the conformance checker should be used to check the conformance of the

--- a/cddiff/src/main/java/de/monticore/cdconcretization/stereotype/StereotypeUtil.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/stereotype/StereotypeUtil.java
@@ -13,6 +13,11 @@ public class StereotypeUtil {
   public static final String FOR_EACH_STEREOTYPE = "forEach";
   
   /**
+   * Stereotype used to mark elements that are optional in the reference model.
+   */
+  public static final String OPTIONAL_STEREOTYPE = "optional";
+  
+  /**
    * Stereotype for binding a reference to a concrete type. This can be used by modelers to
    * manually inform other tools about the specific type incarnation to use in a certain scope of
    * the model.<br>
@@ -55,6 +60,20 @@ public class StereotypeUtil {
       String valueEmptyWarning) {
     return getStereotypeValue(modifier, BIND_STEREOTYPE, valueEmptyWarning).map(
         BindingValue::parseFromString);
+  }
+  
+  /**
+   * Checks if the given modifier contains the "optional" stereotype.
+   *
+   * @param modifier the ASTModifier to check
+   * @return true if the "optional" stereotype is present, false otherwise
+   */
+  public static boolean isOptional(ASTModifier modifier) {
+    if (modifier.isPresentStereotype()) {
+      ASTStereotype stereotype = modifier.getStereotype();
+      return stereotype.contains(OPTIONAL_STEREOTYPE);
+    }
+    return false;
   }
   
   /**

--- a/cddiff/src/main/java/de/monticore/cdconcretization/type/method/BaseMethodInTypeCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/type/method/BaseMethodInTypeCompleter.java
@@ -16,9 +16,13 @@ import de.monticore.cdconcretization.util.NameUtil;
 import de.monticore.symbols.basicsymbols._ast.ASTType;
 import de.monticore.types.check.ISynthesize;
 import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types.mcbasictypes._ast.ASTMCPrimitiveType;
+import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedType;
 import de.monticore.types.mcbasictypes._ast.ASTMCReturnType;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
+import de.monticore.types.mccollectiontypes._ast.*;
 import de.se_rwth.commons.logging.Log;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -71,6 +75,8 @@ public class BaseMethodInTypeCompleter extends AbstractMethodInTypeCompleter {
         parameterTypeIncarnations);
   }
   
+  // TODO This is generic functionality not limited to methods. It should be extracted and reused
+  // for attributes and associations as well.
   /**
    * Finds all incarnations of the given reference method in the given concrete type. If the type is
    * not a CD type, or there is no incarnation, the type is returned as is.
@@ -94,7 +100,14 @@ public class BaseMethodInTypeCompleter extends AbstractMethodInTypeCompleter {
         .isPresentAstNode() ? Optional.ofNullable(symTypeExpr.getTypeInfo().getAstNode()) : Optional
             .empty();
     if (rAttributeTypeOpt.isEmpty() || !(rAttributeTypeOpt.get() instanceof ASTCDType)) {
-      // if it is not a CD type, we cannot have incarnations and just use the type as is!
+      if (refMCType instanceof ASTMCCollectionTypesNode) {
+        // if it is a collection type, we can find the incarnations of the item type
+        return findMCCollectionTypeIncarnations((ASTMCCollectionTypesNode) refMCType, context);
+      }
+      /*
+       * If it is neither a CD type nor an MCCollection type, we cannot have incarnations and just
+       * use the type as is!
+       */
       return Collections.singletonList(refMCType);
     }
     
@@ -112,6 +125,85 @@ public class BaseMethodInTypeCompleter extends AbstractMethodInTypeCompleter {
                 .getInternalQualifiedName()));
       }
       return typeIncarnationsList;
+    }
+  }
+  
+  /**
+   * Finds all incarnations of the given reference MCCollection type in the given context.
+   * This checks for incarnations of the item/key/value type argument of the different collection
+   * types and creates multiple instances if the item/key/value type has multiple incarnations.
+   *
+   * @param refMCType the reference MCCollection type to find incarnations for
+   * @param context the completion context to use for finding the incarnations
+   * @return
+   */
+  protected List<ASTMCType> findMCCollectionTypeIncarnations(ASTMCCollectionTypesNode refMCType,
+      TypeCompletionContext context) {
+    /*
+     * TODO What we should actually do here is reuse the reference adaptation framework for
+     *  MCTypes so we can adapt every nested type etc.
+     *  -> in general we could reuse all the adaptation logic to realize the for each and multi
+     *  incarnation handling! -> think about it: if a type has multiple incarnations and we
+     *  therefore create multiple incarnations of a method this is in fact reference model adaptation!
+     *  -> only that we not apply it to the whole artifact but a single method.
+     *  workaround for now: hardcoded behavior for MCCollection types
+     */
+    if (refMCType instanceof ASTMCListType) {
+      ASTMCType refItemType = ((ASTMCListType) refMCType).getMCTypeArgument().getMCTypeOpt().get();
+      List<ASTMCType> itemTypeIncs = findTypeIncarnations(refItemType, context);
+      return itemTypeIncs.stream().map(typeIncarnation -> CD4CodeMill.mCListTypeBuilder()
+          .setMCTypeArgument(createTypeArgument(typeIncarnation)).build()).collect(Collectors
+              .toList());
+    }
+    else if (refMCType instanceof ASTMCSetType) {
+      ASTMCType refItemType = ((ASTMCSetType) refMCType).getMCTypeArgument().getMCTypeOpt().get();
+      List<ASTMCType> itemTypeIncs = findTypeIncarnations(refItemType, context);
+      return itemTypeIncs.stream().map(typeIncarnation -> CD4CodeMill.mCSetTypeBuilder()
+          .setMCTypeArgument(createTypeArgument(typeIncarnation)).build()).collect(Collectors
+              .toList());
+    }
+    else if (refMCType instanceof ASTMCOptionalType) {
+      ASTMCType refItemType = ((ASTMCOptionalType) refMCType).getMCTypeArgument().getMCTypeOpt()
+          .get();
+      List<ASTMCType> itemTypeIncs = findTypeIncarnations(refItemType, context);
+      return itemTypeIncs.stream().map(typeIncarnation -> CD4CodeMill.mCOptionalTypeBuilder()
+          .setMCTypeArgument(createTypeArgument(typeIncarnation)).build()).collect(Collectors
+              .toList());
+    }
+    else if (refMCType instanceof ASTMCMapType) {
+      ASTMCType keyType = ((ASTMCMapType) refMCType).getKey().getMCTypeOpt().get();
+      ASTMCType valueType = ((ASTMCMapType) refMCType).getValue().getMCTypeOpt().get();
+      List<ASTMCTypeArgument> keyTypeArgIncs = findTypeIncarnations(keyType, context).stream().map(
+          this::createTypeArgument).collect(Collectors.toList());
+      List<ASTMCTypeArgument> valueTypeArgIncs = findTypeIncarnations(valueType, context).stream()
+          .map(this::createTypeArgument).collect(Collectors.toList());
+      /*
+       * TODO We must only combine the incarnations of the key and value type if they are not
+       *  conflicting or imply any conflicting bindings!
+       *  -> we would have the same issues, e.g. when choosing method parameter incarnations
+       *  -> again, this is something we already solved in the reference adaptation framework
+       *  -> so we should reuse it here as well!
+       */
+      return Lists.cartesianProduct(keyTypeArgIncs, valueTypeArgIncs).stream().map(
+          argPair -> CD4CodeMill.mCMapTypeBuilder().setKey(argPair.get(0)).setValue(argPair.get(1))
+              .build()).collect(Collectors.toList());
+    }
+    throw new UnsupportedOperationException("Unsupported MCCollectionTypes type: " + refMCType
+        .getClass().getName());
+  }
+  
+  protected ASTMCTypeArgument createTypeArgument(ASTMCType mcType) {
+    if (mcType instanceof ASTMCQualifiedType) {
+      return CD4CodeMill.mCBasicTypeArgumentBuilder().setMCQualifiedType(
+          (ASTMCQualifiedType) mcType).build();
+    }
+    else if ((mcType instanceof ASTMCPrimitiveType)) {
+      return CD4CodeMill.mCPrimitiveTypeArgumentBuilder().setMCPrimitiveType(
+          (ASTMCPrimitiveType) mcType).build();
+    }
+    else {
+      throw new UnsupportedOperationException("Unsupported type argument type: " + mcType.getClass()
+          .getName());
     }
   }
   

--- a/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
@@ -82,9 +82,8 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
     CompAttributeIncStrategy compAttributeIncStrategy = new CompAttributeIncStrategy();
     CompMethodIncStrategy compMethodIncStrategy = new CompMethodIncStrategy();
     
-    MCTypeMatchingStrategy compMcTypeMatcher = new TypeCheckMCTypeMatchingStrategy(
+    MCTypeMatchingStrategy mcTypeMatcher = new TypeCheckMCTypeMatchingStrategy(
         underspecifiedPlaceholderTypeName);
-    compMcTypeMatcher.setCDTypeMatcher(compTypeIncStrategy);
     
     /*
      * We configure the matching strategies depending on the conformance checker parameter as we
@@ -101,8 +100,9 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
       compAssocIncStrategy.addIncStrategy(new EqNameAssocIncStrategy(referenceCD, mapping));
       compAttributeIncStrategy.addIncStrategy(new EqNameAttributeIncStrategy());
       if (conformanceParams.contains(CDConfParameter.METHOD_OVERLOADING)) {
-        compMethodIncStrategy.addIncStrategy(new EqSignatureMethodIncStrategy(compMcTypeMatcher,
-            conformanceParams.contains(CDConfParameter.STRICT_PARAMETER_ORDER)));
+        compMethodIncStrategy.addIncStrategy(new EqSignatureMethodIncStrategy(mcTypeMatcher,
+            compTypeIncStrategy, conformanceParams.contains(
+                CDConfParameter.STRICT_PARAMETER_ORDER)));
       }
       else {
         compMethodIncStrategy.addIncStrategy(new EqNameMethodIncStrategy());
@@ -162,7 +162,7 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
     return new DefaultCDConformanceContext(concreteCD, referenceCD, mapping,
         underspecifiedPlaceholderTypeName, conformanceParams, compTypeIncStrategy,
         compSubTypeIncStrategy, compAssocIncStrategy, compAttributeIncStrategy,
-        compMethodIncStrategy, compMcTypeMatcher);
+        compMethodIncStrategy, mcTypeMatcher);
   }
   
   /**
@@ -197,8 +197,6 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
     Set<ASTCDType> concTypes = CDDiffUtil.getAllTypesFromCD(context.getConcreteCD());
     CachedMultiMatches<ASTCDType> cachedTypeIncStrategy = new CachedMultiMatches<>(CDSynDiffMatches
         .computeMultiMatching(concTypes, context.getTypeIncStrategy()));
-    
-    context.getMCTypeIncStrategy().setCDTypeMatcher(context.getTypeIncStrategy());
     
     CachedMultiMatches<ASTCDType> cachedSubtypeIncStrategy = new CachedMultiMatches<>(
         CDSynDiffMatches.computeMultiMatching(concTypes, context

--- a/cddiff/src/main/java/de/monticore/cdconformance/conf/type/BasicTypeConfStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/conf/type/BasicTypeConfStrategy.java
@@ -7,6 +7,7 @@ import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDClass;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cdconcretization.stereotype.StereotypeUtil;
 import de.monticore.cdconformance.conf.ConformanceStrategy;
 import de.monticore.cdconformance.conf.attribute.CDAttributeChecker;
 import de.monticore.cdconformance.conf.method.CDMethodChecker;
@@ -176,21 +177,91 @@ public class BasicTypeConfStrategy implements ConformanceStrategy<ASTCDType> {
    * @return true if all required reference associations are incarnated, false otherwise
    */
   protected boolean checkAssocIncarnation(Set<ASTCDAssociation> con, Set<ASTCDAssociation> ref) {
-    return ref.stream().allMatch(refAssoc -> (refAssoc.getModifier().isPresentStereotype()
-        && refAssoc.getModifier().getStereotype().contains("optional")) || con.stream().anyMatch(
-            cAssoc -> incMapping.isIncarnation(cAssoc, refAssoc)));
+    return ref.stream().allMatch(refAssoc -> checkAssocIncarnation(refAssoc, con));
   }
   
+  /**
+   * Checks if the given reference association is incarnated by at least one of the concrete
+   * associations.
+   *
+   * @param ref the reference association to check
+   * @param concrete the concrete associations to check against
+   * @return true if the reference association is incarnated, false otherwise
+   */
+  protected boolean checkAssocIncarnation(ASTCDAssociation ref, Set<ASTCDAssociation> concrete) {
+    if (StereotypeUtil.isOptional(ref.getModifier())) {
+      return true; // optional methods do not need to be incarnated
+    }
+    if (concrete.stream().anyMatch(conMethod -> incMapping.isIncarnation(conMethod, ref))) {
+      return true; // at least one incarnation is present
+    }
+    Log.info("Missing incarnation for association in '" + ref.getEnclosingScope().getName() + "' ("
+        + ref.get_SourcePositionStart() + ")", getClass().getName());
+    return false;
+  }
+  
+  /**
+   * Checks if all the reference attributes are incarnated by at least one of the concrete
+   * attributes (unless they are optional).
+   *
+   * @param con the concrete attributes to check
+   * @param ref the reference attributes to check against
+   * @return true if all reference attributes are incarnated, false otherwise
+   */
   protected boolean checkAttributeIncarnation(Set<ASTCDAttribute> con, Set<ASTCDAttribute> ref) {
-    return ref.stream().allMatch(refAttr -> (refAttr.getModifier().isPresentStereotype() && refAttr
-        .getModifier().getStereotype().contains("optional")) || con.stream().anyMatch(
-            conAttr -> incMapping.isIncarnation(conAttr, refAttr)));
+    return ref.stream().allMatch(refAttr -> checkAttributeIncarnation(refAttr, con));
   }
   
+  /**
+   * Checks if the given reference attribute is incarnated by at least one of the concrete
+   * attributes.
+   *
+   * @param ref the reference attribute to check
+   * @param concrete the concrete attributes to check against
+   * @return true if the reference attribute is incarnated, false otherwise
+   */
+  protected boolean checkAttributeIncarnation(ASTCDAttribute ref, Set<ASTCDAttribute> concrete) {
+    if (StereotypeUtil.isOptional(ref.getModifier())) {
+      return true; // optional methods do not need to be incarnated
+    }
+    if (concrete.stream().anyMatch(conMethod -> incMapping.isIncarnation(conMethod, ref))) {
+      return true; // at least one incarnation is present
+    }
+    Log.info("Missing incarnation for attribute '" + ref.getName() + "' in '" + ref
+        .getEnclosingScope().getName() + "' (" + ref.get_SourcePositionStart() + ")", getClass()
+            .getName());
+    return false;
+  }
+  
+  /**
+   * Checks if all the reference methods are incarnated by at least one of the concrete methods
+   * (unless they are optional).
+   *
+   * @param con the concrete methods to check
+   * @param ref the reference methods to check against
+   * @return true if all reference methods are incarnated, false otherwise
+   */
   protected boolean checkMethodIncarnation(Set<ASTCDMethod> con, Set<ASTCDMethod> ref) {
-    return ref.stream().allMatch(refMethod -> (refMethod.getModifier().isPresentStereotype()
-        && refMethod.getModifier().getStereotype().contains("optional")) || con.stream().anyMatch(
-            conMethod -> incMapping.isIncarnation(conMethod, refMethod)));
+    return ref.stream().allMatch(refMethod -> checkMethodIncarnation(con, refMethod));
+  }
+  
+  /**
+   * Checks if the given reference method is incarnated by at least one of the concrete methods.
+   *
+   * @param concrete the concrete methods to check against
+   * @param ref the reference method to check
+   * @return true if the reference method is incarnated, false otherwise
+   */
+  protected boolean checkMethodIncarnation(Set<ASTCDMethod> concrete, ASTCDMethod ref) {
+    if (StereotypeUtil.isOptional(ref.getModifier())) {
+      return true; // optional methods do not need to be incarnated
+    }
+    if (concrete.stream().anyMatch(conMethod -> incMapping.isIncarnation(conMethod, ref))) {
+      return true; // at least one incarnation is present
+    }
+    Log.info("Missing incarnation for method '" + ref.getName() + "' in '" + ref.getEnclosingScope()
+        .getName() + "' (" + ref.get_SourcePositionStart() + ")", getClass().getName());
+    return false;
   }
   
   protected boolean checkAttributeConformance(Set<ASTCDAttribute> concrete, ASTCDType refType) {

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/DefaultCDIncarnationMapping.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/DefaultCDIncarnationMapping.java
@@ -347,15 +347,13 @@ public class DefaultCDIncarnationMapping implements CDIncarnationMapping {
   
   @Override
   public boolean isIncarnation(ASTMCType conType, ASTMCType refType) {
-    mcTypeIncStrategy.setCDTypeMatcher(this::isIncarnation);
-    return mcTypeIncStrategy.isMatched(conType, refType);
+    return mcTypeIncStrategy.isMatched(conType, refType, this::isIncarnation);
   }
   
   @Override
   public boolean isIncarnation(ISymbol contextSymbol, ASTMCType conType, ASTMCType refType) {
-    mcTypeIncStrategy.setCDTypeMatcher((conCDType, refCDType) -> isIncarnation(contextSymbol,
-        conCDType, refCDType));
-    return mcTypeIncStrategy.isMatched(conType, refType);
+    return mcTypeIncStrategy.isMatched(conType, refType, (conCDType, refCDType) -> isIncarnation(
+        contextSymbol, conCDType, refCDType));
   }
   
   @Override

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/MCTypeMatchingStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/MCTypeMatchingStrategy.java
@@ -5,7 +5,7 @@ import de.monticore.cdbasis._ast.ASTCDType;
 import de.monticore.cdmatcher.BooleanMatchingStrategy;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 
-public interface MCTypeMatchingStrategy extends BooleanMatchingStrategy<ASTMCType> {
+public interface MCTypeMatchingStrategy {
   
   /**
    * Returns if the given concrete type is an incarnation of the given reference type.
@@ -14,10 +14,7 @@ public interface MCTypeMatchingStrategy extends BooleanMatchingStrategy<ASTMCTyp
    * @param refType the reference type
    * @return true if the types are matched, false otherwise
    */
-  boolean isMatched(ASTMCType conType, ASTMCType refType);
-  
-  default void setCDTypeMatcher(BooleanMatchingStrategy<ASTCDType> cdTypeMatcher) {
-    // Can be overridden if implementation needs access to the matching of CDTypes
-  }
+  boolean isMatched(ASTMCType conType, ASTMCType refType,
+      BooleanMatchingStrategy<ASTCDType> cdTypeMatcher);
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/TypeCheckMCTypeMatchingStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/mctype/TypeCheckMCTypeMatchingStrategy.java
@@ -40,7 +40,9 @@ public class TypeCheckMCTypeMatchingStrategy implements MCTypeMatchingStrategy {
    * @param refType the reference type
    * @return true if the types are matched, false otherwise
    */
-  public boolean isMatched(ASTMCType conType, ASTMCType refType) {
+  @Override
+  public boolean isMatched(ASTMCType conType, ASTMCType refType,
+      BooleanMatchingStrategy<ASTCDType> cdTypeMatcher) {
     if (MCTypeUtil.isUnderspecified(underspecifiedTypeName, refType)) {
       if (MCTypeUtil.isUnderspecified(underspecifiedTypeName, conType)) {
         Log.error("The underspecified placeholder type is not allowed as a concrete type.");
@@ -64,6 +66,13 @@ public class TypeCheckMCTypeMatchingStrategy implements MCTypeMatchingStrategy {
     //  2. no conflicting bindings attached to one of the type parameters
     //  (can be solved with a simple visitor once we have the "Binding" infrastructure from OCL
     //   available here)
+    /*
+     * IMPORTANT: Set the CD type matcher before calling compatibilityCalculator so it uses the
+     * desired incarnation mapping for the CD types.
+     * This makes the method NOT THREAD SAVE! (like a lot of other methods in the conformance check
+     * and concretization as well, so not a huge issue).
+     */
+    compatibilityCalculator.setCDTypeMatcher(cdTypeMatcher);
     List<Bound> result = compatibilityCalculator.constrainSameType(concreteType, referenceType);
     /*
      * IMPORTANT: Do NOT log an error here if it is no match! Conformance checking code might call
@@ -74,11 +83,6 @@ public class TypeCheckMCTypeMatchingStrategy implements MCTypeMatchingStrategy {
      * found for any candidate.
      */
     return result.isEmpty();
-  }
-  
-  @Override
-  public void setCDTypeMatcher(BooleanMatchingStrategy<ASTCDType> cdTypeMatcher) {
-    compatibilityCalculator.setCDTypeMatcher(cdTypeMatcher);
   }
   
 }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/method/EqSignatureMethodIncStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/method/EqSignatureMethodIncStrategy.java
@@ -5,6 +5,7 @@ import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cd4codebasis._ast.ASTCDParameter;
 import de.monticore.cdbasis._ast.ASTCDType;
 import de.monticore.cdconformance.inc.mctype.MCTypeMatchingStrategy;
+import de.monticore.cdmatcher.BooleanMatchingStrategy;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,13 +21,15 @@ import java.util.stream.Collectors;
 public class EqSignatureMethodIncStrategy implements CDMethodMatchingStrategy {
   
   private final MCTypeMatchingStrategy mcTypeIncStrategy;
+  private final BooleanMatchingStrategy<ASTCDType> cdTypeMatcher;
   private final boolean strictParameterOrder;
   
   private ASTCDType refType;
   
   public EqSignatureMethodIncStrategy(MCTypeMatchingStrategy mcTypeIncStrategy,
-      boolean strictParameterOrder) {
+      BooleanMatchingStrategy<ASTCDType> cdTypeMatcher, boolean strictParameterOrder) {
     this.mcTypeIncStrategy = mcTypeIncStrategy;
+    this.cdTypeMatcher = cdTypeMatcher;
     this.strictParameterOrder = strictParameterOrder;
   }
   
@@ -55,7 +58,7 @@ public class EqSignatureMethodIncStrategy implements CDMethodMatchingStrategy {
     for (int i = 0; i < conParams.size(); i++) {
       ASTCDParameter conParam = conParams.get(i);
       ASTCDParameter refParam = refParams.get(i);
-      if (!mcTypeIncStrategy.isMatched(conParam.getMCType(), refParam.getMCType())) {
+      if (!mcTypeIncStrategy.isMatched(conParam.getMCType(), refParam.getMCType(), cdTypeMatcher)) {
         return false;
       }
     }
@@ -66,7 +69,7 @@ public class EqSignatureMethodIncStrategy implements CDMethodMatchingStrategy {
       List<ASTCDParameter> refParams) {
     for (ASTCDParameter refParam : refParams) {
       if (conParams.stream().noneMatch(conParam -> mcTypeIncStrategy.isMatched(conParam.getMCType(),
-          refParam.getMCType()))) {
+          refParam.getMCType(), cdTypeMatcher))) {
         return false;
       }
     }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/AbstractCDConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/AbstractCDConcretizationTest.java
@@ -160,7 +160,7 @@ public abstract class AbstractCDConcretizationTest {
   }
   
   // TODO Replace once there is a MontiCore method: MCAssertions#assertNoFindings()
-  private static void assertNoFindings(String message) {
+  protected static void assertNoFindings(String message) {
     if (!Log.getFindings().isEmpty()) {
       fail(message);
     }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -1,11 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconcretization;
 
+import de.monticore.cd4code.CD4CodeMill;
+import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdconformance.CDConfParameter;
 import de.monticore.cdconformance.CDConformanceChecker;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
   
@@ -146,6 +151,38 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
       testConcretizedConformsToRefAndExpectedOut(
           "evaluation/banking/usageByExtension/BankingConc.cd", "evaluation/banking/BankingRef.cd",
           "evaluation/banking/usageByExtension/BankingOut.cd");
+    }
+    
+  }
+  
+  @Nested
+  class Observer {
+    
+    @Test
+    void mutualObservers() {
+      parseModels("evaluation/observer/mutualObservers/MutualObserversConc.cd",
+          "evaluation/observer/ObserverRef.cd");
+      ASTCDCompilationUnit expectedCD = parseCD(
+          "evaluation/observer/mutualObservers/MutualObserversOut.cd");
+      
+      ConcretizationCompleter completer = new ConcretizationCompleter("ref1", confParameters);
+      
+      // 1. concretize and check conformance
+      try {
+        // TODO Improve API to handle multiple mappings after we tested the basics
+        completer.completeCD(conCD, refCD);
+        completer.setMapping("ref2");
+        completer.completeCD(conCD, refCD);
+      }
+      catch (CompletionException e) {
+        fail("CompletionException", e);
+      }
+      System.out.println("Concretized CD:");
+      System.out.println(CD4CodeMill.prettyPrint(conCD, false));
+      
+      assertNoFindings("Findings while concretizing CD");
+      // 2. check if concretized CD equals expected output
+      assertTrue(conCD.deepEquals(expectedCD, false), "Concretized output does not match expected");
     }
     
   }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -187,4 +187,12 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
     
   }
   
+  @Test
+  void testRepository() {
+    // TODO Remove once we have explicit support for 'forEach' conformance check
+    confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
+    testConcretizedConformsToRefAndExpectedOut("evaluation/repository/DomainModel.cd",
+        "evaluation/repository/RepositoryRef.cd", "evaluation/repository/RepositoryOut.cd");
+  }
+  
 }

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -269,4 +269,15 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
     assertTrue(checker.checkConformance(conCD, refCD, "ref"));
   }
   
+  /**
+   * Example from KMR24 for multiple mappings.
+   */
+  @Test
+  public void testMutualObserversExample() {
+    parseModels("mutualObservers/SimpleMutualObserversConc.cd", "mutualObservers/SimpleObserverRef.cd");
+    checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING,
+        SRC_TARGET_ASSOC_MAPPING, ALLOW_CARD_RESTRICTION));
+    assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref1", "ref2")));
+  }
+  
 }

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -274,7 +274,8 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
    */
   @Test
   public void testMutualObserversExample() {
-    parseModels("mutualObservers/SimpleMutualObserversConc.cd", "mutualObservers/SimpleObserverRef.cd");
+    parseModels("mutualObservers/SimpleMutualObserversConc.cd",
+        "mutualObservers/SimpleObserverRef.cd");
     checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING,
         SRC_TARGET_ASSOC_MAPPING, ALLOW_CARD_RESTRICTION));
     assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref1", "ref2")));

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -5,6 +5,9 @@ import static de.monticore.cdconformance.CDConfParameter.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Set;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -279,6 +282,48 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
     checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING,
         SRC_TARGET_ASSOC_MAPPING, ALLOW_CARD_RESTRICTION));
     assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref1", "ref2")));
+  }
+  
+  /**
+   * The conformance relation was defined as reflexive in [KRS+24]. However, we should question
+   * this as [KMR24] mentioned it is possible for some language elements to only be allowed in
+   * a reference model but not in a concrete model. This would contradict reflexivity, e.g.,
+   * how would we handle a {@code forEach} stereotype in a concrete model?
+   */
+  @Nested
+  class ReflexiveConformanceTests {
+    
+    @Test
+    public void visitorConformsToItself() {
+      parseModels("visitor/VisitorRef.cd", "visitor/VisitorRef.cd");
+      checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING,
+          SRC_TARGET_ASSOC_MAPPING, ALLOW_CARD_RESTRICTION, METHOD_OVERLOADING));
+      assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref")));
+    }
+    
+    /**
+     * This could work in theory, but currently we have issues when resolving symbols because
+     * two symbols with the same name exists (as reference model and concrete model are identical).
+     * Also, we currently report an error if the underspecified placeholder type ('any') is
+     * used in the concrete model.
+     */
+    @Disabled
+    @Test
+    public void builderAndMillConformsToItself() {
+      parseModels("builder/BuilderAndMillRef.cd", "builder/BuilderAndMillRef.cd");
+      checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING,
+          SRC_TARGET_ASSOC_MAPPING, ALLOW_CARD_RESTRICTION, METHOD_OVERLOADING));
+      assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref")));
+    }
+    
+    @Test
+    public void assocExampleConformsToItself() {
+      parseModels("associations/Reference.cd", "associations/Reference.cd");
+      checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING,
+          SRC_TARGET_ASSOC_MAPPING, ALLOW_CARD_RESTRICTION, METHOD_OVERLOADING));
+      assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref")));
+    }
+    
   }
   
 }

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/observer/ObserverRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/observer/ObserverRef.cd
@@ -1,0 +1,14 @@
+classdiagram ObserverRef {
+
+  class Observer {
+    void update();
+  }
+
+  class Subject {
+    void register(Observer o);
+    void unregister(Observer o);
+    void notifyAll();
+  }
+
+  association Subject -> (observers) Observer [*] <<ordered>>;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/observer/mutualObservers/MutualObserversConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/observer/mutualObservers/MutualObserversConc.cd
@@ -1,0 +1,5 @@
+classdiagram MutualObserversConc {
+  <<ref1="Observer", ref2="Subject">> class Attacker;
+  <<ref1="Subject", ref2="Observer">> class Defender;
+  association watches [*] Attacker <-> Defender [*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/observer/mutualObservers/MutualObserversOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/observer/mutualObservers/MutualObserversOut.cd
@@ -1,0 +1,18 @@
+classdiagram MutualObserversConc {
+
+  <<ref1="Observer", ref2="Subject">> class Attacker {
+    void update();
+    void register(Defender o);
+    void unregister(Defender o);
+    void notifyAll();
+
+  }
+  <<ref1="Subject", ref2="Observer">> class Defender {
+    void update();
+    void register(Attacker o);
+    void unregister(Attacker o);
+    void notifyAll();
+  }
+  association watches [*] Attacker (observers) <-> (observers) Defender[*];
+
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/repository/DomainModel.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/repository/DomainModel.cd
@@ -1,0 +1,17 @@
+import java.lang.String;
+
+ classdiagram DomainModel {
+   <<ref="Entity">> class Employee {
+     <<ref="id">> String id;
+     <<ref="id">> String taxId;
+     String firstName;
+     String lastName;
+     int number;
+     int salary;
+   }
+
+   <<ref="Entity">> class Department {
+     String managerName;
+     <<ref="id">> int depId;
+   }
+ }

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/repository/RepositoryOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/repository/RepositoryOut.cd
@@ -1,0 +1,34 @@
+import java.lang.String;
+
+classdiagram DomainModel {
+  <<ref="Entity">> class Employee {
+    <<ref="id">> String id;
+    <<ref="id">> String taxId;
+    String firstName;
+    String lastName;
+    int number;
+    int salary;
+  }
+
+  <<ref="Entity">> class Department {
+    String managerName;
+    <<ref="id">> int depId;
+  }
+
+  <<ref="RepositoryRef.EntityRepository">>class DepartmentRepository {
+    <<ref="RepositoryRef.EntityRepository.findById">> Optional<Department> findByDepId(int depId);
+    List<Department> findAll();
+    Department save(Department entity);
+    <<ref="RepositoryRef.EntityRepository.removeById">> void removeByDepId(int depId);
+
+  }
+
+  <<ref="RepositoryRef.EntityRepository">>class EmployeeRepository {
+    <<ref="RepositoryRef.EntityRepository.findById">> Optional<Employee> findById(String id);
+    <<ref="RepositoryRef.EntityRepository.findById">> Optional<Employee> findByTaxId(String taxId);
+    List<Employee> findAll();
+    Employee save(Employee entity);
+    <<ref="RepositoryRef.EntityRepository.removeById">> void removeById(String id);
+    <<ref="RepositoryRef.EntityRepository.removeById">> void removeByTaxId(String taxId);
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/repository/RepositoryRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/repository/RepositoryRef.cd
@@ -1,0 +1,15 @@
+import java.lang.String;
+
+classdiagram RepositoryRef {
+
+  class Entity {
+    any id;
+  }
+
+  <<forEach="Entity">> class EntityRepository {
+    <<forEach="Entity.id">> Optional<Entity> findById(any id);
+    List<Entity> findAll();
+    Entity save(Entity entity);
+    <<forEach="Entity.id">> void removeById(any id);
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/builder/BuilderAndMillRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/builder/BuilderAndMillRef.cd
@@ -1,0 +1,20 @@
+import java.lang.String;
+
+classdiagram BuilderAndMillRef {
+  class DataClass {
+    // TODO use <<matchStructure>> here once it is implemented
+    any attribute;
+  }
+
+  <<forEach="DataClass">> class DataClassBuilder {
+    // Incarnations will have the same name as the referenced attribute incarnations by convention
+    // because the referenced attribute has the same name as the annotated attribute!
+    <<forEach="DataClass.attribute">> any attribute;
+    <<forEach="DataClass.attribute">> DataClassBuilder attribute(any attribute);
+    DataClass build();
+  }
+
+  class Mill {
+    <<forEach="DataClassBuilder">> DataClassBuilder dataClassBuilder();
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/mutualObservers/SimpleMutualObserversConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/mutualObservers/SimpleMutualObserversConc.cd
@@ -1,0 +1,5 @@
+classdiagram SimpleMutualObserversConc {
+  <<ref1="Observer", ref2="Observed">> class Attacker;
+  <<ref1="Observed", ref2="Observer">> class Defender;
+  association watches [*] Attacker <-> Defender [*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/mutualObservers/SimpleObserverRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/mutualObservers/SimpleObserverRef.cd
@@ -1,0 +1,10 @@
+/*
+ * Note this is a simplified reference model for the observer pattern (from KMR24)
+ * just for demonstration of the multiple mapping feature.
+ * See OCl reference code adaptation for a full model with specification for all methods.
+ */
+classdiagram SimpleObserverRef {
+  class Observer;
+  class Observed;
+  association observes Observer -> Observed [*];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/mutualObservers/SimpleObserverRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/mutualObservers/SimpleObserverRef.cd
@@ -1,7 +1,8 @@
 /*
  * Note this is a simplified reference model for the observer pattern (from KMR24)
  * just for demonstration of the multiple mapping feature.
- * See OCl reference code adaptation for a full model with specification for all methods.
+ * See 'cdconcretization/evaluation' or OCL reference code adaptation for a full model with
+ * specification for all methods.
  */
 classdiagram SimpleObserverRef {
   class Observer;

--- a/cddiff/src/test/resources/de/monticore/cdconformance/visitor/VisitorRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/visitor/VisitorRef.cd
@@ -1,0 +1,14 @@
+classdiagram VisitorRef {
+	
+	interface Visitable {
+	  void accept(VisitableVisitor visitor);
+	}
+
+  // TODO use <<matchStructure>> here once it is implemented
+	class ConcreteVisitable implements Visitable;
+
+	<<forEach="Visitable">> interface VisitableVisitor {
+    void visit(Visitable visitable);
+    <<forEach="ConcreteVisitable">> void visit(ConcreteVisitable concreteVisitable);
+	}
+}


### PR DESCRIPTION
## Added
- Correct adaptation of MCCollection types (Optional, Set, List, Map) . We have to replace type arguments with their incarnation before completing the types into the concrete CD.
  - Notice the comment about reusing the reference adaptation framework, which we developed for OCL! What the completer implementation in CD Concretization do is actually reference adaptation. Not on the complete artifact level, but e.g. for a reference `ASTCDMethod` node. -> Will discuss this in thesis.
- More detailed logging of what attribute/method/association incarnations are missing in CD Conformance Checker

## Evaluation
- completion of mutual observers example
- completion with multiple mappings
- CRUD repository interface from Entity class

## Fixed
- removed `setCDTypeMatcher` from `MCTypeMatchingStartegy` and add mandatory parameter to `isMatched`.
  - Why?
  -  The `CDIncarnationMapping` implementation used `setCDTypeMatcher` to set a specific matching function depending on the use case. Either matching the full scope of types or only a matching function considering bindings holing at a certain context symbol. This has the unfortunate side effect that `cdTypeMatcher` is sometimes set to a restricted matching function even when used by 'EqSignatureMethodIncStrategy' which expects the full scope of types to be matched.
  -   _THIS CAN LEAD TO VERY STRANGE BEHAVIOR_.  I had examples where a test case was successful when executed alone, but failed when executed together with other test cases. But if I executed them all in debug mode, they were successful again. It was even worse, if I executed all cases in normal mode but added a System.out.println using `getMCType()` before passing it to the MCTypeMatchingStrategy, then the test case was successful again!
    -  What should we learn from this?
        - Stateful classes should be handled with care!
        - Stateful matching strategies are a bad design choice → Better make dependencies explicit in the method


 