### PR TITLE
fix(cdconf): CDFullIncMapping fixes

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
@@ -65,11 +65,11 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
     this.methodIncStrategy = methodIncStrategy;
     this.mcTypeIncStrategy = mcTypeMatcher;
     
-    IOOSymbolsLocalIncMapping artifactIncMapping = new CDArtifactIncMapping(getConcreteCD(),
+    IOOSymbolsLocalIncMapping fullIncMapping = new CDFullIncMapping(getConcreteCD(),
         typeIncStrategy, attributeIncStrategy, methodIncStrategy);
     
     OOSymbolsIncMapping ooSymbolsIncMapping = new MethodOverloadingOOSymbolsIncMapping(
-        artifactIncMapping, referenceCD.getEnclosingScope(), referenceCD.getEnclosingScope());
+        fullIncMapping, referenceCD.getEnclosingScope(), referenceCD.getEnclosingScope());
     
     incarnationMapping = new DefaultCDIncarnationMapping(concreteCD, typeIncStrategy, mcTypeMatcher,
         attributeIncStrategy, methodIncStrategy, assocIncStrategy, ooSymbolsIncMapping);

--- a/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/DefaultCDConformanceContext.java
@@ -66,7 +66,7 @@ public class DefaultCDConformanceContext implements CDConformanceContext {
     this.mcTypeIncStrategy = mcTypeMatcher;
     
     IOOSymbolsLocalIncMapping fullIncMapping = new CDFullIncMapping(getConcreteCD(),
-        typeIncStrategy, attributeIncStrategy, methodIncStrategy);
+        typeIncStrategy, attributeIncStrategy, methodIncStrategy, conformanceParams);
     
     OOSymbolsIncMapping ooSymbolsIncMapping = new MethodOverloadingOOSymbolsIncMapping(
         fullIncMapping, referenceCD.getEnclosingScope(), referenceCD.getEnclosingScope());

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/CDFullIncMapping.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/CDFullIncMapping.java
@@ -4,8 +4,10 @@ package de.monticore.cdconformance.inc;
 import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdbasis._ast.*;
 import de.monticore.cdconcretization.ConcretizationHelper;
+import de.monticore.cdconformance.CDConfParameter;
 import de.monticore.cdconformance.inc.attribute.CDAttributeMatchingStrategy;
 import de.monticore.cdconformance.inc.method.CDMethodMatchingStrategy;
+import de.monticore.cddiff.CDDiffUtil;
 import de.monticore.cdmatcher.ExternalCandidatesMatchingStrategy;
 import de.monticore.symbols.basicsymbols._symboltable.FunctionSymbol;
 import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
