### PR TITLE
Fix: Re-add unused template attribute

### DIFF
--- a/cdlang/src/main/java/de/monticore/cd/codegen/decorators/SetterDecorator.java
+++ b/cdlang/src/main/java/de/monticore/cd/codegen/decorators/SetterDecorator.java
@@ -91,7 +91,7 @@ public class SetterDecorator extends AbstractDecorator<SetterDecorator.SetterDat
     ASTMCType type = getCDGenService().getFirstTypeArgument(attribute.getMCType()).deepClone();
     return decorate(clazz, attribute, SetterMethodKind.SET_MANDATORY_OR_OPT, "methods.opt.Set4Opt",
         name, List.of(CDParameterFacade.getInstance().createParameter(type, attribute.getName())),
-        attribute);
+        attribute, "--unused--");
   }
   
   protected MethodInformation decorateOptionalAbsent(ASTCDClass clazz, ASTCDAttribute attribute) {

--- a/cdlang/src/main/resources/methods/opt/Set4Opt.ftl
+++ b/cdlang/src/main/resources/methods/opt/Set4Opt.ftl
@@ -1,5 +1,5 @@
 <#-- (c) https://github.com/MontiCore/monticore -->
-${tc.signature("attribute")}
+${tc.signature("attribute", "nativeAttributeName")}
 ${defineHookPoint("Setter:Before")}
 this.${attribute.getName()} = Optional.ofNullable(${attribute.getName()});
 ${defineHookPoint("Setter:After")}


### PR DESCRIPTION
template is used in untested OptionalMutatorDecorator, breaking the next MC release