@@ -18,6 +20,7 @@ import de.monticore.symbols.oosymbols.refmodel.IOOSymbolsLocalIncMapping;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Represents the full incarnation mapping between a reference and a concrete CD model
@@ -33,15 +36,17 @@ public class CDFullIncMapping implements IOOSymbolsLocalIncMapping {
   private final ExternalCandidatesMatchingStrategy<ASTCDType> typeIncStrategy;
   private final CDAttributeMatchingStrategy attributeIncStrategy;
   private final CDMethodMatchingStrategy methodIncStrategy;
+  private final Set<CDConfParameter> confParams;
   
   public CDFullIncMapping(ASTCDCompilationUnit concreteCD,
       ExternalCandidatesMatchingStrategy<ASTCDType> typeIncStrategy,
-      CDAttributeMatchingStrategy attributeIncStrategy,
-      CDMethodMatchingStrategy methodIncStrategy) {
+      CDAttributeMatchingStrategy attributeIncStrategy, CDMethodMatchingStrategy methodIncStrategy,
+      Set<CDConfParameter> confParameters) {
     this.concreteCD = concreteCD;
     this.typeIncStrategy = typeIncStrategy;
     this.attributeIncStrategy = attributeIncStrategy;
     this.methodIncStrategy = methodIncStrategy;
+    this.confParams = confParameters;
   }
   
   @Override
@@ -81,14 +86,20 @@ public class CDFullIncMapping implements IOOSymbolsLocalIncMapping {
       ASTCDType attributeDeclaringType = (ASTCDType) variableSymbol.getEnclosingScope()
           .getAstNode();
       
-      // TODO What about the "deep" case where attributes are matched in supertypes?
-      return getASTCDTypeIncarnations(attributeDeclaringType).stream().flatMap(
-          cAttributeDeclaringType -> {
-            attributeIncStrategy.setReferenceType(attributeDeclaringType);
-            return cAttributeDeclaringType.getCDAttributeList().stream().filter(
-                attributeIncarnation -> attributeIncStrategy.isMatched(attributeIncarnation,
-                    referenceAttribute));
-          }).map(ASTCDAttribute::getSymbol).collect(Collectors.toSet());
+      Stream<ASTCDType> declaringTypeIncs = getASTCDTypeIncarnations(attributeDeclaringType)
+          .stream();
+      if (confParams.contains(CDConfParameter.INHERITANCE)) {
+        // If inheritance is allowed, also consider all super types of the incarnations of the
+        // declaring type as potential declaring types of attribute incarnations
+        declaringTypeIncs = declaringTypeIncs.flatMap(inc -> CDDiffUtil.getAllSuperTypes(inc)
+            .stream());
+      }
+      return declaringTypeIncs.flatMap(cAttributeDeclaringType -> {
+        attributeIncStrategy.setReferenceType(attributeDeclaringType);
+        return cAttributeDeclaringType.getCDAttributeList().stream().filter(
+            attributeIncarnation -> attributeIncStrategy.isMatched(attributeIncarnation,
+                referenceAttribute));
+      }).map(ASTCDAttribute::getSymbol).collect(Collectors.toSet());
     }
     else {
       return Collections.emptySet();
@@ -101,8 +112,14 @@ public class CDFullIncMapping implements IOOSymbolsLocalIncMapping {
       ASTCDMethod referenceMethod = (ASTCDMethod) functionSymbol.getAstNode();
       ASTCDType declaringType = (ASTCDType) functionSymbol.getEnclosingScope().getAstNode();
       
-      // TODO What about the "deep" case where attributes are matched in supertypes?
-      return getASTCDTypeIncarnations(declaringType).stream().flatMap(cAttributeDeclaringType -> {
+      Stream<ASTCDType> declaringTypeIncs = getASTCDTypeIncarnations(declaringType).stream();
+      if (confParams.contains(CDConfParameter.INHERITANCE)) {
+        // If inheritance is allowed, also consider all super types of the incarnations of the
+        // declaring type as potential declaring types of attribute incarnations
+        declaringTypeIncs = declaringTypeIncs.flatMap(inc -> CDDiffUtil.getAllSuperTypes(inc)
+            .stream());
+      }
+      return declaringTypeIncs.flatMap(cAttributeDeclaringType -> {
         methodIncStrategy.setReferenceType(declaringType);
         return cAttributeDeclaringType.getCDMethodList().stream().filter(
             methodInc -> methodIncStrategy.isMatched(methodInc, referenceMethod));

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/CDFullIncMapping.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/CDFullIncMapping.java
@@ -20,23 +20,21 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Represents the artifact-wide incarnation mapping between a reference and a concrete CD model
- * <i>without</i> ony restrictions by bindings.<br>
+ * Represents the full incarnation mapping between a reference and a concrete CD model
+ * <i>without</i> any restrictions by bindings.<br>
  * <br>
  * This is basically, the "link" between the AST-based, handwritten matching strategies and the
  * systematic, symbol-based incarnation mapping & binding infrastructure which could be generated
  * automatically in the future.
  */
-// TODO naming "global" sounds reasonable, but it is not fully global
-//   alternative: "UnrestrictedCDIncMapping" because it is not restricted to a specific scope
-public class CDArtifactIncMapping implements IOOSymbolsLocalIncMapping {
+public class CDFullIncMapping implements IOOSymbolsLocalIncMapping {
   
   private final ASTCDCompilationUnit concreteCD;
   private final ExternalCandidatesMatchingStrategy<ASTCDType> typeIncStrategy;
   private final CDAttributeMatchingStrategy attributeIncStrategy;
   private final CDMethodMatchingStrategy methodIncStrategy;
   
-  public CDArtifactIncMapping(ASTCDCompilationUnit concreteCD,
+  public CDFullIncMapping(ASTCDCompilationUnit concreteCD,
       ExternalCandidatesMatchingStrategy<ASTCDType> typeIncStrategy,
       CDAttributeMatchingStrategy attributeIncStrategy,
       CDMethodMatchingStrategy methodIncStrategy) {

--- a/cddiff/src/test/java/de/monticore/cdconcretization/AttributeConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/AttributeConcretizationTest.java
@@ -152,6 +152,29 @@ class AttributeConcretizationTest extends AbstractCDConcretizationTest {
   }
   
   /**
+   * Same as 'testAttributeForEachAttribute' but now with inheritance of some attribute
+   * incarnations from a superclass.<br>
+   * <br>
+   * Currently disabled as the completed attributes get a suffix for the declaring type which is not
+   * expected here. Seems as it could be easily fixed in
+   * {@link de.monticore.cdconcretization.type.attribute.ForEachAttributeInTypeCompleter} but
+   * requires some deeper changes in how we can query attribute incarnations.
+   * 1. we need methods to query attributes/methods filtered by declaring type incarnation (but
+   * still considering supertypes)
+   * 2. we need to rethink some filtering because of conflicting bindings. Currently, attributes
+   * shifted to a superclass are filtered out because their declaring type is not a valid
+   * incarnation of the declaring reference type.
+   */
+  @Disabled("completed attributes get suffix for declaring type which is not expected here")
+  @Test
+  void testAttributeForEachAttributeInheritance() {
+    testConcretizedConformsToRefAndExpectedOut(
+        "attributes/forEach/ForEachAttributeInheritanceConc.cd",
+        "attributes/forEach/ForEachAttributeRef.cd",
+        "attributes/forEach/ForEachAttributeInheritanceOut.cd");
+  }
+  
+  /**
    * An underspecified attribute (type: any) needs to be incarnated at least once. Otherwise, we
    * would have to add an attribute of type 'any' to the concrete CD which is not allowed.
    */

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/forEach/ForEachAttributeInheritanceConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/forEach/ForEachAttributeInheritanceConc.cd
@@ -1,0 +1,13 @@
+import java.lang.String;
+
+classdiagram ForEachAttributeInheritanceConc {
+  class Person {
+    <<ref="DataClass.attribute">> String firstName;
+    <<ref="DataClass.attribute">> String lastName;
+  }
+
+  <<ref="DataClass">> class Employee extends Person {
+    <<ref="attribute">> int number;
+    <<ref="attribute">> int salary;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/forEach/ForEachAttributeInheritanceOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/attributes/forEach/ForEachAttributeInheritanceOut.cd
@@ -1,0 +1,20 @@
+import java.lang.String;
+
+classdiagram ForEachAttributeInheritanceConc {
+  class Person {
+    <<ref="DataClass.attribute">> String firstName;
+    <<ref="DataClass.attribute">> String lastName;
+  }
+
+  <<ref="DataClass">> class Employee extends Person {
+    <<ref="attribute">> int number;
+    <<ref="attribute">> int salary;
+  }
+
+  class Builder {
+    <<ref="ForEachAttributeRef.Builder.attribute">> String firstName;
+    <<ref="ForEachAttributeRef.Builder.attribute">> String lastName;
+    <<ref="ForEachAttributeRef.Builder.attribute">> int number;
+    <<ref="ForEachAttributeRef.Builder.attribute">> int salary;
+  }
+}


### PR DESCRIPTION
## Changed
- renamed `CDArtifactIncMapping` to `CDFullIncMapping`

## Fixed
- search for attribute & method incarnations in superclass if `CDConfParameter.INHERITANCE` is present

## Tests
Added (disabled) test case for attributes shifted into a concrete superclass which are used as "forEach" parameter element. 
Currently disabled as the completed attributes get a suffix for the declaring type which is not expected here. Seems as it could be easily fixed in `ForEachAttributeInTypeCompleter` but requires some deeper changes in how we can query attribute incarnations:
1. we need methods to query attributes/methods filtered by declaring type incarnation (but still considering supertypes)
2. we need to rethink some filtering because of conflicting bindings. Currently, attributes shifted to a superclass are filtered out because their declaring type is not a valid incarnation of the declaring reference type.