### PR TITLE
CDConcretization:. Evaluation & Fixes

### DIFF
--- a/cddiff/src/main/java/de/monticore/cdconcretization/CDRefSymbolHandlerDelegator.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/CDRefSymbolHandlerDelegator.java
@@ -1,13 +1,17 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconcretization;
 
+import de.monticore.cd4codebasis._ast.ASTCDMethod;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDType;
 import de.monticore.cdbasis._symboltable.ICDBasisScope;
+import de.monticore.cdconcretization.util.MethodSignatureString;
 import de.monticore.symbols.basicsymbols._ast.ASTType;
 import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
 import de.monticore.symbols.oosymbols._ast.ASTField;
+import de.monticore.symbols.oosymbols._ast.ASTMethod;
 import de.monticore.symbols.oosymbols._symboltable.FieldSymbol;
+import de.monticore.symbols.oosymbols._symboltable.MethodSymbol;
 import de.se_rwth.commons.SourcePosition;
 import de.se_rwth.commons.logging.Log;
 import java.util.Optional;
@@ -27,6 +31,7 @@ public class CDRefSymbolHandlerDelegator<E extends Throwable> {
   
   private FailableConsumer<ASTCDType, E> typeHandler;
   private FailableConsumer<ASTCDAttribute, E> attributeHandler;
+  private FailableConsumer<ASTCDMethod, E> methodHandler;
   
   private FailableRunnable<E> defaultHandler;
   
@@ -44,7 +49,13 @@ public class CDRefSymbolHandlerDelegator<E extends Throwable> {
     if (!processed) {
       processed = resolveAsAttributeSymbol(scope, referenceSymbol, sourcePosition);
     }
-    // TODO Support method, and association references
+    if (!processed) {
+      // IMPORTANT: Method resolution must be the last, as it can have the same name as attributes
+      // However, if the name is not unique, we can always add () to indicate a method, but
+      // attributes always use the plain name.
+      processed = resolveAsMethodSymbol(scope, referenceSymbol, sourcePosition);
+    }
+    // TODO Support association references
     if (!processed && defaultHandler != null) {
       defaultHandler.run();
     }
@@ -109,6 +120,37 @@ public class CDRefSymbolHandlerDelegator<E extends Throwable> {
   }
   
   /**
+   * Tries to resolve the given reference as a method symbol, e.g. 'Foo.method', or 'Foo.method()'
+   * as encoded by {@link MethodSignatureString}.
+   *
+   * @return true if the reference was processed, false otherwise
+   * @throws E exception that might be thrown from the handlers
+   */
+  private boolean resolveAsMethodSymbol(ICDBasisScope scope, String referenceExpr,
+      SourcePosition sourcePosition) throws E {
+    Optional<MethodSymbol> methodSymbol = MethodSignatureString.resolveMethodSignature(scope,
+        referenceExpr);
+    if (methodSymbol.isPresent()) {
+      ASTMethod method = methodSymbol.get().getAstNode();
+      if (method instanceof ASTCDMethod) {
+        ASTCDMethod referencedMethod = (ASTCDMethod) method;
+        Log.debug("Resolved CDMethod reference: " + referencedMethod, LOG_NAME);
+        if (methodHandler == null) {
+          Log.error("A reference to a CDMethod is not supported @ " + sourcePosition);
+          return false;
+        }
+        methodHandler.accept(referencedMethod);
+        return true;
+      }
+      else {
+        Log.error("Referenced method symbol " + referenceExpr + " is not a CDMethod! (type: "
+            + method.getClass().getName() + ") @" + sourcePosition);
+      }
+    }
+    return false;
+  }
+  
+  /**
    * Sets the handler to be called when a CDType reference is resolved.
    *
    * @param typeHandler the handler to be called
@@ -126,6 +168,16 @@ public class CDRefSymbolHandlerDelegator<E extends Throwable> {
   public CDRefSymbolHandlerDelegator<E> onAttribute(
       FailableConsumer<ASTCDAttribute, E> attributeHandler) {
     this.attributeHandler = attributeHandler;
+    return this;
+  }
+  
+  /**
+   * Sets the handler to be called when a CDMethod reference is resolved.
+   *
+   * @param methodHandler the handler to be called
+   */
+  public CDRefSymbolHandlerDelegator<E> onMethod(FailableConsumer<ASTCDMethod, E> methodHandler) {
+    this.methodHandler = methodHandler;
     return this;
   }
   

--- a/cddiff/src/main/java/de/monticore/cdconcretization/cd/MissingAssociationsCDCompleter.java
+++ b/cddiff/src/main/java/de/monticore/cdconcretization/cd/MissingAssociationsCDCompleter.java
@@ -107,10 +107,10 @@ public class MissingAssociationsCDCompleter extends AbstractCDCompleter {
       
       // Finally, process any remaining type incarnations that still need to be handled
       // Process the remaining left-type incarnations against right-type incarnations
-      addAssociationIncarnations(ccd, leftTypeInc2Process, rRightTypeIncarnations, rAssoc);
+      addAssociationIncarnations(ccd, leftTypeInc2Process, rRightTypeIncarnations, rAssoc, context);
       
       // Process the remaining right-type incarnations against left-type incarnations
-      addAssociationIncarnations(ccd, rLeftTypeIncarnations, rightTypeInc2Process, rAssoc);
+      addAssociationIncarnations(ccd, rLeftTypeIncarnations, rightTypeInc2Process, rAssoc, context);
       Log.debug("=== DONE processing assoc: " + CD4CodeMill.prettyPrint(rAssoc, false), LOG_NAME);
     }
     super.complete(ccd, rcd, context);
@@ -234,7 +234,8 @@ public class MissingAssociationsCDCompleter extends AbstractCDCompleter {
    */
   private void addAssociationIncarnations(ASTCDCompilationUnit concreteCD,
       Set<ASTCDType> leftTypesIncs, Set<ASTCDType> rightTypeIncs,
-      ASTCDAssociation referenceAssociation) {
+      ASTCDAssociation referenceAssociation, CDCompletionContext context)
+      throws CompletionException {
     
     for (ASTCDType leftTypeInc : leftTypesIncs) {
       for (ASTCDType rightTypeInc : rightTypeIncs) {
@@ -250,12 +251,21 @@ public class MissingAssociationsCDCompleter extends AbstractCDCompleter {
         
         // If the right type does not have a role name, it is implicitly the type incarnation's
         // name (first character lowercase) anyway.
-        if (association.getRight().isPresentCDRole()) {
-          // If a role name is already present, append the type incarnation's name to it
+        // If a role name is already present and there are multiple incarnations of the
+        // type, append the type incarnation's name to it to avoid name conflicts.
+        // NOTE: leftTypesIncs, and rightTypeIncs are ONLY the sets of type incarnations that still need an
+        // association incarnation. We need to consider the TOTAL number of type incarnations to decide
+        // whether we need to append the type incarnation name or not.
+        int totalRightTypeIncs = context.getIncarnationMapping().getIncarnations(
+            ConcretizationHelper.getAssocRightType(context.getReferenceCD(), referenceAssociation))
+            .size();
+        if (association.getRight().isPresentCDRole() && totalRightTypeIncs > 1) {
           association.getRight().getCDRole().setName(association.getRight().getCDRole().getName()
               + "_" + rightTypeInc.getName());
         }
-        if (association.getLeft().isPresentCDRole()) {
+        int totalLeftTypeIncs = context.getIncarnationMapping().getIncarnations(ConcretizationHelper
+            .getAssocLeftType(context.getReferenceCD(), referenceAssociation)).size();
+        if (association.getLeft().isPresentCDRole() && totalLeftTypeIncs > 1) {
           association.getLeft().getCDRole().setName(association.getLeft().getCDRole().getName()
               + "_" + leftTypeInc.getName());
         }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/STBindingDerivingVisitor.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/STBindingDerivingVisitor.java
@@ -69,20 +69,24 @@ public class STBindingDerivingVisitor implements CDBasisVisitor2, CD4CodeBasisVi
   
   @Override
   public void visit(ASTCDAssociation node) {
-    // TODO check this when working on associations
     // an association side has only a symbol if it has a name
-    // Either, we not allow binding stereotypes on unnamed associations or we add the bindings
-    // from the association level to each association side (always having an implicit name from the
-    // source/target type).
-    //checkForBindingStereotype(node.getEnclosingScope(), node.getSymbol(), node.getModifier());
+    // TODO Either, we not allow binding stereotypes on unnamed associations or we add the bindings
+    //   from the association level to each association side (always having an implicit name from the
+    //   source/target type).
+    if (node.isPresentSymbol()) {
+      checkForBindingStereotype(node.getEnclosingScope(), node.getSymbol(), node.getModifier());
+    }
   }
   
   @Override
   public void visit(ASTCDAssocSide node) {
-    // TODO check this when working on associations
     // an association side has only a symbol if it has a role name
-    //  However, we can always have an implicit name from the source/target type!
-    //checkForBindingStereotype(node.getEnclosingScope(), node.getSymbol(), node.getModifier());
+    // However, we can always have an implicit name from the source/target type!
+    // TODO Think about always executing a tafo to add implicit role names before conformance
+    //   checking/concretization to ensure there is a symbol for each assoc side.
+    if (node.isPresentSymbol()) {
+      checkForBindingStereotype(node.getEnclosingScope(), node.getSymbol(), node.getModifier());
+    }
   }
   
   @Override

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/STBindingDerivingVisitor.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/STBindingDerivingVisitor.java
@@ -16,8 +16,10 @@ import de.monticore.cdbasis._visitor.CDBasisVisitor2;
 import de.monticore.cdconcretization.CDRefSymbolHandlerDelegator;
 import de.monticore.cdconcretization.stereotype.BindingValue;
 import de.monticore.cdconcretization.stereotype.StereotypeUtil;
+import de.monticore.cdconcretization.util.MethodSignatureString;
 import de.monticore.cdconcretization.util.SymbolUtil;
 import de.monticore.symbols.oosymbols._symboltable.FieldSymbol;
+import de.monticore.symbols.oosymbols._symboltable.MethodSymbol;
 import de.monticore.symboltable.ISymbol;
 import de.monticore.umlmodifier._ast.ASTModifier;
 import de.se_rwth.commons.logging.Log;
@@ -107,7 +109,9 @@ public class STBindingDerivingVisitor implements CDBasisVisitor2, CD4CodeBasisVi
           .get()));
       handler.onAttribute((refAttribute) -> handleAttributeBinding(concreteScope, cdSymbol,
           refAttribute, binding.get()));
-      // TODO support methods & associations
+      handler.onMethod((refMethod) -> handleMethodBinding(concreteScope, cdSymbol, refMethod,
+          binding.get()));
+      // TODO support associations
       handler.resolveSymbol(concreteScope, binding.get().getReferenceName(), modifier
           .get_SourcePositionStart());
     }
@@ -182,6 +186,45 @@ public class STBindingDerivingVisitor implements CDBasisVisitor2, CD4CodeBasisVi
         Log.warn("The incarnation binding '" + incarnationName + "' cannot be resolved as a "
             + "CDAttribute. Reference attribute: '" + referenceAttribute.getName() + "'",
             annotatedSymbol.getSourcePosition());
+        foundInvalidBinding = true;
+      }
+    }
+  }
+  
+  /**
+   * Handles the binding for a reference method by resolving each incarnation as method symbol
+   * in the given scope and adding the bindings to the incarnation mapping.
+   *
+   * @param scope the scope in which symbols are resolved
+   * @param annotatedSymbol the symbol that is annotated with the binding stereotype
+   * @param referenceMethod the reference method that is bound with this binding
+   * @param binding the binding value that contains the incarnation names
+   */
+  private void handleMethodBinding(ICDBasisScope scope, ISymbol annotatedSymbol,
+      ASTCDMethod referenceMethod, BindingValue binding) {
+    for (String incarnationName : binding.getIncarnationNames()) {
+      Optional<MethodSymbol> incarnationMethod = MethodSignatureString.resolveMethodSignature(scope,
+          incarnationName);
+      if (incarnationMethod.isPresent()) {
+        if (incMapping.isIncarnation(SymbolUtil.cdMethodFromMethodSymbol(incarnationMethod.get()),
+            referenceMethod)) {
+          incMapping.addBinding(annotatedSymbol, referenceMethod.getSymbol(), incarnationMethod
+              .get());
+          Log.info("Added binding from stereotype @ '" + annotatedSymbol.getFullName() + "':  "
+              + referenceMethod.getSymbol().getFullName() + "=" + incarnationMethod.get()
+                  .getFullName(), LOG_NAME);
+        }
+        else {
+          Log.warn("The incarnation binding '" + incarnationMethod.get().getFullName()
+              + "' is not an incarnation of reference method '" + referenceMethod.getSymbol()
+                  .getFullName() + "'.", annotatedSymbol.getSourcePosition());
+          foundInvalidBinding = true;
+        }
+      }
+      else {
+        Log.warn("The incarnation binding '" + incarnationName + "' cannot be resolved as a "
+            + "CDMethod. Reference method: '" + referenceMethod.getName() + "'", annotatedSymbol
+                .getSourcePosition());
         foundInvalidBinding = true;
       }
     }

--- a/cddiff/src/main/java/de/monticore/cdconformance/inc/association/ImplicitRoleNameAssocIncStrategy.java
+++ b/cddiff/src/main/java/de/monticore/cdconformance/inc/association/ImplicitRoleNameAssocIncStrategy.java
@@ -4,9 +4,9 @@ package de.monticore.cdconformance.inc.association;
 import de.monticore.cdassociation._ast.ASTCDAssocSide;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._ast.ASTCDType;
+import de.monticore.cddiff.CDDiffUtil;
 import de.monticore.cdmatcher.ExternalCandidatesMatchingStrategy;
 import de.monticore.cdmatcher.MatchCDAssocsBySrcTypeAndTgtRole;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
 
@@ -41,8 +41,8 @@ public class ImplicitRoleNameAssocIncStrategy extends MatchCDAssocsBySrcTypeAndT
     
     if (conType.isPresent() && refType.isPresent() && typeMatcher.isMatched(conType.get(), refType
         .get())) {
-      String implicitRefRoleName = StringUtils.uncapitalize(reference.getName());
-      String implicitConRoleName = StringUtils.uncapitalize(concrete.getName());
+      String implicitRefRoleName = CDDiffUtil.getDefaultRoleName(reference);
+      String implicitConRoleName = CDDiffUtil.getDefaultRoleName(concrete);
       
       if (concrete.isPresentCDRole()) {
         String conRoleName = concrete.getCDRole().getName();

--- a/cddiff/src/main/java/de/monticore/cddiff/CDDiffUtil.java
+++ b/cddiff/src/main/java/de/monticore/cddiff/CDDiffUtil.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /** Collection of helper-methods for CDDiff. */
 public class CDDiffUtil {
@@ -70,17 +71,23 @@ public class CDDiffUtil {
   }
   
   /**
-   * The default role-name for a referenced type is the (simple) type-name with the first letter in
-   * lower case.
+   * If a role name is explicitly given, it is returned. Otherwise, the default role name is
+   * inferred from the type name.
    */
   public static String inferRole(ASTCDAssocSide assocSide) {
     if (assocSide.isPresentCDRole()) {
       return assocSide.getCDRole().getName();
     }
-    char[] roleName = assocSide.getMCQualifiedType().getMCQualifiedName().getBaseName()
-        .toCharArray();
-    roleName[0] = Character.toLowerCase(roleName[0]);
-    return new String(roleName);
+    return getDefaultRoleName(assocSide);
+  }
+  
+  /**
+   * The default role-name for a referenced type is the (simple) type-name with the first letter in
+   * lower case.
+   */
+  public static String getDefaultRoleName(ASTCDAssocSide assocSide) {
+    return StringUtils.uncapitalize(assocSide.getMCQualifiedType().getMCQualifiedName()
+        .getBaseName());
   }
   
   public static void saveDiffCDs2File(ASTCDCompilationUnit ast1, ASTCDCompilationUnit ast2,

--- a/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/ConcretizationCompleterTest.java
@@ -156,8 +156,8 @@ class ConcretizationCompleterTest extends AbstractCDConcretizationTest {
     Map<String, Set<String>> expectedMap2 = new LinkedHashMap<>();
     expectedMap2.put("roleNameRight", new LinkedHashSet<>(Arrays.asList("roleNameRight_C",
         "roleNameRight_D", "roleNameRight_B")));
-    expectedMap2.put("roleNameLeft", new LinkedHashSet<>(Arrays.asList("roleNameLeft_A",
-        "roleNameLeft_A", "roleNameLeft_A")));
+    expectedMap2.put("roleNameLeft", new LinkedHashSet<>(Arrays.asList("roleNameLeft",
+        "roleNameLeft", "roleNameLeft")));
     
     Map<String, Set<String>> actualMapTemp2 = new LinkedHashMap<>();
     for (Map.Entry<CDRoleSymbol, Set<CDRoleSymbol>> entry : actualMap2.entrySet()) {

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -303,4 +303,15 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
     
   }
   
+  @Nested
+  class MaCoCo {
+    
+    @Test
+    void testConcreteEmpty() {
+      testConcretizedConformsToRefAndExpectedOut("evaluation/macoco/EmptyConc.cd",
+          "evaluation/macoco/MaCoCoRef.cd", "evaluation/macoco/EmptyConcOut.cd");
+    }
+    
+  }
+  
 }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -207,18 +207,18 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
     }
     
   }
-
+  
   @Test
   void testMill() {
     // TODO Remove once we have explicit support for 'forEach' conformance check
     confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
     testConcretizedConformsToRefAndExpectedOut("evaluation/mill/LanguageInfrastructureConc.cd",
-            "evaluation/mill/MillRef.cd", "evaluation/mill/MillOut.cd");
+        "evaluation/mill/MillRef.cd", "evaluation/mill/MillOut.cd");
   }
-
+  
   @Nested
   class StaticDelegator {
-
+    
     /**
      * Disabled because currently 'method forEach method' is not support yet.
      */
@@ -227,20 +227,22 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
     void testStaticDelegator() {
       // TODO Remove once we have explicit support for 'forEach' conformance check
       confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
-      testConcretizedConformsToRefAndExpectedOut("evaluation/staticDelegator/StaticDelegatorConc.cd",
-              "evaluation/staticDelegator/StaticDelegatorRef.cd", "evaluation/staticDelegator/StaticDelegatorOut.cd");
+      testConcretizedConformsToRefAndExpectedOut(
+          "evaluation/staticDelegator/StaticDelegatorConc.cd",
+          "evaluation/staticDelegator/StaticDelegatorRef.cd",
+          "evaluation/staticDelegator/StaticDelegatorOut.cd");
     }
-
+    
     @Test
     void testStaticMethodExistsAttributeWorkaround() {
       // TODO Remove once we have explicit support for 'forEach' conformance check
       confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
       testConcretizedConformsToRefAndExpectedOut(
-              "evaluation/staticDelegator/attrWorkaround/StaticExistsConc.cd",
-              "evaluation/staticDelegator/attrWorkaround/StaticDelegatorRef.cd",
-              "evaluation/staticDelegator/attrWorkaround/StaticExistsOut.cd");
+          "evaluation/staticDelegator/attrWorkaround/StaticExistsConc.cd",
+          "evaluation/staticDelegator/attrWorkaround/StaticDelegatorRef.cd",
+          "evaluation/staticDelegator/attrWorkaround/StaticExistsOut.cd");
     }
-
+    
     /**
      * Disabled because forEach is not implemented to be "bidirectional". Thus, we cannot complete
      * in both directions (static and instance methods) with having only a single forEach in the
@@ -255,25 +257,26 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
       // TODO Remove once we have explicit support for 'forEach' conformance check
       confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
       testConcretizedConformsToRefAndExpectedOut(
-              "evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsConc.cd",
-              "evaluation/staticDelegator/attrWorkaround/StaticDelegatorRef.cd",
-              "evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsOut.cd");
+          "evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsConc.cd",
+          "evaluation/staticDelegator/attrWorkaround/StaticDelegatorRef.cd",
+          "evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsOut.cd");
     }
+    
   }
-
+  
   @Nested
   class TransitiveDependencies {
-
+    
     @Test
     void testTransitiveDependencyInSyntacticalOrder() {
       // TODO Remove once we have explicit support for 'forEach' conformance check
       confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
       testConcretizedConformsToRefAndExpectedOut(
-              "evaluation/transitiveDependencies/TransitiveDependenciesConc.cd",
-              "evaluation/transitiveDependencies/TransitiveDependenciesRef.cd",
-              "evaluation/transitiveDependencies/TransitiveDependenciesOut.cd");
+          "evaluation/transitiveDependencies/TransitiveDependenciesConc.cd",
+          "evaluation/transitiveDependencies/TransitiveDependenciesRef.cd",
+          "evaluation/transitiveDependencies/TransitiveDependenciesOut.cd");
     }
-
+    
     /**
      * Disabled because currently the forEach completion is dependent on the syntactical order of
      * elements in the reference model. In this example, the {@code DataClassBuilderFactory}
@@ -287,9 +290,11 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
       // TODO Remove once we have explicit support for 'forEach' conformance check
       confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
       testConcretizedConformsToRefAndExpectedOut(
-              "evaluation/transitiveDependencies/TransitiveDependenciesConc.cd",
-              "evaluation/transitiveDependencies/TransitiveDependenciesSwappedOrderRef.cd",
-              "evaluation/transitiveDependencies/TransitiveDependenciesOut.cd");
+          "evaluation/transitiveDependencies/TransitiveDependenciesConc.cd",
+          "evaluation/transitiveDependencies/TransitiveDependenciesSwappedOrderRef.cd",
+          "evaluation/transitiveDependencies/TransitiveDependenciesOut.cd");
     }
+    
   }
+  
 }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -207,5 +207,12 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
     }
     
   }
-  
+
+  @Test
+  void testMill() {
+    // TODO Remove once we have explicit support for 'forEach' conformance check
+    confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
+    testConcretizedConformsToRefAndExpectedOut("evaluation/mill/LanguageInfrastructureConc.cd",
+            "evaluation/mill/MillRef.cd", "evaluation/mill/MillOut.cd");
+  }
 }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -260,4 +260,36 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
               "evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsOut.cd");
     }
   }
+
+  @Nested
+  class TransitiveDependencies {
+
+    @Test
+    void testTransitiveDependencyInSyntacticalOrder() {
+      // TODO Remove once we have explicit support for 'forEach' conformance check
+      confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
+      testConcretizedConformsToRefAndExpectedOut(
+              "evaluation/transitiveDependencies/TransitiveDependenciesConc.cd",
+              "evaluation/transitiveDependencies/TransitiveDependenciesRef.cd",
+              "evaluation/transitiveDependencies/TransitiveDependenciesOut.cd");
+    }
+
+    /**
+     * Disabled because currently the forEach completion is dependent on the syntactical order of
+     * elements in the reference model. In this example, the {@code DataClassBuilderFactory}
+     * with a dependency on {@code DataClassBuilder} is declared before the {@code DataClassBuilder}
+     * itself. Therefore, during completion, no incarnation of {@code DataClassBuilder} can be found
+     * and thus no incarnation of {@code DataClassBuilderFactory} is added.
+     */
+    @Test
+    @Disabled
+    void testTransitiveDependencySwappedOrder() {
+      // TODO Remove once we have explicit support for 'forEach' conformance check
+      confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
+      testConcretizedConformsToRefAndExpectedOut(
+              "evaluation/transitiveDependencies/TransitiveDependenciesConc.cd",
+              "evaluation/transitiveDependencies/TransitiveDependenciesSwappedOrderRef.cd",
+              "evaluation/transitiveDependencies/TransitiveDependenciesOut.cd");
+    }
+  }
 }

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -135,6 +135,12 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
           "evaluation/banking/BankingRef.cd", "evaluation/banking/singleInc/BankingOut.cd");
     }
     
+    @Test
+    void banking2() {
+      testConcretizedConformsToRefAndExpectedOut("evaluation/banking2/BankingConc.cd",
+          "evaluation/banking2/BankingRef.cd", "evaluation/banking2/BankingOut.cd");
+    }
+    
     /*
      * Should be resolved when using new incarnation mapping/binding abstractions.
      * See https://git.rwth-aachen.de/se-student/theses/ma-jorden/master-theses/-/issues/68

--- a/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconcretization/EvaluationConcretizationTest.java
@@ -215,4 +215,49 @@ class EvaluationConcretizationTest extends AbstractCDConcretizationTest {
     testConcretizedConformsToRefAndExpectedOut("evaluation/mill/LanguageInfrastructureConc.cd",
             "evaluation/mill/MillRef.cd", "evaluation/mill/MillOut.cd");
   }
+
+  @Nested
+  class StaticDelegator {
+
+    /**
+     * Disabled because currently 'method forEach method' is not support yet.
+     */
+    @Test
+    @Disabled
+    void testStaticDelegator() {
+      // TODO Remove once we have explicit support for 'forEach' conformance check
+      confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
+      testConcretizedConformsToRefAndExpectedOut("evaluation/staticDelegator/StaticDelegatorConc.cd",
+              "evaluation/staticDelegator/StaticDelegatorRef.cd", "evaluation/staticDelegator/StaticDelegatorOut.cd");
+    }
+
+    @Test
+    void testStaticMethodExistsAttributeWorkaround() {
+      // TODO Remove once we have explicit support for 'forEach' conformance check
+      confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
+      testConcretizedConformsToRefAndExpectedOut(
+              "evaluation/staticDelegator/attrWorkaround/StaticExistsConc.cd",
+              "evaluation/staticDelegator/attrWorkaround/StaticDelegatorRef.cd",
+              "evaluation/staticDelegator/attrWorkaround/StaticExistsOut.cd");
+    }
+
+    /**
+     * Disabled because forEach is not implemented to be "bidirectional". Thus, we cannot complete
+     * in both directions (static and instance methods) with having only a single forEach in the
+     * reference model.
+     * Further, if we add a second forEach for the instance methods, we run into problems with
+     * the current incarnation binding concept as the derived dependency elements cannot be found
+     * in the concrete model.
+     */
+    @Test
+    @Disabled
+    void testInstanceMethodExistsAttributeWorkaround() {
+      // TODO Remove once we have explicit support for 'forEach' conformance check
+      confParameters.add(CDConfParameter.STRICT_PARAMETER_ORDER);
+      testConcretizedConformsToRefAndExpectedOut(
+              "evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsConc.cd",
+              "evaluation/staticDelegator/attrWorkaround/StaticDelegatorRef.cd",
+              "evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsOut.cd");
+    }
+  }
 }

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -326,4 +326,17 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
     
   }
   
+  @Nested
+  class Evaluation {
+    
+    @Test
+    public void macocoConformsToItself() {
+      parseModels("evaluation/MaCoCo.cd", "evaluation/MaCoCo.cd");
+      checker = new CDConformanceChecker(Set.of(STEREOTYPE_MAPPING, NAME_MAPPING,
+          SRC_TARGET_ASSOC_MAPPING, METHOD_OVERLOADING));
+      assertTrue(checker.checkConformance(conCD, refCD, Set.of("ref")));
+    }
+    
+  }
+  
 }

--- a/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
+++ b/cddiff/src/test/java/de/monticore/cdconformance/CDConformanceCheckerTest.java
@@ -1,16 +1,17 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cdconformance;
 
-import static de.monticore.cdconformance.CDConfParameter.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Set;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Set;
+
+import static de.monticore.cdconformance.CDConfParameter.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CDConformanceCheckerTest extends ConfAbstractTest {
   
@@ -267,6 +268,37 @@ public class CDConformanceCheckerTest extends ConfAbstractTest {
   public void testAssocRoleNameDerivedFromTypeValid(String concrete) {
     parseModels("associations/role_name_derived_from_type/valid/" + concrete,
         "associations/role_name_derived_from_type/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(INHERITANCE, NAME_MAPPING, STEREOTYPE_MAPPING,
+        SRC_TARGET_ASSOC_MAPPING));
+    assertTrue(checker.checkConformance(conCD, refCD, "ref"));
+  }
+  
+  @ParameterizedTest
+  @ValueSource(strings = { "ExactSame.cd" })
+  public void testAssocSameTypeMultipleRolesValid(String concrete) {
+    parseModels("associations/sameTypeMultipleRoles/valid/" + concrete,
+        "associations/sameTypeMultipleRoles/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(INHERITANCE, NAME_MAPPING, STEREOTYPE_MAPPING,
+        SRC_TARGET_ASSOC_MAPPING));
+    assertTrue(checker.checkConformance(conCD, refCD, "ref"));
+  }
+  
+  @ParameterizedTest
+  @ValueSource(strings = { "BothMissing.cd", "OneRoleMissing1.cd", "OneRoleMissing2.cd",
+      "DifferentRoleNames.cd" })
+  public void testAssocSameTypeMultipleRolesInvalid(String concrete) {
+    parseModels("associations/sameTypeMultipleRoles/invalid/" + concrete,
+        "associations/sameTypeMultipleRoles/Reference.cd");
+    checker = new CDConformanceChecker(Set.of(INHERITANCE, NAME_MAPPING, STEREOTYPE_MAPPING,
+        SRC_TARGET_ASSOC_MAPPING));
+    assertFalse(checker.checkConformance(conCD, refCD, "ref"));
+  }
+  
+  @ParameterizedTest
+  @ValueSource(strings = { "DifferentRoleNamesSTMapped.cd" })
+  public void testAssocSameTypeMultipleRolesExplicitAssocNamesValid(String concrete) {
+    parseModels("associations/sameTypeMultipleRoles/valid/" + concrete,
+        "associations/sameTypeMultipleRoles/ReferenceExplicitAssocName.cd");
     checker = new CDConformanceChecker(Set.of(INHERITANCE, NAME_MAPPING, STEREOTYPE_MAPPING,
         SRC_TARGET_ASSOC_MAPPING));
     assertTrue(checker.checkConformance(conCD, refCD, "ref"));

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationMultipleTypeIncarnationOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/associations/AssociationMultipleTypeIncarnationOut.cd
@@ -4,7 +4,7 @@ classdiagram AssocMultipleTypeIncarnationConc {
   <<ref="Department">>class MathDept;
   <<ref="Department">>class ScienceDept;
 
-  association Teacher (hasTeacher_Teacher) <-> (teachesIn_MathDept) MathDept;
-  association Teacher (hasTeacher_Teacher) <-> (teachesIn_ScienceDept) ScienceDept;
+  association Teacher (hasTeacher) <-> (teachesIn_MathDept) MathDept;
+  association Teacher (hasTeacher) <-> (teachesIn_ScienceDept) ScienceDept;
 
 }

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking2/BankingConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking2/BankingConc.cd
@@ -1,0 +1,14 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram BankingConc {
+
+  <<ref="Bank">> class SEPABank {
+    <<ref="id">> String bic;
+    <<ref="overallBalance">> double totalMoney; // money of all accounts together
+  }
+
+  <<ref="Account">> class BankAccount {
+    <<ref="id">> String iban;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking2/BankingOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking2/BankingOut.cd
@@ -1,0 +1,43 @@
+/* (c) https://github.com/MontiCore/monticore */
+import java.lang.String;
+
+classdiagram BankingConc {
+
+  <<ref="Bank">> class SEPABank implements Auditable {
+    <<ref="id">> String bic;
+    <<ref="overallBalance">> double totalMoney; // money of all accounts together
+  }
+
+  <<ref="Account">> abstract class BankAccount implements Auditable {
+    <<ref="id">> String iban;
+    double balance;
+    AccountStatus status;
+    void withdraw(double amount);
+    void deposit(double amount);
+    void transfer(BankAccount targetAccount, double amount);
+  }
+
+  interface Auditable {
+    String generateReport();
+  }
+
+  class SavingsAccount extends BankAccount;
+  class CheckingAccount extends BankAccount;
+
+  enum AccountStatus {
+    PENDING, ACTIVE, CLOSED;
+  }
+
+  class Customer;
+
+  class Transaction {
+    double amount;
+  }
+
+  association SEPABank -> BankAccount [*];
+  association allCustomers SEPABank -> Customer [*];
+  association [*] BankAccount <-> Customer [*];
+  association BankAccount -> Transaction [*] {ordered};
+  association Transaction -> (source) BankAccount [1];
+  association Transaction -> (target) BankAccount [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking2/BankingRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/banking2/BankingRef.cd
@@ -1,0 +1,42 @@
+import java.lang.String;
+
+classdiagram BankingRef {
+
+  interface Auditable {
+    String generateReport();
+  }
+
+  class Bank implements Auditable {
+    String id;
+    double overallBalance;
+  }
+
+  abstract class Account implements Auditable {
+    String id;
+    double balance;
+    AccountStatus status;
+    void withdraw(double amount);
+    void deposit(double amount);
+    void transfer(Account targetAccount, double amount);
+  }
+
+  class SavingsAccount extends Account;
+  class CheckingAccount extends Account;
+
+  enum AccountStatus {
+    PENDING, ACTIVE, CLOSED;
+  }
+
+  class Customer;
+
+  class Transaction {
+    double amount;
+  }
+
+  association Bank -> Account [*];
+  association allCustomers Bank -> Customer [*];
+  association [*] Account <-> Customer [*];
+  association Account -> Transaction [*] {ordered};
+  association Transaction -> (source) Account [1];
+  association Transaction -> (target) Account [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/crud-backend/CRUDBackendOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/crud-backend/CRUDBackendOut.cd
@@ -40,6 +40,8 @@ classdiagram DomainModel {
      <<ref="CRUDBackendRef.EntityController.getById">> HttpResponse getByTaxId(String taxId);
      HttpResponse getAll();
      HttpResponse create(CreateEmployeeData data);
+     <<ref="CRUDBackendRef.EntityController.updateById">> HttpResponse updateById(String id, UpdateEmployeeData data);
+     <<ref="CRUDBackendRef.EntityController.updateById">> HttpResponse updateByTaxId(String taxId, UpdateEmployeeData data);
      <<ref="CRUDBackendRef.EntityController.removeById">> HttpResponse removeById(String id);
      <<ref="CRUDBackendRef.EntityController.removeById">> HttpResponse removeByTaxId(String taxId);
    }
@@ -48,6 +50,7 @@ classdiagram DomainModel {
      <<ref="CRUDBackendRef.EntityController.getById">> HttpResponse getByDepId(int depId);
      HttpResponse getAll();
      HttpResponse create(CreateDepartmentData data);
+     <<ref="CRUDBackendRef.EntityController.updateById">> HttpResponse updateByDepId(int depId, UpdateDepartmentData data);
      <<ref="CRUDBackendRef.EntityController.removeById">> HttpResponse removeByDepId(int depId);
    }
 

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/crud-backend/CRUDBackendRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/crud-backend/CRUDBackendRef.cd
@@ -18,7 +18,7 @@ classdiagram CRUDBackendRef {
     <<forEach="Entity.id">> HttpResponse getById(any id);
     HttpResponse getAll();
     HttpResponse create(CreateEntityData data);
-    //<<forEach="Entity.id">> HttpResponse updateById(any id, UpdateEntityData data);
+    <<forEach="Entity.id">> HttpResponse updateById(any id, UpdateEntityData data);
     <<forEach="Entity.id">> HttpResponse removeById(any id);
   }
 

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/macoco/EmptyConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/macoco/EmptyConc.cd
@@ -1,0 +1,3 @@
+classdiagram EmptyConc {
+
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/macoco/EmptyConcOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/macoco/EmptyConcOut.cd
@@ -1,0 +1,1453 @@
+/* (c) https://github.com/MontiCore/monticore */
+/* adapted and customized by (c) MaCoCo, ein RWTH Aachen projekt */
+
+// No packages supported yet in CD completion!
+//package de.macoco.be.domain;
+
+import java.lang.String;
+import java.lang.Long;
+import java.lang.Integer;
+import java.lang.Boolean;
+
+import java.time.ZonedDateTime;
+
+classdiagram EmptyConc {
+
+  //----------------------------------------------
+  //--------------- PERSONAL ---------------------
+  //----------------------------------------------
+
+  /**
+   * Person ist die Zentrale Klasse des Personal-Komplexes.
+   **/
+  class Person {
+    String vorname;
+    Optional<String> vorsatzwort;
+    String nachname;
+    String kuerzel;       // Abgeleitet analog wie bei SAP: 3 Vor- 3 Nachnamenbuchstaben
+    Optional<String> personalnummer;
+    Optional<ZonedDateTime> gebDatum;
+    Optional<ZonedDateTime> beschBeginn;
+    Optional<ZonedDateTime> beschEnde;
+    List<String> kommentar;
+    boolean istAktiv;
+    boolean istStundenzettelpflichtig = false;
+    Optional<ZonedDateTime> stundenzettelpflichtigVon;
+    Optional<ZonedDateTime> stundenzettelpflichtigBis; // TODO: brauchen wir nicht mehr
+    Optional<Long> ueberStundenUebertrag;
+    boolean darfWochenendarbeiten;
+    // Start WZL:
+    Optional<ZonedDateTime> hoechstbeschaeftigungBis;
+    List<String> staatsangehoerigkeiten;
+    Optional<String> telefonnummer;
+    Optional<ZonedDateTime> arbeitserlaubnisBis;
+    boolean extern;
+    Optional<String> titel;
+    Optional<String> rufname;
+    Optional<String> adresse;
+    Optional<String> email;
+    Optional<String> geburtsname;
+    Optional<String> geschlecht;
+    Optional<String> lBVNummer;
+    Optional<ZonedDateTime> entfristung;
+    <<dbColumnDefinition="TEXT">>
+    Optional<String> qualifikationstitel;
+    boolean speicherungGewuenscht = false;
+    <<dbColumnDefinition="TEXT">>
+    Optional<String> urlaubskommentar;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [1] Person -> (anstellungsarten) Anstellungsart [*];
+  association [*] Person -> (vorgesetzte) Person [*];
+  association [1] Person -> (notiz) Freitext [0..1];
+
+  //Für Studentenzettel:
+  association [1] Person -> (jahresurlaubstage) Jahresurlaub [*];
+  association [1] Person -> (zusatzurlaubstage) Sonderurlaub [*];
+  association [1] Person -> (stundenzettel) Stundenzettel [*];
+  association [1] Person -> (abwesenheiten) Abwesenheit [*];
+
+    <<nocascade>>
+  association [1] Person -> (user) MacocoUser [0..1];
+
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart
+
+  class Anstellungsart {
+    BeschaeftigungsArt beschArt;
+  }
+
+  association [1] Anstellungsart -> (vertraege) Vertrag [*];
+  association [1] Anstellungsart -> (anstellungsformen) Anstellungsform [*];
+
+  enum BeschaeftigungsArt {
+    WiMi("Wissenschaftliche/r Mitarbeiter/in (WiMi)"),
+    HiWi("Hilfskraft (HiWi)"),
+    BTV("Beschäftigte/r in Technik und Verwaltung (BTV)"),
+    BEAMTE("Beamte/r"),
+    AZUBI("Azubi/ne"),
+    PLAN;
+  }
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> *Vertrag
+  // eine direkte Verbindung zwischen Person und Vertrag existiert nicht.
+
+  class Vertrag {       // spiegelt den Vertrag der Hochschule wieder
+    ZonedDateTime vertragsBeginn;
+    ZonedDateTime vertragsEnde;
+    boolean aenderungsvertrag;
+    /String vertragsStatus; // Aktiv, Planung, Abgelaufen // TODO: change String to enum
+    List<String> kommentar;
+    ZahlenWert planUmfang;
+    Optional<Long> arbeitsstundenProWoche; //Stundenzettel
+    boolean kuendigungsschutz;  // WZL
+    Optional<String> vertragsgrundlage;  // WZL / TODO: change to enum
+    Optional<String> aktion;  // WZL / TODO: change to enum
+    Optional<ZonedDateTime> aktionsDatum;  // WZL / TODO: change to enum
+  }
+
+  association [1] Vertrag -> (kostenstellen) Kostenstelle [*];
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> Anstellungsform
+
+  /**
+   * Beschreibt alle wesentlichen Merkmale einer Anstellung.
+   * Entgeltgruppe, Stufe, etc.
+   **/
+  class Anstellungsform {
+    boolean erstanstellung;
+    Optional<String> entgeltGruppe; // { TVL-13}  Für Hiwis: {SHK (default), WHB, WHK}
+    Optional<String> erfahrungsStufe; // 1- 6 ; sowie Spezialfälle (TVL Ü+);
+    boolean unbefristet;
+    ZonedDateTime anstellungVon;
+    Optional<ZonedDateTime> anstellungBis;
+    long gehaltCent;  // evtl. Schätzgehalt in Zukunft
+    boolean istEigenerReferenzwert;
+    List<String> kommentar;
+    Optional<String> berufsgruppe; // WZL / TODO: change to enum
+    Optional<String> aktion;  // WZL / TODO: change to enum
+    Optional<ZonedDateTime> aktionsDatum;  // WZL / TODO: change to enum
+  }
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> *Vertrag -> *Kostenstelle
+
+  class Kostenstelle {
+    ZonedDateTime verbuchungsBeginn;
+    ZonedDateTime verbuchungsEnde;
+    KostenstelleBezeichnung bezeichnung;
+    List<String> kommentar;
+    ZahlenWert beschaeftigungsUmfang;
+    boolean buchungenNeuErzeugen;
+    boolean buchungenLoeschen;
+    boolean gesperrt;
+  }
+
+  enum KostenstelleBezeichnung {
+    NONE(""),
+    AN_INSTITUT("An-Institut"),
+    GMBH("GmbH"),
+    ANDERER_LEHRSTUHL,
+    ANDERES_INSTITUT,
+    VORUEBERGEHEND_ABWESEND("Vorübergehend Abwesend"),
+    ANDERE_FINANZIERUNG;
+  }
+
+  enum Zuweisungsart {
+    KONTO("Kontenzuweisung"),
+    STELLENZUWEISUNG,
+    PLANSTELLE,
+    SONSTIGES;
+  }
+
+  association [*] Kostenstelle -> (personalBudget) Budget [0..1];
+  association Kostenstelle -> (stellenzuweisung) Stellenzuweisung [0..1];
+  association Kostenstelle -> (planstelle) Planstelle [0..1];
+                              <<nocascade>>
+  association [0..1] Kostenstelle -> (personalBuchungen) Buchung [*];
+
+  // Person -> *Anstellungsart -> *Vertrag -> *Kostenstelle -> ?Planstelle
+
+  class Planstelle {
+    String bezeichnung;
+    Optional<String> minEntgeltgruppe;
+    Optional<String> minEntgeltstufe;
+    Optional<String> maxEntgeltgruppe;
+    Optional<String> maxEntgeltstufe;
+    Optional<ZonedDateTime> verfuegbarVon;
+    Optional<ZonedDateTime> verfuegbarBis;
+    Optional<String> kommentar;
+    ZahlenWert planUmfang;
+    boolean aktiv;
+  }
+
+  association Planstelle -> (konto) Konto [0..1];
+
+  //----------------------------------------------
+
+  /**
+   * Repräsentiert verschiedene Arten von monetären Haben
+   * @attribute wert ist jeweils unterschiedlich zu interpretieren:
+   * EURO heisst, der wert ist in Cent angegeben
+   * STUNDE heisst: er ist in Stunden angegeben
+   *    (und das obwohl jedes Monat, Jahr unterschiedliche Stundenzahlen hat)
+   * PROZENT heisst er ist zwischen 0 und 100 angegeben (100%)
+   * NONE
+   **/
+  class ZahlenWert {
+    ZahlenTyp zahlenTyp;
+    long wert;
+  }
+
+  enum ZahlenTyp {EURO, STUNDE, PROZENT, NONE; }
+
+  //----------------------------------------------
+  //------------- Alerts -------------------------
+  //----------------------------------------------
+
+  // Konto -> *MailAlert
+
+  class MailAlert {
+    String name;
+                                    <<dbColumnDefinition="TEXT">>
+    String alertCondition;
+                                    <<dbColumnDefinition="TEXT">>
+    String mailBody;
+    int repetitions;
+    ZonedDateTime firstAlert;
+    ZonedDateTime lastAlert;
+
+    Optional<String> receipients;
+    Optional<String> ccs;
+    Optional<String> bccs;
+
+    // extra Attribute zur Speicherung einiger Werte (vom System unbenutzt)
+    long a1;
+    long a2;
+    boolean flag1;
+    boolean flag2;
+    String s1;
+    String s2;
+  }
+
+  //----------------------------------------------
+  // ============ Finanz-Datenstruktur ===========
+  //----------------------------------------------
+
+  /**
+   * Hauptklasse; das Konto, von der alle anderen abhängen.
+   * Hat mehrere Varianten (Subklassen)
+   */
+  abstract class Konto {
+    String name;
+    Optional<String> pspElement;
+    Optional<String> kontotyp;  // unterschiedlich je nach Kontoart
+    Optional<ZonedDateTime> sapDatum;
+    Optional<String> internesAktenzeichen;
+    boolean istPlanKonto;
+    boolean istVerbuchungsKonto;
+    boolean istAktiv;
+    Optional<String> vergabeVerordnung;
+    Optional<String> farbe;
+    Optional<ZonedDateTime> aenderungsdatum;
+    /Optional<ZonedDateTime> optStartDatum;
+    /Optional<ZonedDateTime> optEndDatum;
+    /Geschaeftsvorgang gueltigerGeschaeftsvorgang;
+  }
+
+  <<treatAsBidirectional>>
+  association [1] Konto (konto) -> (gesamtBudget) Budget [0..1];
+  association [1] Konto -> (kommentare) Freitext [*];
+  association [1] Konto -> (notiz) Freitext [0..1];
+  association [1] Konto <-> MailAlert [*];
+  association [1] Konto -> (abgleichsKonto) ExternKonto [0..1];
+
+  abstract class ErweitertesKonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<ZonedDateTime> bewilligungsDatum;    // Bewilligungsdatum ist im Industrieprojekt nur mandatory, wenn kein Sammelkonto
+    Optional<ZonedDateTime> verlaengertBisDatum;
+    Optional<ZonedDateTime> aufstockungsDatum;
+    Optional<Long> foerderquote;
+    // human names: "Aktenzeichen (RWTH)"
+    // Drittmittel: "Förderkennzeichen",
+    Optional<String> aktenzeichen;
+    Optional<Long> finanzierteKomplettsumme;
+    // human names:
+    // Drittmittel: "Aktenzeichen (Fördergeber)",
+    // Industrieprojekt: "Bestellnummer",
+    // Sonstiges: "Bestellnummer/Aktenzeichen (Fördergeber)"
+    Optional<String> referenzSponsor;
+    boolean hatProgrammpauschale;
+  }
+
+
+  class Drittmittelprojekt extends ErweitertesKonto {
+  }
+
+  association [*] Drittmittelprojekt -> (fachlicherVerantwortlicher) Person [*];
+
+  class Haushaltskonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+  }
+
+  class Industrieprojekt extends ErweitertesKonto {
+    Optional<String> auftraggeber;
+    boolean istSammelkonto;
+    Optional<Long> mehrwertsteuer;
+  }
+
+  association [*] Industrieprojekt -> (fachlicherVerantwortlicher) Person [*];
+
+  class Sonstiges extends ErweitertesKonto {
+    Optional<String> auftraggeber;
+    Geschaeftsvorgang geschaeftsvorgang;
+    Optional<Long> mehrwertsteuer;
+    boolean istSammelkonto;
+  }
+
+
+  enum AbrechnungsInterval {
+    GESAMTE_PROJEKTLAUFZEIT("Gesamte Projektlaufzeit"),
+    JAEHRLICH("Jährlich"),
+    HALBJAEHRLICH("Halbjährlich"),
+    QUARTALSWEISE("Quartalsweise"),
+    MONATLICH("Monatlich");
+  }
+
+  association [1] Konto -> OrganigrammKonto [*];
+
+  class OrganigrammKonto {
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    Optional<ZahlenWert> umfang;
+  }
+
+  association [*] OrganigrammKonto -> Organigramm [1];
+
+  class ZeitlicheVerbuchungskontoZuordnung {
+  	Optional<Long> programmPauschale;
+  	Optional<Long> gemeinkostensatz;
+  	Optional<ZonedDateTime> startDate;
+  	Optional<ZonedDateTime> endDate;
+  	boolean istHauptVerbuchungskonto;
+  }
+
+  association [1] ErweitertesKonto -> (verbuchungskontoZuordnung) ZeitlicheVerbuchungskontoZuordnung [*];
+  association [*] ZeitlicheVerbuchungskontoZuordnung -> (verbuchungskonto) Konto [0..1];
+
+  //----------------------------------------------
+
+  // ------ Budget ------
+  // Konto -> 1Budget
+  // Konto -> 1Budget -> *Budget
+  // Konto -> 1Budget -> *Budget -> *Budget
+
+  /**
+   * Ein Budget erlaubt es ein Konto nach verschiedenen
+   * Strukturierungskriterien zu zerlegen. Budgets sind nur auf drei Ebenen
+   * erlaubt: 1 Hauptbudget, * OberBudgets, ** Unterbudgets.
+   * Die Budget-Struktur stellt einen Baum der maximalen Tiefe 3 dar.
+   */
+
+  class Budget {
+    String typ; // name
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<String> kommentar;
+    Optional<long> budgetRahmenCent; // wird im Gesamtbudget als Bewilligungssumme interpretiert
+    Optional<long> eigenAnteilCent;
+    List<long> jahresBudgets;
+    boolean proportionaleVerteilung;
+    boolean forOverheads; // das erste Budget (gesamtBudget.getUnterbudgets[0])
+    Optional<String> budgetKategorie;
+    /int budgetDepth;
+  }
+
+  association [*] Budget -> Konto [1];
+  association [0..1] Budget (elternBudget) <-> (unterBudget) Budget [*];
+  association [1] Budget (budget) <-> (buchungseintrag) Buchungseintrag [*];
+  association [1] Budget (budget) <-> (stellenzuweisung) Stellenzuweisung [*];
+  <<noOrphanRemoval, noRemoveCascade>>
+  association [0..1] Budget -> Organigramm [0..1];
+
+  //----------------------------------------------
+
+  // ------ Buchungseinträge ------
+  // Konto -> 1Budget (->*Budget)* -> *Buchung
+
+  /**
+   * Buchungen aller Arten: gemeinsame Oberklasse
+   */
+  abstract class Buchungseintrag {
+    ZonedDateTime datum;
+    Optional<String> buchungseintragText; // human name: Buchung: "Buchungstext", Rechnung: "Rechnungsgrund", Mittelabruf: "Anmerkung", Mittelzuweisung: "Grund"
+    long betragCent;                          // human name: "Betrag", Rechnung: "Rechnungsbetrag", Konten mit Programmpauschale: "Rechnungsbetrag (inkl Pauschale)"
+    boolean istAktiv;
+    Optional<ZonedDateTime> aenderungsdatum;
+    /Geschaeftsvorgang gueltigerGeschaeftsvorgang;
+    /String lfdeNummer;
+  }
+
+  class Buchung extends Buchungseintrag {
+    ZonedDateTime belegdatum;
+    String zahlungsgrund; //Belegpositionstext
+    Optional<String> kreditorDebitor;
+    List<String> sachkonto;
+    Optional<ZonedDateTime> buchungsdatum;
+    BuchungsStatus status;
+    List<String> belegnummern;
+    List<String> auftragsnummer;
+    Optional<String> bereich;
+    Optional<String> projekt;
+    Optional<ZonedDateTime> geschaeftsjahr;
+    Optional<Long> steuer;
+    Optional<Long> skonto;
+    Optional<Long> gez_Skonto;
+    Optional<String> erfasser;
+    Optional<String> belegart;
+    Optional<String> referenz;
+    Optional<String> stornonummer;
+    Optional<String> stkz;
+    Optional<ZonedDateTime> erfassungsdatum;
+    Optional<ZonedDateTime> ausgleichsdatum;
+    long betragCentOriginal; // Bei Abweichungen von BetragCent kann nun eine Absicht ueberprueft werden
+    boolean budgetChangedManually; // s.o.
+    Optional<String> kostenarten;
+    /Optional<Integer> bezugsdatumJahr;
+  }
+
+  class Rechnungsstellung extends Buchungseintrag {
+    Optional<ZonedDateTime> rechnungsdatum;
+    Optional<String> rechnungsnummer;
+    RechnungsstellungStatus status;
+    List<String> belegnummern;
+    Optional<Long> gemeinkosten;
+    Optional<Long> honorierung;
+    Optional<String> projekt;
+    Optional<String> debitor;
+    Optional<Long> mehrwertsteuer;
+    Optional<ZonedDateTime> zahlungsziel;
+  }
+
+  class Mittelzuweisung extends Buchungseintrag {
+    Optional<ZonedDateTime> verfallDatum;
+    Optional<String> kennung;
+    MittelzuweisungStatus status;
+  }
+
+  class Mittelabruf extends Buchungseintrag {
+    ZonedDateTime abrufdatum;
+    MittelabrufStatus status;
+    String zeitraum;
+    Optional<Long> pauschaleManuell; // Präsent, falls die Pauschale manuell geändert wurde
+  }
+
+  // ------ Stellenzuweisung ------
+
+  // Konto -> 1Budget (->*Budget)* -> *Stellenzuweisung
+
+  class Stellenzuweisung {
+    ZonedDateTime erstellDatum;         // aktuelles Datum
+    Optional<ZonedDateTime> startDatum; // Datum, zu welchem die Stelle beginnt
+    Optional<ZonedDateTime> endDatum;   // Datum, zu welchem die Stelle endet
+    long wert;
+    String kennung;
+    StellenzuweisungStatus status;
+    ZahlenWert stellenumfang;
+    boolean istAktiv;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  enum Geschaeftsvorgang {
+    NONE,
+    MITTELABRUF,
+    ZUWEISUNG,
+    RECHNUNG;
+  }
+
+  enum BuchungsStatus {
+    EINGEREICHT,
+    SAP("SAP"),
+    SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    FEHLERHAFT;
+  }
+
+  enum RechnungsstellungStatus {
+    OFFENE_RECHNUNG,
+    SAP("SAP"),
+     SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG;
+  }
+
+  enum MittelzuweisungStatus {
+    BESCHEID_ERHALTEN ("Bescheid erhalten"),
+    SAP("SAP"),
+    SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    FEHLERHAFT;
+  }
+
+  enum MittelabrufStatus {
+    ABGERUFEN,
+    SAP("SAP"),
+     SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    EINGEREICHT;
+  }
+
+  enum StellenzuweisungStatus {
+    BESETZT,
+    TEILBESETZT,
+    UNBESETZT,
+    PLANUNG;
+  }
+
+  enum VertragStatus {
+    AKTIV,
+    PLANUNG,
+    ABGELAUFEN;
+  }
+
+  //----------------------------------------------
+  // =============== SAPii ===============
+  //----------------------------------------------
+
+  class SAPVerbindung {
+    SAPverbindungsStatus status;
+  }
+
+  class Anfrage {
+    String ikz;
+    String bezeichner;
+    boolean letzteAnfrageErfolgreich;
+  }
+
+  enum SAPverbindungsStatus {
+    VERBUNDEN,
+    GETRENNT,
+    PROBLEM;
+  }
+
+  enum SAPimportMode {
+    DEFAULT,
+    F1KONTO;
+  }
+
+  association [1] SAPVerbindung -> (authorizedBy) MacocoUser [*];
+  association [1] MacocoUser -> (anfragen) Anfrage [*];
+  association [1] Anfrage -> (filteredKonten) PSPImportFilter [*];
+
+  //----------------------------------------------
+
+  class AbgleichsBuchung extends Buchung {
+      AbgleichsStatus abgleichsStatus;
+      Optional<String> abgleichKommentar;
+      String positionsNummer;
+      boolean deactivated;
+  }
+
+    enum AbgleichsStatus {
+      ABGESCHLOSSEN,            // Der Abgleich dieser Buchung ist Abgeschlossen
+      TEILWEISE_ABGESCHLOSSEN,  // Der Abgleich wurde schon Bearbeitet es fehlen jedoch Summen
+      ABWEICHEND,               // Der Abgleich ist Vollständig mit Abweichenden Summen
+      OFFEN,                    // Der Abgleich wurde noch nicht gesetzt
+      VORGESCHLAGEN;            // Der Abgleich wurde vom System vorgeschlagen
+    }
+
+  class AbgleichsGruppe {
+    String bezeichnung;
+  }
+                                <<nocascade>>
+  association AbgleichsGruppe -> (buchungen) Buchung [*];
+                                <<nocascade>>
+  association AbgleichsGruppe -> (abgleichsBuchungen) AbgleichsBuchung [*];
+                                 <<nocascade>>
+  association AbgleichsGruppe -> (konto) Konto [1];
+
+  // ------ Freitext ------
+
+  class Freitext {
+    Optional<ZonedDateTime> erstellDatum;
+    Optional<ZonedDateTime> bearbeitetDatum;
+                                    <<dbColumnDefinition="TEXT">>
+    Optional<String> text;
+  }
+
+  class Legende {
+    LegendeTyp type;
+    String expression;
+      <<dbColumnDefinition="TEXT">>
+    String description;
+  }
+
+  enum LegendeTyp {
+    KONTO_FARBE;
+  }
+
+  //----------------------------------------------
+  // =============== Projekte ===============
+  //----------------------------------------------
+
+  abstract class Projekt {
+    String name;
+    String kuerzel;
+    Optional<Long> minPM;
+    Optional<Long> maxPM;
+    Optional<Long> finanzPM;
+    Optional<ZonedDateTime> laufzeitVon;
+    Optional<ZonedDateTime> laufzeitBis;
+    Optional<String> kommentar;
+    Optional<String> foerdergeberAZ;
+    ProjektStatus status;
+    boolean istAktiv;
+    boolean lockedForStundenzettel;   // Das gesamte Projekt ist gesperrt
+    List<ZonedDateTime> lockedMonths; // Stellen die Ausnahme aus der Lock-Regelung für das gesamte Projekt dar
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [1] Projekt -> Aufwand [*];
+  association [1] Projekt -> Arbeitspaket [*];
+  association [1] Projekt -> Anstellung [*];
+  association [*] Projekt -> Konto [0..1];
+  association [*] Projekt -> (hauptverantwortlich) Person [*];
+  association [1] Projekt -> (notiz) Freitext [0..1];
+
+  class Auftragsprojekt extends Projekt {
+    Optional<String> nummer;
+    ProjektTyp typ;
+    Optional<String> regelung;
+  }
+
+  class Organisation extends Projekt {
+  }
+
+  class Lehre extends Projekt {
+    Optional<Long> stunden;
+  }
+
+  class Arbeitspaket {
+    String nummer; // könnte auch 1.1 sein
+    String name;
+    Optional<String>  beschreibung;
+    Optional<ZonedDateTime> beginnDatum;
+    Optional<ZonedDateTime> endeDatum;
+    Optional<Long> pMs;
+    Optional<Long> stunden;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  class Aufwand {
+    /long pM;
+    ZahlenWert umfang;
+    ZonedDateTime laufzeitVon;
+    ZonedDateTime laufzeitBis;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [*] Aufwand -> Person [0..1];
+
+  class Anstellung {
+    Optional<String> bezeichnung;
+    ZahlenWert umfang;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    boolean verfaellt;
+    Optional<Stellentyp> min;
+    Optional<Stellentyp> max;
+    /long pM;
+    BeschaeftigungsArt beschaeftigungsArt;
+  }
+
+  association [*] Anstellung -> Person [0..1];
+
+  class Stellentyp {
+    Optional<String> entgeltgruppe;
+    Optional<String> entgeltstufe;
+  }
+
+  enum ProjektStatus {
+    IN_DEFINITION,
+    BEANTRAGT,
+    GENEHMIGT,
+    ABGELEHNT,
+    LAUFEND,
+    FACHLICH_ABGESCHLOSSEN("Fachlich abgeschlossen"),
+    ENDBERICHT_EINGEREICHT("Endbericht eingereicht"),
+    INPRUEFUNG("In Prüfung"),
+    GEPRUEFT("Geprüft"),
+    ABGERECHNET,
+    ABGESCHLOSSEN,
+    ARCHIVIERT;
+  }
+
+  enum ProjektArt {
+    AUFTRAG,
+    ORGANISATION,
+    LEHRE,
+    NONE;
+  }
+
+  enum ProjektTyp {
+    HOHEITLICH,
+    INDUSTRIE,
+    UNIVERSITAET("Universität"),
+    SONSTIGE;
+  }
+
+  enum Vergabeverordnung {
+    VOL_A ("VOL/A"),
+    VOB_A ("VOB/A"),
+    UVGO_NRW ("UVgO NRW"),
+    UVGO_BUND ("UVgO Bund"),
+    NONE (" ");
+  }
+
+  //----------------------------------------------
+  // =============== Stundenzettel ===============
+  //----------------------------------------------
+
+  class Stundenzettel {
+    StundenzettelStatus status;
+    ZonedDateTime zeit;
+    Optional<Long> abgegebenVonUserId;
+    Optional<ZonedDateTime> abgabeDatum;
+  }
+
+  association [1] Stundenzettel -> (eintraege) StundenzettelEintrag [*];
+
+  class StundenzettelEintrag {
+    ZonedDateTime uhrzeitVon;
+    Optional<ZonedDateTime> uhrzeitBis;
+    Optional<String> beschreibung;
+    /long stunden;
+    StundenzettelProjekt pauseOderSonstiges;
+  }
+
+  association [*] StundenzettelEintrag ->  Projekt [0..1];
+  association [*] StundenzettelEintrag ->  Arbeitspaket [0..1];
+
+  class StundenzettelHistorieEintrag {
+    ZonedDateTime bearbeitungsdatum;
+    Optional<Long> editorId;
+    Optional<String> editedBy;
+    String monat;
+    int jahr;
+    String changeOperation;
+  }
+
+  enum StundenzettelChangeOperation {
+    INVALID,
+    ABGEGEBEN("Abgegeben"),
+    INTERN_GEPRUEFT("Intern Geprüft"),
+    INTERN_ABGESCHLOSSEN("Intern Abgeschlossen");
+  }
+
+  association [1] Person ->  StundenzettelHistorieEintrag [*];
+
+  class Abwesenheit {
+    Abwesenheitsgrund grund;
+    ZonedDateTime  datumVon;
+    ZonedDateTime datumBis;
+    Optional<String> kommentar;
+    Optional<ZonedDateTime> uhrzeitVon;
+    Optional<ZonedDateTime> uhrzeitBis;
+    Optional<Long> minutenProTag;
+    /long tageGesamt;
+  }
+
+  class Dienstreise extends Abwesenheit {
+    Optional<String> reisenummer;
+    Optional<String> dienstreisegrund;
+    Optional<String> reiseziel;
+    Optional<Long> gesamtkosten;
+    Optional<String> status;
+    Optional<String> statusText;
+  }
+
+  association [*] Abwesenheit -> Konto [0..1];
+
+  association [1] Abwesenheit -> UrlaubsGenehmigung [0..1];
+
+  association [*] Dienstreise -> Budget [0..1];
+
+  class Arbeitstage {
+    ZonedDateTime guiltigAb;
+    ZonedDateTime guiltigBis;
+    List<Integer> wochenTage; // 0..4 (Montag-Freitag)
+  }
+
+  association [1] Person -> Arbeitstage [*];
+
+  class Jahresurlaub {
+    int jahr;
+    long tageAnzahl;
+    Optional<Long> stundenAnzahl;
+    boolean istManuellerEintrag;
+  }
+
+  class UrlaubsGenehmigung {
+    Optional<ZonedDateTime> beantragt;
+    Optional<ZonedDateTime> genehmigt;
+    Optional<ZonedDateTime> geprueft;
+    Optional<ZonedDateTime> storniert;
+    Urlaubssstatus status;
+    Stornierungsstatus stornierungsStatus;
+  }
+
+  class Sonderurlaub {  // Für WZL: Zusatzurlaub umbenennen in Sonderurlaub und neues Feld anzahl
+    ZonedDateTime  datumVon;
+    ZonedDateTime datumBis;
+    long anzahl;
+  }
+
+  class UrlaubEinstellungen {
+    boolean urlaubsanspruchInStunden;
+  }
+
+  enum Abwesenheitsgrund {
+    U_URLAUB,
+    D_DIENSTREISE,
+    S_SONSTIGE;
+    /*
+    Z_ZUSATZURLAUB,
+    A_ARBEITSUNFALL,
+    AB_ABGELTUNG,
+    E_ELTERNZEIT,
+    F_FREISTELLUNG,
+    K_KRANKHEIT,
+    KU_KUR,
+    S_SONSTIGES;*/
+  }
+
+  enum Urlaubssstatus {
+    NONE,
+    BEANTRAGT,
+    GEPRUEFT("Geprüft"),
+    PRUEFUNG_ABGELEHNT("Prüfung abgelehnt"),
+    GENEHMIGT,
+    GENEHMIGUNG_ABGELEHNT;
+  }
+
+  enum Stornierungsstatus {
+    NONE,
+    VERBOTEN,
+    STORNIERUNGSANTRAG,
+    STORNIERT;
+  }
+
+  enum Abrechnungsstatus {
+    OFFEN,
+    ABZURECHNEN,
+    ABGERECHNET,
+    STORNIERT;
+  }
+
+  enum StundenzettelStatus {
+    IN_ERFASSUNG,
+    INTERN_INPRUEFUNG("Intern in Prüfung"),
+    INTERN_ABGESCHLOSSEN,
+    DRITTMITTELABTEILUNG_INPRUEFUNG("Drittmittelabteilung in Prüfung"),
+    DRITTMITTELABTEILUNG_ABGESCHLOSSEN,
+    ENDBERICHT_EINGEREICHT,
+    GEPRUEFT("Geprüft"),
+    FOERDERGEBER_ABGESCHLOSSEN("Fördergeber abgeschlossen"),
+    ABGESCHLOSSEN;
+  }
+
+  enum StundenzettelProjekt {
+    PAUSE,
+    SONSTIGE,
+    NONE;
+  }
+
+  association [*] F1Konto -> (institut) Institut [0..1];
+
+  class ExternKonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<String> importVermerk;
+    AbgleichType abgleichVerhalten;
+  }
+
+  enum AbgleichType {
+    IGNORE,
+    MANUEL,
+    AUTO_COPY;
+  }
+
+  association [*] ExternKonto -> (institut) Institut [0..1];
+
+  class PSPImportFilter{
+    boolean importThisPSPelement;
+    boolean importBookings;
+    String name;
+    String pspElement;
+    Optional<ZonedDateTime> startDate;
+  }
+
+  association [*] PSPImportFilter -> (targetPSP) Konto [0..1];
+
+  //----------------------------------------------
+  // Reports
+
+  class EventReport {
+    ZonedDateTime eventStart;
+    Optional<ZonedDateTime> eventEnd;
+    /EventStatus status;
+    String message; // <a href="wiki/BuchungImport">BuchungImport</a>: Nutzer 'netz' hat die Datei '.....' importiert
+  }
+
+  class EventReportEntry {
+    EventType type;
+    Optional<Long> targetId; // click -> navigate to id
+    Optional<Integer> count;
+    <<dbColumnDefinition="TEXT">>
+    String message; // Zeile 4 Fehler ...... Zeile 5 .....
+    EventStatus status;
+  }
+  association [1] EventReport -> (entries) EventReportEntry [*];
+
+  class ImportReport extends EventReport {
+  }
+
+  class ImportReportEntry extends EventReportEntry {
+  }
+
+
+  class PersonalExportReport extends EventReport {
+    Long dataId;
+
+    ZonedDateTime datenStart;
+    ZonedDateTime datenEnd;
+    Long countData;
+    /Long countError;
+    EventStatus exportStatus;
+  }
+
+  class PersonalExportReportEntry extends EventReportEntry {
+    Optional<String> vorsatzwort;
+    String vorname;
+    String nachname;
+    BeschaeftigungsArt beschaeftigungsArt;
+    ZonedDateTime monat;
+  }
+
+  enum EventStatus {
+    // Import
+    SUCCESS("erfolgreich"),
+    ERROR("fehlerhaft"),
+    INFO("erfolgreich"), // success + special
+    CREATED("erstellt"),
+    UPDATED("upgedated"),
+    IGNORED("ignoriert"),
+    IN_PROGRESS("in bearbeitung"),
+
+    // Personal Export
+    SENT("verschickt"),
+    CORRECT("sachlich korrekt");
+  }
+
+  enum EventType {
+    IMPORT_KONTO("Konten"),
+    IMPORT_BUCHUNG("Buchungs"),
+    IMPORT_PERSON("Personen"),
+    IMPORT_INSTITUT("Instituts"),
+    IMPORT_NUTZER("Nutzer"),
+    IMPORT_VERTRAG("Vertrags"),
+    EXPORT_FINANZEN_KONTO("Konten"),
+    EXPORT_FINANZEN_PLANSTELLE("Planstellen"),
+    EXPORT_FINANZEN_VERTRAG("Vertragabdeckungs");
+  }
+
+
+  //----------------------------------------------
+  // =============== Fakultät 1 DS ===============
+  //----------------------------------------------
+
+  // Institut
+  <<dbColumn = "unique=true">>
+  class Institut {
+    String institutsKennZiffer;
+    String institutsName;
+    String professorName;
+    boolean lokalInstitut;
+  }
+
+  // Fachgruppe
+  enum Fachgruppe {
+    MATHEMATIK,
+    INFORMATIK,
+    PHYSIK,
+    CHEMIE,
+    BIOLOGIE;
+  }
+
+  //SAP-Abschöpfung von Geschäftsjahr
+  class GeschaeftsjahrSAPAbschoepfung {
+    String fachgruppe;
+    String institutsKennZiffer;
+    String institutsName;
+    String pspElement;
+    long gesamtSAPAbschoepfung;
+  }
+
+  class SAPAbschoepfung {
+    Long betragCent;
+    ZonedDateTime year;
+  }
+
+  association [1] GeschaeftsjahrSAPAbschoepfung -> (sapAbschoepfung) SAPAbschoepfung [*];
+
+
+  // Konto
+  class F1Konto extends Haushaltskonto {
+    long originalBudgetCent;
+    long sonstigeZuweisungenCent;
+    long resteCent;
+    long aktuellerKontostandCent;
+    long kontoRahmenCent;
+    KommunikationsStatus kommunikationsStatus;
+    StrafsteuerStatus strafsteuerStatus;
+    long strafsteuerBasisCent;
+    long strafsteuerSAPCent;
+    long strafsteuerCent;
+    long strafsteuerBerechnungsGrundlageCent;
+    Optional<Long> kontoStandBeginnGeschaeftsjahr;
+  }
+
+  // Konto -> 1Budget (->*Budget)* -> *Buchung -> ?Begruendung
+
+  // Buchungen werden hier noch erweitert:
+  association [1] Buchung -> (begruendung) Begruendung [0..1];
+
+  class Begruendung {
+    String text;
+    ZonedDateTime erstellung;
+    Optional<ZonedDateTime> letzteBearbeitung;
+    Optional<StrafsteuerGeschaeftsjahr> geschaeftsjahr;
+  }
+
+  association [1] Begruendung -> (akzeptanz) Akzeptanz [0..1];
+  //association [1] Begruendung -> (geschaeftsjahr) StrafsteuerGeschaeftsjahr [0..1];
+
+  //----------------------------------------------
+
+  // Konto -> 1Budget (->*Budget)* -> *Buchung -> ?Begruendung -> ?Akzeptanz
+
+  class Akzeptanz {
+    Akzeptanzstatus akzeptanzstatus;
+    Optional<long> teilbetragCent;
+    Optional<ZonedDateTime> bearbeitung;
+    boolean istAktiv;
+    Optional<String> kommentar;
+  }
+
+  //----------------------------------------------
+
+  enum KommunikationsStatus {
+    KOM_STAT_NO_ACTION_NEEDED,       // Kein Handlungsbedarf
+    KOM_STAT_BEGR_FEHLT,             // Begründung fehlt
+    KOM_STAT_ANTW_FEHLT,             // Antwort fehlt
+    KOM_STAT_ANTW_CHANGED,           // Buchung oder Begründung wurden geändert
+    KOM_STAT_BEGR_CHANGED,           // Antwort wurde geändert
+    KOM_STAT_ANTW_BEGR_CHANGED,      // Antwort und Begründung wurde geändert
+    KOM_STAT_ANTW_FEHLT_CHANGED;     // Antwort Fehlt, andere Antwort wurde geändert
+  }
+
+  enum StrafsteuerStatus {
+    NONE,
+    SOME,
+    ALL;
+  }
+
+  enum Akzeptanzstatus {
+    OFFEN,
+    OK,
+    TEILOK,
+    NOTOK;
+  }
+
+  class StrafsteuerGeschaeftsjahr {
+    ZonedDateTime jahr;
+    boolean current;
+  }
+
+  class StrafsteuerSperrDatum {
+    ZonedDateTime sperrDatum;
+  }
+
+  //----------------------------------------------
+  // =============== MacocoUser ===============
+  //----------------------------------------------
+
+  class MacocoUser {
+                                     <<dbColumn = "unique=true">>
+    String username;
+    Optional<String> encodedPassword;
+    String passwordSaltBase64;
+    ZonedDateTime registrationDate;
+    Optional<String> initials;
+    MacocoUserActivationStatus activated;
+    boolean enabled;
+                                      <<dbColumn = "unique=true">>
+    String email;
+    boolean authentifiziert;
+    Optional<String> timID;
+    Optional<String> sapAccessToken;
+    Optional<String> sapRefreshToKen;
+
+  }
+
+  association  [*] MacocoUser -> (institute) Institut [*];
+
+  enum MacocoUserActivationStatus {
+    AKTIVIERT,
+    MAIL_NICHT_GESENDET("Mail nicht gesendet"),
+    MAIL_FEHLERHAFT("Mail fehlerhaft"),
+    MAIL_GESENDET("Mail gesendet");
+  }
+
+  // Favoriten
+  class Favorite {
+    String title;
+    String url;
+  }
+
+  association [1] MacocoUser -> (favorite) Favorite [*];
+
+  class RoleAssignment {
+  }
+
+  association [*] RoleAssignment -> (user) MacocoUser [1];
+  association [*] RoleAssignment -> (accessPolicy) AccessPolicy [1];
+
+  class AccessPolicy {
+    String roleName;
+    Optional<Long> objId;
+  }
+
+  class GroupedAccessPolicy {
+    String name;
+  }
+
+  association [*] GroupedAccessPolicy -> (user) MacocoUser [*];
+  association [1] GroupedAccessPolicy -> (policy) AccessPolicy [*];
+
+  //----------------------------------------------
+  // =============== Fristen ===============
+  //----------------------------------------------
+
+  class Frist {
+    String beschreibung;
+    Friststatus status;
+    Fristobjekt fristobjekt;
+    ZonedDateTime faelligkeitsdatum;
+    Optional<String> notiz;
+    Boolean manuellerEintrag;
+    Long bezugsobjektId;
+    String bezugsobjektName;
+    Optional<ZonedDateTime> aenderungsdatum;
+    boolean istAktiv;
+  }
+
+  association [*] Frist -> (zuweisung) Person [0..1];
+
+  association [1] Person -> Frist [*];
+  association [1] Konto -> Frist [*];
+  association [1] Projekt -> Frist [*];
+  association [1] Mittelabruf -> Frist [0..1];
+  association [1] Rechnungsstellung -> Frist [0..1];
+  association [1] Vertrag -> Frist [0..1];
+  association [1] Zulage -> Frist [0..1];
+
+  enum Friststatus {
+    PLANUNG,
+    IN_BEARBEITUNG,
+    ERLEDIGT;
+  }
+
+  enum Fristobjekt {
+    PERSON,
+    KONTO,
+    VERTRAGSVERLAENGERUNG("Vertragsverlängerung"),
+    ZULAGE,
+    RECHNUNG,
+    MITTELABRUF,
+    PROJEKT;
+  }
+
+  class DefaultFristen {
+    ZonedDateTime finanzenStartDatum;
+    Long finanzenFristinWeeks;
+    ZonedDateTime personalStartDatum;
+    Long personalFristinWeeks;
+  }
+
+  //----------------------------------------------
+  // ============= Einstellungen =================
+  //----------------------------------------------
+
+  class Setting {
+    String identifier;
+  }
+
+  class InstanzSetting extends Setting {
+    String value;
+  }
+
+  class UISetting extends Setting {
+    String seite;
+  }
+
+  association [0..1] MacocoUser -> (setting) UISetting [*];
+
+  class FilterSetting extends UISetting {
+    List<String> filterValues;
+  }
+
+  class TableSetting extends UISetting {
+    TableIdentifierTyp typ;
+    boolean zeigeInaktive;
+    int zeilenLimit;
+    Optional<String> gruppiereNach;
+    Optional<String> sortiereNach;
+    Optional<String> sortiereDir;
+    boolean isShowColor;
+  }
+
+  association [1] TableSetting -> (spalten) TableSettingSpalten [*];
+
+  enum TableIdentifierTyp {
+    DEFAULT,
+    USER,
+    INSTITUT;
+  }
+
+  class TableSettingSpalten {
+    String name;
+    boolean istAktiv;
+    long breite;
+  }
+
+  class ErweiterbareListen{
+    String bereich;
+    String feldbezeichnung;
+    List<String> inhalte;
+  }
+
+  //----------------------------------------------
+  // =============== Card Settings ===============
+  //----------------------------------------------
+
+  class CardSetting {
+    String page;
+    String identifier;
+    <<dbColumnDefinition="TEXT">>
+    String configuration;
+  }
+
+  association [*] CardSetting -> (benutzer) MacocoUser [0..1];
+
+  //----------------------------------------------
+  // =============== WZL ===============
+  //----------------------------------------------
+
+  class Elternzeit { // WZL
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    ZahlenWert umfang;
+  }
+
+  class Nebentaetigkeit { // WZL
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    ZahlenWert umfang;
+    Optional<String> arbeitgeber;
+    Optional<String> taetigkeitsbereich;
+  }
+
+  class Zulage  { // WZL
+    Optional<String> pspelement;
+    Optional<String> bezeichnung;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    Long arbeitgeberbrutto;
+    Long arbeitnehmerbrutto;
+  }
+
+  // WZL
+  enum Geschlecht { NONE(""), WEIBLICH("weiblich"), MAENNLICH("männlich"), DIVERS("divers"); }
+
+  // WZL
+  // -> DataSource
+  enum Titel { NONE(""), E1("Apl. Prof. Dr.") , E2("B.Sc.") , E3("Dipl.-Inform.") , E4("Dipl.-Ing."), E5("Dipl.-Ing. (FH)"),
+    E6("Dipl.-Ing. (RUS)"), E7("Dipl.-Kff.") , E8("Dipl.-Math."), E9("Dipl.-Phys.") , E10("Dipl.-Wirt. Ing.") , E11("Dr.")  , E12("Dr. phil."),
+    E13("Dr. rer. nat."), E14("Dr. rer. pol."), E15("Dr.-Ing."), E16("M.A.") , E17("M.Eng."), E18("M.Sc."), E19("PhD"), E20("Prof. Dr.-Ing."); }
+
+  // WZL
+  // -> DataSource
+  enum Berufsgruppe { NONE(""), E1("Akademischer Direktor"), E2("Angestellter in der DV"), E3("Auszubildende/r"), E4("Bibl.-Beschäftiger"),
+    E5("Elektriker"), E6("Elektroniker"), E7("Elektrotechniker"), E8("Fachinformatiker"), E9("Fachinformatiker"), E10("Industriemechaniker"),
+    E11("Lagerarbeiter"), E12("Mechaniker"), E13("Meister"), E14("Praktikant, SV-frei"), E15("Programmierer"), E16("Stud. Hilfskraft"),
+    E17("Techn. Beschäftigter"), E18("Techn. Zeichner"), E19("Techniker"), E20("Universitätsprofessor"), E21("Verw. Beschäftigter"), E22("Werkstoffprüfer"),
+    E23("Wiss. Beschäftigter"), E24("Wiss. Hilfskraft Bachelor"), E25("Wiss. Hilfskraft Master"); }
+
+  // WZL
+  enum Aktion { NONE(""), ANFRAGE_VERSENDET("Anfrage versendet"), ERINNERUNG_VERSENDET("Erinnerung versendet"),
+    ZUR_UNTERSCHRIFT_BEIM_VORGESETZTEN("Zur Unterschrift beim Vorgesetzten"),
+    BEI_ZHV_VORGELEGT("Bei ZHV vorgelegt"), VON_ZHV_BESTAETIGT("Von ZHV bestätigt"); }
+
+  // WZL
+  // -> DataSource
+  enum Vertragsgrundlage { NONE(""), E1("sonst. Befristungen (gleicht Auszubildenden)"), E2("unbefristet"), E3("unbefr. (Beamter aL)"), E4("§14 Abs. 2 TzBfG"),
+    E5("Elternzeitvertretung"), E6("Befristung SHK"), E7("Mehrbedarf sonstiger"), E8("Mehrb. Forschungspr."), E9("§2(5)Nr.3WZVG MuS-EZ"),
+    E10("§2 WZVG DM (NP)"), E11("§2 WZVG KiBetr NP"), E12("WZVG-Postdoc-Quali."), E13("WZVG-N-Gr._Leiter"), E14("WZVG-Wiss.-Quali NP"),
+    E15("§2 WZVG DM (VP)"), E16("§2 WZVG KiBetr VP"), E17("WZVG-Promotion"), E18("WZVG-sonst.Wiss-Qual"), E19("Befristung WHB"), E20("Befristung WHK"),
+    E21("§2 (1) S.2 WZVG nPr"), E22("§14(1) Nr.2 TzBfG-Üb"), E23("befr. Arbeitszeitänderung"), E24("Übernahme nach Ausbildung"); }
+
+  association [1] Person -> (elternzeiten) Elternzeit [*]; // WZL
+  association [1] Person -> (nebentaetigkeiten) Nebentaetigkeit[*];  // WZL
+  association [1] Person -> (zulagen) Zulage [*];  // WZL
+
+  // WZL Personal Export
+  class PersonalExportData {
+  }
+  association [1] PersonalExportData -> (entries) PersonalExportDataEntry [*];
+
+  class PersonalExportDataEntry {
+    String personalnummer;
+    Optional<String> vorsatzwort;
+    String nachname;
+    String vorname;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    String pspElement;
+    Long prozentsatz;
+  }
+
+   class PersonalExportEinstellungen {
+     String pspElement;
+     List<String> bezeichnungen;
+     ZonedDateTime startmonat;
+     ZonedDateTime endmonat;
+   }
+
+  class Organigramm {
+    boolean istStabstelle;
+    boolean istAktiv;
+    String bezeichnung;
+  }
+
+  <<noOrphanRemoval>>
+  association [0..1] Organigramm (parent) <-> (child) Organigramm [*];
+
+  association [1] Organigramm -> (leiter) OrganigrammPersonInfo [*];
+  association [1] Organigramm -> (stellvertreter) OrganigrammPersonInfo [*];
+  association [1] Organigramm -> (mitarbeiter) OrganigrammPersonInfo [*];
+
+  class OrganigrammPersonInfo {
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    Optional<ZahlenWert> umfang;
+  }
+
+  association [*] OrganigrammPersonInfo -> Person [1];
+
+  //----------------------------------------------
+  // =============== WZL END ===============
+  //----------------------------------------------
+
+
+  // Druckeinstellungen
+  class DruckEinstellungenProjekt {
+    Long projektId;
+    Integer jahr;
+    Integer monat;
+    Optional<String> mittelabrufnummer;
+    Optional<String> belegnummer;
+  }
+
+  association [1] DruckEinstellungenProjekt -> (druckEinstellungenPersonen) DruckEinstellungenPerson [*];
+
+  class DruckEinstellungenPerson {
+    Long personId;
+    Optional<ZahlenWert> stundensatz;
+  }
+
+  class BlacklistedToken {
+    <<dbColumnDefinition="TEXT">> // have more than 255 characters
+    String token;
+    ZonedDateTime addedAt;
+    ZonedDateTime expiresAt;
+  }
+
+  class RefreshToken {
+    long userId;
+    String token;
+  }
+
+  // NotificationCenter
+  class UserNotification {
+    UserNotificationType notificationType;
+    String title;
+
+    <<dbColumnDefinition="TEXT">>
+    String message;
+    ZonedDateTime timeStamp;
+
+    // clickable
+    Optional<String> link; // fuer Router
+
+    boolean seen;
+    boolean pinned;
+  }
+
+  enum UserNotificationType { SUCCESS, INFO, WARNING, DANGER; }
+
+  association [1] MacocoUser -> (notification) UserNotification [*];
+
+  //----------------------------------------------
+  // =============== Command Logs ================
+  //----------------------------------------------
+  class AccessIdentifier {
+  }
+
+  class CommandLog {
+    ZonedDateTime timestamp;
+    List<String> diff;
+    String affectedArea;
+    String affectedObject;
+  }
+
+  association [1] CommandLog -> (executor) MacocoUser [0..1]; // TODO: In den Migrationsskript für 2.9.0 -> 2.10.0 : früher war association [1] CommandLog -> (executor) MacocoUser [1];
+  association [1] CommandLog -> (permission) AccessIdentifier [*];
+
+  //----------------------------------------------
+  // =============== Dokumente ===================
+  //----------------------------------------------
+
+  // Bei Änderung PermissionCheckHelper.doesUserHavePermissionForDokument updaten
+  enum DokumentGroup {
+    PERSONAL("personal"),
+    KONTO("konto");
+  }
+
+  class Dokument {
+    DokumentGroup groupName;
+    Long associationId;       // ID des Objektes an dem das Dokument hängt
+    ZonedDateTime datum;      // Upload-Datum
+    String bezeichnung;
+    String dateiFormat;
+    Long fileSize;
+    Optional<String> anmerkung;
+    boolean istAktiv;
+  }
+
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/macoco/MaCoCoRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/macoco/MaCoCoRef.cd
@@ -1,0 +1,1455 @@
+/* (c) https://github.com/MontiCore/monticore */
+/* adapted and customized by (c) MaCoCo, ein RWTH Aachen projekt */
+
+// No packages supported yet in CD completion!
+//package de.macoco.be.domain;
+
+import java.lang.String;
+import java.lang.Long;
+import java.lang.Integer;
+import java.lang.Boolean;
+
+import java.time.ZonedDateTime;
+
+classdiagram MaCoCo {
+
+  //----------------------------------------------
+  //--------------- PERSONAL ---------------------
+  //----------------------------------------------
+
+  /**
+   * Person ist die Zentrale Klasse des Personal-Komplexes.
+   **/
+  class Person {
+    String vorname;
+    Optional<String> vorsatzwort;
+    String nachname;
+    String kuerzel;       // Abgeleitet analog wie bei SAP: 3 Vor- 3 Nachnamenbuchstaben
+    Optional<String> personalnummer;
+    Optional<ZonedDateTime> gebDatum;
+    Optional<ZonedDateTime> beschBeginn;
+    Optional<ZonedDateTime> beschEnde;
+    List<String> kommentar;
+    boolean istAktiv;
+    boolean istStundenzettelpflichtig = false;
+    Optional<ZonedDateTime> stundenzettelpflichtigVon;
+    Optional<ZonedDateTime> stundenzettelpflichtigBis; // TODO: brauchen wir nicht mehr
+    Optional<Long> ueberStundenUebertrag;
+    boolean darfWochenendarbeiten;
+    // Start WZL:
+    Optional<ZonedDateTime> hoechstbeschaeftigungBis;
+    List<String> staatsangehoerigkeiten;
+    Optional<String> telefonnummer;
+    Optional<ZonedDateTime> arbeitserlaubnisBis;
+    boolean extern;
+    Optional<String> titel;
+    Optional<String> rufname;
+    Optional<String> adresse;
+    Optional<String> email;
+    Optional<String> geburtsname;
+    Optional<String> geschlecht;
+    Optional<String> lBVNummer;
+    Optional<ZonedDateTime> entfristung;
+    <<dbColumnDefinition="TEXT">>
+    Optional<String> qualifikationstitel;
+    boolean speicherungGewuenscht = false;
+    <<dbColumnDefinition="TEXT">>
+    Optional<String> urlaubskommentar;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [1] Person -> (anstellungsarten) Anstellungsart [*];
+  association [*] Person -> (vorgesetzte) Person [*];
+  association [1] Person -> (notiz) Freitext [0..1];
+
+  //Für Studentenzettel:
+  association [1] Person -> (jahresurlaubstage) Jahresurlaub [*];
+  association [1] Person -> (zusatzurlaubstage) Sonderurlaub [*];
+  association [1] Person -> (stundenzettel) Stundenzettel [*];
+  association [1] Person -> (abwesenheiten) Abwesenheit [*];
+
+    <<nocascade>>
+  association [1] Person -> (user) MacocoUser [0..1];
+
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart
+
+  class Anstellungsart {
+    BeschaeftigungsArt beschArt;
+  }
+
+  association [1] Anstellungsart -> (vertraege) Vertrag [*];
+  association [1] Anstellungsart -> (anstellungsformen) Anstellungsform [*];
+
+  enum BeschaeftigungsArt {
+    WiMi("Wissenschaftliche/r Mitarbeiter/in (WiMi)"),
+    HiWi("Hilfskraft (HiWi)"),
+    BTV("Beschäftigte/r in Technik und Verwaltung (BTV)"),
+    BEAMTE("Beamte/r"),
+    AZUBI("Azubi/ne"),
+    PLAN;
+  }
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> *Vertrag
+  // eine direkte Verbindung zwischen Person und Vertrag existiert nicht.
+
+  class Vertrag {       // spiegelt den Vertrag der Hochschule wieder
+    ZonedDateTime vertragsBeginn;
+    ZonedDateTime vertragsEnde;
+    boolean aenderungsvertrag;
+    /String vertragsStatus; // Aktiv, Planung, Abgelaufen // TODO: change String to enum
+    List<String> kommentar;
+    ZahlenWert planUmfang;
+    Optional<Long> arbeitsstundenProWoche; //Stundenzettel
+    boolean kuendigungsschutz;  // WZL
+    Optional<String> vertragsgrundlage;  // WZL / TODO: change to enum
+    Optional<String> aktion;  // WZL / TODO: change to enum
+    Optional<ZonedDateTime> aktionsDatum;  // WZL / TODO: change to enum
+  }
+
+  association [1] Vertrag -> (kostenstellen) Kostenstelle [*];
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> Anstellungsform
+
+  /**
+   * Beschreibt alle wesentlichen Merkmale einer Anstellung.
+   * Entgeltgruppe, Stufe, etc.
+   **/
+  class Anstellungsform {
+    boolean erstanstellung;
+    Optional<String> entgeltGruppe; // { TVL-13}  Für Hiwis: {SHK (default), WHB, WHK}
+    Optional<String> erfahrungsStufe; // 1- 6 ; sowie Spezialfälle (TVL Ü+);
+    boolean unbefristet;
+    ZonedDateTime anstellungVon;
+    Optional<ZonedDateTime> anstellungBis;
+    long gehaltCent;  // evtl. Schätzgehalt in Zukunft
+    boolean istEigenerReferenzwert;
+    List<String> kommentar;
+    Optional<String> berufsgruppe; // WZL / TODO: change to enum
+    Optional<String> aktion;  // WZL / TODO: change to enum
+    Optional<ZonedDateTime> aktionsDatum;  // WZL / TODO: change to enum
+  }
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> *Vertrag -> *Kostenstelle
+
+  class Kostenstelle {
+    ZonedDateTime verbuchungsBeginn;
+    ZonedDateTime verbuchungsEnde;
+    KostenstelleBezeichnung bezeichnung;
+    List<String> kommentar;
+    ZahlenWert beschaeftigungsUmfang;
+    boolean buchungenNeuErzeugen;
+    boolean buchungenLoeschen;
+    boolean gesperrt;
+  }
+
+  enum KostenstelleBezeichnung {
+    NONE(""),
+    AN_INSTITUT("An-Institut"),
+    GMBH("GmbH"),
+    ANDERER_LEHRSTUHL,
+    ANDERES_INSTITUT,
+    VORUEBERGEHEND_ABWESEND("Vorübergehend Abwesend"),
+    ANDERE_FINANZIERUNG;
+  }
+
+  enum Zuweisungsart {
+    KONTO("Kontenzuweisung"),
+    STELLENZUWEISUNG,
+    PLANSTELLE,
+    SONSTIGES;
+  }
+
+  association [*] Kostenstelle -> (personalBudget) Budget [0..1];
+  association Kostenstelle -> (stellenzuweisung) Stellenzuweisung [0..1];
+  association Kostenstelle -> (planstelle) Planstelle [0..1];
+                              <<nocascade>>
+  association [0..1] Kostenstelle -> (personalBuchungen) Buchung [*];
+
+  // Person -> *Anstellungsart -> *Vertrag -> *Kostenstelle -> ?Planstelle
+
+  class Planstelle {
+    String bezeichnung;
+    Optional<String> minEntgeltgruppe;
+    Optional<String> minEntgeltstufe;
+    Optional<String> maxEntgeltgruppe;
+    Optional<String> maxEntgeltstufe;
+    Optional<ZonedDateTime> verfuegbarVon;
+    Optional<ZonedDateTime> verfuegbarBis;
+    Optional<String> kommentar;
+    ZahlenWert planUmfang;
+    boolean aktiv;
+  }
+
+  association Planstelle -> (konto) Konto [0..1];
+
+  //----------------------------------------------
+
+  /**
+   * Repräsentiert verschiedene Arten von monetären Haben
+   * @attribute wert ist jeweils unterschiedlich zu interpretieren:
+   * EURO heisst, der wert ist in Cent angegeben
+   * STUNDE heisst: er ist in Stunden angegeben
+   *    (und das obwohl jedes Monat, Jahr unterschiedliche Stundenzahlen hat)
+   * PROZENT heisst er ist zwischen 0 und 100 angegeben (100%)
+   * NONE
+   **/
+  class ZahlenWert {
+    ZahlenTyp zahlenTyp;
+    long wert;
+  }
+
+  enum ZahlenTyp {EURO, STUNDE, PROZENT, NONE; }
+
+  //----------------------------------------------
+  //------------- Alerts -------------------------
+  //----------------------------------------------
+
+  // Konto -> *MailAlert
+
+  class MailAlert {
+    String name;
+                                    <<dbColumnDefinition="TEXT">>
+    String alertCondition;
+                                    <<dbColumnDefinition="TEXT">>
+    String mailBody;
+    int repetitions;
+    ZonedDateTime firstAlert;
+    ZonedDateTime lastAlert;
+
+    Optional<String> receipients;
+    Optional<String> ccs;
+    Optional<String> bccs;
+
+    // extra Attribute zur Speicherung einiger Werte (vom System unbenutzt)
+    long a1;
+    long a2;
+    boolean flag1;
+    boolean flag2;
+    String s1;
+    String s2;
+  }
+
+  //----------------------------------------------
+  // ============ Finanz-Datenstruktur ===========
+  //----------------------------------------------
+
+  /**
+   * Hauptklasse; das Konto, von der alle anderen abhängen.
+   * Hat mehrere Varianten (Subklassen)
+   */
+  abstract class Konto {
+    String name;
+    Optional<String> pspElement;
+    Optional<String> kontotyp;  // unterschiedlich je nach Kontoart
+    Optional<ZonedDateTime> sapDatum;
+    Optional<String> internesAktenzeichen;
+    boolean istPlanKonto;
+    boolean istVerbuchungsKonto;
+    boolean istAktiv;
+    Optional<String> vergabeVerordnung;
+    Optional<String> farbe;
+    Optional<ZonedDateTime> aenderungsdatum;
+    /Optional<ZonedDateTime> optStartDatum;
+    /Optional<ZonedDateTime> optEndDatum;
+    /Geschaeftsvorgang gueltigerGeschaeftsvorgang;
+  }
+
+  <<treatAsBidirectional>>
+  association [1] Konto (konto) -> (gesamtBudget) Budget [0..1];
+  association [1] Konto -> (kommentare) Freitext [*];
+  association [1] Konto -> (notiz) Freitext [0..1];
+  association [1] Konto <-> MailAlert [*];
+  association [1] Konto -> (abgleichsKonto) ExternKonto [0..1];
+
+  abstract class ErweitertesKonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<ZonedDateTime> bewilligungsDatum;    // Bewilligungsdatum ist im Industrieprojekt nur mandatory, wenn kein Sammelkonto
+    Optional<ZonedDateTime> verlaengertBisDatum;
+    Optional<ZonedDateTime> aufstockungsDatum;
+    Optional<Long> foerderquote;
+    // human names: "Aktenzeichen (RWTH)"
+    // Drittmittel: "Förderkennzeichen",
+    Optional<String> aktenzeichen;
+    Optional<Long> finanzierteKomplettsumme;
+    // human names:
+    // Drittmittel: "Aktenzeichen (Fördergeber)",
+    // Industrieprojekt: "Bestellnummer",
+    // Sonstiges: "Bestellnummer/Aktenzeichen (Fördergeber)"
+    Optional<String> referenzSponsor;
+    boolean hatProgrammpauschale;
+  }
+
+
+  class Drittmittelprojekt extends ErweitertesKonto {
+  }
+
+  association [*] Drittmittelprojekt -> (fachlicherVerantwortlicher) Person [*];
+
+  class Haushaltskonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+  }
+
+  class Industrieprojekt extends ErweitertesKonto {
+    Optional<String> auftraggeber;
+    boolean istSammelkonto;
+    Optional<Long> mehrwertsteuer;
+  }
+
+  association [*] Industrieprojekt -> (fachlicherVerantwortlicher) Person [*];
+
+  class Sonstiges extends ErweitertesKonto {
+    Optional<String> auftraggeber;
+    Geschaeftsvorgang geschaeftsvorgang;
+    Optional<Long> mehrwertsteuer;
+    boolean istSammelkonto;
+  }
+
+
+  enum AbrechnungsInterval {
+    GESAMTE_PROJEKTLAUFZEIT("Gesamte Projektlaufzeit"),
+    JAEHRLICH("Jährlich"),
+    HALBJAEHRLICH("Halbjährlich"),
+    QUARTALSWEISE("Quartalsweise"),
+    MONATLICH("Monatlich");
+  }
+
+  association [1] Konto -> OrganigrammKonto [*];
+
+  class OrganigrammKonto {
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    Optional<ZahlenWert> umfang;
+  }
+
+  association [*] OrganigrammKonto -> Organigramm [1];
+
+  class ZeitlicheVerbuchungskontoZuordnung {
+  	Optional<Long> programmPauschale;
+  	Optional<Long> gemeinkostensatz;
+  	Optional<ZonedDateTime> startDate;
+  	Optional<ZonedDateTime> endDate;
+  	boolean istHauptVerbuchungskonto;
+  }
+
+  association [1] ErweitertesKonto -> (verbuchungskontoZuordnung) ZeitlicheVerbuchungskontoZuordnung [*];
+  association [*] ZeitlicheVerbuchungskontoZuordnung -> (verbuchungskonto) Konto [0..1];
+
+  //----------------------------------------------
+
+  // ------ Budget ------
+  // Konto -> 1Budget
+  // Konto -> 1Budget -> *Budget
+  // Konto -> 1Budget -> *Budget -> *Budget
+
+  /**
+   * Ein Budget erlaubt es ein Konto nach verschiedenen
+   * Strukturierungskriterien zu zerlegen. Budgets sind nur auf drei Ebenen
+   * erlaubt: 1 Hauptbudget, * OberBudgets, ** Unterbudgets.
+   * Die Budget-Struktur stellt einen Baum der maximalen Tiefe 3 dar.
+   */
+
+  class Budget {
+    String typ; // name
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<String> kommentar;
+    Optional<long> budgetRahmenCent; // wird im Gesamtbudget als Bewilligungssumme interpretiert
+    Optional<long> eigenAnteilCent;
+    List<long> jahresBudgets;
+    boolean proportionaleVerteilung;
+    boolean forOverheads; // das erste Budget (gesamtBudget.getUnterbudgets[0])
+    Optional<String> budgetKategorie;
+    /int budgetDepth;
+  }
+
+  association [*] Budget -> Konto [1];
+  association [0..1] Budget (elternBudget) <-> (unterBudget) Budget [*];
+  association [1] Budget (budget) <-> (buchungseintrag) Buchungseintrag [*];
+  association [1] Budget (budget) <-> (stellenzuweisung) Stellenzuweisung [*];
+  <<noOrphanRemoval, noRemoveCascade>>
+  association [0..1] Budget -> Organigramm [0..1];
+
+  //----------------------------------------------
+
+  // ------ Buchungseinträge ------
+  // Konto -> 1Budget (->*Budget)* -> *Buchung
+
+  /**
+   * Buchungen aller Arten: gemeinsame Oberklasse
+   */
+  abstract class Buchungseintrag {
+    ZonedDateTime datum;
+    Optional<String> buchungseintragText; // human name: Buchung: "Buchungstext", Rechnung: "Rechnungsgrund", Mittelabruf: "Anmerkung", Mittelzuweisung: "Grund"
+    long betragCent;                          // human name: "Betrag", Rechnung: "Rechnungsbetrag", Konten mit Programmpauschale: "Rechnungsbetrag (inkl Pauschale)"
+    boolean istAktiv;
+    Optional<ZonedDateTime> aenderungsdatum;
+    /Geschaeftsvorgang gueltigerGeschaeftsvorgang;
+    /String lfdeNummer;
+  }
+
+  class Buchung extends Buchungseintrag {
+    ZonedDateTime belegdatum;
+    String zahlungsgrund; //Belegpositionstext
+    Optional<String> kreditorDebitor;
+    List<String> sachkonto;
+    Optional<ZonedDateTime> buchungsdatum;
+    BuchungsStatus status;
+    List<String> belegnummern;
+    List<String> auftragsnummer;
+    Optional<String> bereich;
+    Optional<String> projekt;
+    Optional<ZonedDateTime> geschaeftsjahr;
+    Optional<Long> steuer;
+    Optional<Long> skonto;
+    Optional<Long> gez_Skonto;
+    Optional<String> erfasser;
+    Optional<String> belegart;
+    Optional<String> referenz;
+    Optional<String> stornonummer;
+    Optional<String> stkz;
+    Optional<ZonedDateTime> erfassungsdatum;
+    Optional<ZonedDateTime> ausgleichsdatum;
+    long betragCentOriginal; // Bei Abweichungen von BetragCent kann nun eine Absicht ueberprueft werden
+    boolean budgetChangedManually; // s.o.
+    Optional<String> kostenarten;
+    /Optional<Integer> bezugsdatumJahr;
+  }
+
+  class Rechnungsstellung extends Buchungseintrag {
+    Optional<ZonedDateTime> rechnungsdatum;
+    Optional<String> rechnungsnummer;
+    RechnungsstellungStatus status;
+    List<String> belegnummern;
+    Optional<Long> gemeinkosten;
+    Optional<Long> honorierung;
+    Optional<String> projekt;
+    Optional<String> debitor;
+    Optional<Long> mehrwertsteuer;
+    Optional<ZonedDateTime> zahlungsziel;
+  }
+
+  class Mittelzuweisung extends Buchungseintrag {
+    Optional<ZonedDateTime> verfallDatum;
+    Optional<String> kennung;
+    MittelzuweisungStatus status;
+  }
+
+  class Mittelabruf extends Buchungseintrag {
+    ZonedDateTime abrufdatum;
+    MittelabrufStatus status;
+    String zeitraum;
+    Optional<Long> pauschaleManuell; // Präsent, falls die Pauschale manuell geändert wurde
+  }
+
+  // ------ Stellenzuweisung ------
+
+  // Konto -> 1Budget (->*Budget)* -> *Stellenzuweisung
+
+  class Stellenzuweisung {
+    ZonedDateTime erstellDatum;         // aktuelles Datum
+    Optional<ZonedDateTime> startDatum; // Datum, zu welchem die Stelle beginnt
+    Optional<ZonedDateTime> endDatum;   // Datum, zu welchem die Stelle endet
+    long wert;
+    String kennung;
+    StellenzuweisungStatus status;
+    ZahlenWert stellenumfang;
+    boolean istAktiv;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  enum Geschaeftsvorgang {
+    NONE,
+    MITTELABRUF,
+    ZUWEISUNG,
+    RECHNUNG;
+  }
+
+  enum BuchungsStatus {
+    EINGEREICHT,
+    SAP("SAP"),
+    SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    FEHLERHAFT;
+  }
+
+  enum RechnungsstellungStatus {
+    OFFENE_RECHNUNG,
+    SAP("SAP"),
+     SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG;
+  }
+
+  enum MittelzuweisungStatus {
+    BESCHEID_ERHALTEN ("Bescheid erhalten"),
+    SAP("SAP"),
+    SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    FEHLERHAFT;
+  }
+
+  enum MittelabrufStatus {
+    ABGERUFEN,
+    SAP("SAP"),
+     SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    EINGEREICHT;
+  }
+
+  enum StellenzuweisungStatus {
+    BESETZT,
+    TEILBESETZT,
+    UNBESETZT,
+    PLANUNG;
+  }
+
+  enum VertragStatus {
+    AKTIV,
+    PLANUNG,
+    ABGELAUFEN;
+  }
+
+  //----------------------------------------------
+  // =============== SAPii ===============
+  //----------------------------------------------
+
+  class SAPVerbindung {
+    SAPverbindungsStatus status;
+  }
+
+  class Anfrage {
+    String ikz;
+    String bezeichner;
+    boolean letzteAnfrageErfolgreich;
+  }
+
+  enum SAPverbindungsStatus {
+    VERBUNDEN,
+    GETRENNT,
+    PROBLEM;
+  }
+
+  enum SAPimportMode {
+    DEFAULT,
+    F1KONTO;
+  }
+
+  association [1] SAPVerbindung -> (authorizedBy) MacocoUser [*];
+  association [1] MacocoUser -> (anfragen) Anfrage [*];
+  association [1] Anfrage -> (filteredKonten) PSPImportFilter [*];
+
+  //----------------------------------------------
+
+  class AbgleichsBuchung extends Buchung {
+      AbgleichsStatus abgleichsStatus;
+      Optional<String> abgleichKommentar;
+      String positionsNummer;
+      boolean deactivated;
+  }
+
+    enum AbgleichsStatus {
+      ABGESCHLOSSEN,            // Der Abgleich dieser Buchung ist Abgeschlossen
+      TEILWEISE_ABGESCHLOSSEN,  // Der Abgleich wurde schon Bearbeitet es fehlen jedoch Summen
+      ABWEICHEND,               // Der Abgleich ist Vollständig mit Abweichenden Summen
+      OFFEN,                    // Der Abgleich wurde noch nicht gesetzt
+      VORGESCHLAGEN;            // Der Abgleich wurde vom System vorgeschlagen
+    }
+
+  class AbgleichsGruppe {
+    String bezeichnung;
+  }
+                                <<nocascade>>
+  association AbgleichsGruppe -> (buchungen) Buchung [*];
+                                <<nocascade>>
+  association AbgleichsGruppe -> (abgleichsBuchungen) AbgleichsBuchung [*];
+                                 <<nocascade>>
+  association AbgleichsGruppe -> (konto) Konto [1];
+
+  // ------ Freitext ------
+
+  class Freitext {
+    Optional<ZonedDateTime> erstellDatum;
+    Optional<ZonedDateTime> bearbeitetDatum;
+                                    <<dbColumnDefinition="TEXT">>
+    Optional<String> text;
+  }
+
+  class Legende {
+    LegendeTyp type;
+    String expression;
+      <<dbColumnDefinition="TEXT">>
+    String description;
+  }
+
+  enum LegendeTyp {
+    KONTO_FARBE;
+  }
+
+  //----------------------------------------------
+  // =============== Projekte ===============
+  //----------------------------------------------
+
+  abstract class Projekt {
+    String name;
+    String kuerzel;
+    Optional<Long> minPM;
+    Optional<Long> maxPM;
+    Optional<Long> finanzPM;
+    Optional<ZonedDateTime> laufzeitVon;
+    Optional<ZonedDateTime> laufzeitBis;
+    Optional<String> kommentar;
+    Optional<String> foerdergeberAZ;
+    ProjektStatus status;
+    boolean istAktiv;
+    boolean lockedForStundenzettel;   // Das gesamte Projekt ist gesperrt
+    List<ZonedDateTime> lockedMonths; // Stellen die Ausnahme aus der Lock-Regelung für das gesamte Projekt dar
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [1] Projekt -> Aufwand [*];
+  association [1] Projekt -> Arbeitspaket [*];
+  association [1] Projekt -> Anstellung [*];
+  association [*] Projekt -> Konto [0..1];
+  association [*] Projekt -> (hauptverantwortlich) Person [*];
+  association [1] Projekt -> (notiz) Freitext [0..1];
+
+  class Auftragsprojekt extends Projekt {
+    Optional<String> nummer;
+    ProjektTyp typ;
+    Optional<String> regelung;
+  }
+
+  class Organisation extends Projekt {
+  }
+
+  class Lehre extends Projekt {
+    Optional<Long> stunden;
+  }
+
+  class Arbeitspaket {
+    String nummer; // könnte auch 1.1 sein
+    String name;
+    Optional<String>  beschreibung;
+    Optional<ZonedDateTime> beginnDatum;
+    Optional<ZonedDateTime> endeDatum;
+    Optional<Long> pMs;
+    Optional<Long> stunden;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  class Aufwand {
+    /long pM;
+    ZahlenWert umfang;
+    ZonedDateTime laufzeitVon;
+    ZonedDateTime laufzeitBis;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [*] Aufwand -> Person [0..1];
+
+  class Anstellung {
+    Optional<String> bezeichnung;
+    ZahlenWert umfang;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    boolean verfaellt;
+    Optional<Stellentyp> min;
+    Optional<Stellentyp> max;
+    /long pM;
+    BeschaeftigungsArt beschaeftigungsArt;
+  }
+
+  association [*] Anstellung -> Person [0..1];
+
+  class Stellentyp {
+    Optional<String> entgeltgruppe;
+    Optional<String> entgeltstufe;
+  }
+
+  enum ProjektStatus {
+    IN_DEFINITION,
+    BEANTRAGT,
+    GENEHMIGT,
+    ABGELEHNT,
+    LAUFEND,
+    FACHLICH_ABGESCHLOSSEN("Fachlich abgeschlossen"),
+    ENDBERICHT_EINGEREICHT("Endbericht eingereicht"),
+    INPRUEFUNG("In Prüfung"),
+    GEPRUEFT("Geprüft"),
+    ABGERECHNET,
+    ABGESCHLOSSEN,
+    ARCHIVIERT;
+  }
+
+  enum ProjektArt {
+    AUFTRAG,
+    ORGANISATION,
+    LEHRE,
+    NONE;
+  }
+
+  enum ProjektTyp {
+    HOHEITLICH,
+    INDUSTRIE,
+    UNIVERSITAET("Universität"),
+    SONSTIGE;
+  }
+
+  enum Vergabeverordnung {
+    VOL_A ("VOL/A"),
+    VOB_A ("VOB/A"),
+    UVGO_NRW ("UVgO NRW"),
+    UVGO_BUND ("UVgO Bund"),
+    NONE (" ");
+  }
+
+  //----------------------------------------------
+  // =============== Stundenzettel ===============
+  //----------------------------------------------
+
+  class Stundenzettel {
+    StundenzettelStatus status;
+    ZonedDateTime zeit;
+    Optional<Long> abgegebenVonUserId;
+    Optional<ZonedDateTime> abgabeDatum;
+  }
+
+  association [1] Stundenzettel -> (eintraege) StundenzettelEintrag [*];
+
+  class StundenzettelEintrag {
+    ZonedDateTime uhrzeitVon;
+    Optional<ZonedDateTime> uhrzeitBis;
+    Optional<String> beschreibung;
+    /long stunden;
+    StundenzettelProjekt pauseOderSonstiges;
+  }
+
+  association [*] StundenzettelEintrag ->  Projekt [0..1];
+  association [*] StundenzettelEintrag ->  Arbeitspaket [0..1];
+
+  class StundenzettelHistorieEintrag {
+    ZonedDateTime bearbeitungsdatum;
+    Optional<Long> editorId;
+    Optional<String> editedBy;
+    String monat;
+    int jahr;
+    String changeOperation;
+  }
+
+  enum StundenzettelChangeOperation {
+    INVALID,
+    ABGEGEBEN("Abgegeben"),
+    INTERN_GEPRUEFT("Intern Geprüft"),
+    INTERN_ABGESCHLOSSEN("Intern Abgeschlossen");
+  }
+
+  association [1] Person ->  StundenzettelHistorieEintrag [*];
+
+  class Abwesenheit {
+    Abwesenheitsgrund grund;
+    ZonedDateTime  datumVon;
+    ZonedDateTime datumBis;
+    Optional<String> kommentar;
+    Optional<ZonedDateTime> uhrzeitVon;
+    Optional<ZonedDateTime> uhrzeitBis;
+    Optional<Long> minutenProTag;
+    /long tageGesamt;
+  }
+
+  class Dienstreise extends Abwesenheit {
+    Optional<String> reisenummer;
+    Optional<String> dienstreisegrund;
+    Optional<String> reiseziel;
+    Optional<Long> gesamtkosten;
+    Optional<String> status;
+    Optional<String> statusText;
+  }
+
+  association [*] Abwesenheit -> Konto [0..1];
+
+  association [1] Abwesenheit -> UrlaubsGenehmigung [0..1];
+
+  association [*] Dienstreise -> Budget [0..1];
+
+  class Arbeitstage {
+    ZonedDateTime guiltigAb;
+    ZonedDateTime guiltigBis;
+    List<Integer> wochenTage; // 0..4 (Montag-Freitag)
+  }
+
+  association [1] Person -> Arbeitstage [*];
+
+  class Jahresurlaub {
+    int jahr;
+    long tageAnzahl;
+    Optional<Long> stundenAnzahl;
+    boolean istManuellerEintrag;
+  }
+
+  class UrlaubsGenehmigung {
+    Optional<ZonedDateTime> beantragt;
+    Optional<ZonedDateTime> genehmigt;
+    Optional<ZonedDateTime> geprueft;
+    Optional<ZonedDateTime> storniert;
+    Urlaubssstatus status;
+    Stornierungsstatus stornierungsStatus;
+  }
+
+  class Sonderurlaub {  // Für WZL: Zusatzurlaub umbenennen in Sonderurlaub und neues Feld anzahl
+    ZonedDateTime  datumVon;
+    ZonedDateTime datumBis;
+    long anzahl;
+  }
+
+  class UrlaubEinstellungen {
+    boolean urlaubsanspruchInStunden;
+  }
+
+  enum Abwesenheitsgrund {
+    U_URLAUB,
+    D_DIENSTREISE,
+    S_SONSTIGE;
+    /*
+    Z_ZUSATZURLAUB,
+    A_ARBEITSUNFALL,
+    AB_ABGELTUNG,
+    E_ELTERNZEIT,
+    F_FREISTELLUNG,
+    K_KRANKHEIT,
+    KU_KUR,
+    S_SONSTIGES;*/
+  }
+
+  enum Urlaubssstatus {
+    NONE,
+    BEANTRAGT,
+    GEPRUEFT("Geprüft"),
+    PRUEFUNG_ABGELEHNT("Prüfung abgelehnt"),
+    GENEHMIGT,
+    GENEHMIGUNG_ABGELEHNT;
+  }
+
+  enum Stornierungsstatus {
+    NONE,
+    VERBOTEN,
+    STORNIERUNGSANTRAG,
+    STORNIERT;
+  }
+
+  enum Abrechnungsstatus {
+    OFFEN,
+    ABZURECHNEN,
+    ABGERECHNET,
+    STORNIERT;
+  }
+
+  enum StundenzettelStatus {
+    IN_ERFASSUNG,
+    INTERN_INPRUEFUNG("Intern in Prüfung"),
+    INTERN_ABGESCHLOSSEN,
+    DRITTMITTELABTEILUNG_INPRUEFUNG("Drittmittelabteilung in Prüfung"),
+    DRITTMITTELABTEILUNG_ABGESCHLOSSEN,
+    ENDBERICHT_EINGEREICHT,
+    GEPRUEFT("Geprüft"),
+    FOERDERGEBER_ABGESCHLOSSEN("Fördergeber abgeschlossen"),
+    ABGESCHLOSSEN;
+  }
+
+  enum StundenzettelProjekt {
+    PAUSE,
+    SONSTIGE,
+    NONE;
+  }
+
+  association [*] F1Konto -> (institut) Institut [0..1];
+
+  class ExternKonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<String> importVermerk;
+    AbgleichType abgleichVerhalten;
+  }
+
+  enum AbgleichType {
+    IGNORE,
+    MANUEL,
+    AUTO_COPY;
+  }
+
+  association [*] ExternKonto -> (institut) Institut [0..1];
+
+  class PSPImportFilter{
+    boolean importThisPSPelement;
+    boolean importBookings;
+    String name;
+    String pspElement;
+    Optional<ZonedDateTime> startDate;
+  }
+
+  association [*] PSPImportFilter -> (targetPSP) Konto [0..1];
+
+  //----------------------------------------------
+  // Reports
+
+  class EventReport {
+    ZonedDateTime eventStart;
+    Optional<ZonedDateTime> eventEnd;
+    /EventStatus status;
+    String message; // <a href="wiki/BuchungImport">BuchungImport</a>: Nutzer 'netz' hat die Datei '.....' importiert
+  }
+
+  class EventReportEntry {
+    EventType type;
+    Optional<Long> targetId; // click -> navigate to id
+    Optional<Integer> count;
+    <<dbColumnDefinition="TEXT">>
+    String message; // Zeile 4 Fehler ...... Zeile 5 .....
+    EventStatus status;
+  }
+  association [1] EventReport -> (entries) EventReportEntry [*];
+
+  class ImportReport extends EventReport {
+  }
+
+  class ImportReportEntry extends EventReportEntry {
+  }
+
+
+  class PersonalExportReport extends EventReport {
+    Long dataId;
+
+    ZonedDateTime datenStart;
+    ZonedDateTime datenEnd;
+    Long countData;
+    /Long countError;
+    EventStatus exportStatus;
+  }
+
+  class PersonalExportReportEntry extends EventReportEntry {
+    Optional<String> vorsatzwort;
+    String vorname;
+    String nachname;
+    BeschaeftigungsArt beschaeftigungsArt;
+    ZonedDateTime monat;
+  }
+
+  enum EventStatus {
+    // Import
+    SUCCESS("erfolgreich"),
+    ERROR("fehlerhaft"),
+    INFO("erfolgreich"), // success + special
+    CREATED("erstellt"),
+    UPDATED("upgedated"),
+    IGNORED("ignoriert"),
+    IN_PROGRESS("in bearbeitung"),
+
+    // Personal Export
+    SENT("verschickt"),
+    CORRECT("sachlich korrekt");
+  }
+
+  enum EventType {
+    IMPORT_KONTO("Konten"),
+    IMPORT_BUCHUNG("Buchungs"),
+    IMPORT_PERSON("Personen"),
+    IMPORT_INSTITUT("Instituts"),
+    IMPORT_NUTZER("Nutzer"),
+    IMPORT_VERTRAG("Vertrags"),
+    EXPORT_FINANZEN_KONTO("Konten"),
+    EXPORT_FINANZEN_PLANSTELLE("Planstellen"),
+    EXPORT_FINANZEN_VERTRAG("Vertragabdeckungs");
+  }
+
+
+  //----------------------------------------------
+  // =============== Fakultät 1 DS ===============
+  //----------------------------------------------
+
+  // Institut
+  <<dbColumn = "unique=true">>
+  class Institut {
+    String institutsKennZiffer;
+    String institutsName;
+    String professorName;
+    boolean lokalInstitut;
+  }
+
+  // Fachgruppe
+  enum Fachgruppe {
+    MATHEMATIK,
+    INFORMATIK,
+    PHYSIK,
+    CHEMIE,
+    BIOLOGIE;
+  }
+
+  //SAP-Abschöpfung von Geschäftsjahr
+  class GeschaeftsjahrSAPAbschoepfung {
+    String fachgruppe;
+    String institutsKennZiffer;
+    String institutsName;
+    String pspElement;
+    long gesamtSAPAbschoepfung;
+  }
+
+  class SAPAbschoepfung {
+    Long betragCent;
+    ZonedDateTime year;
+  }
+
+  association [1] GeschaeftsjahrSAPAbschoepfung -> (sapAbschoepfung) SAPAbschoepfung [*];
+
+
+  // Konto
+  class F1Konto extends Haushaltskonto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    long originalBudgetCent;
+    long sonstigeZuweisungenCent;
+    long resteCent;
+    long aktuellerKontostandCent;
+    long kontoRahmenCent;
+    KommunikationsStatus kommunikationsStatus;
+    StrafsteuerStatus strafsteuerStatus;
+    long strafsteuerBasisCent;
+    long strafsteuerSAPCent;
+    long strafsteuerCent;
+    long strafsteuerBerechnungsGrundlageCent;
+    Optional<Long> kontoStandBeginnGeschaeftsjahr;
+  }
+
+  // Konto -> 1Budget (->*Budget)* -> *Buchung -> ?Begruendung
+
+  // Buchungen werden hier noch erweitert:
+  association [1] Buchung -> (begruendung) Begruendung [0..1];
+
+  class Begruendung {
+    String text;
+    ZonedDateTime erstellung;
+    Optional<ZonedDateTime> letzteBearbeitung;
+    Optional<StrafsteuerGeschaeftsjahr> geschaeftsjahr;
+  }
+
+  association [1] Begruendung -> (akzeptanz) Akzeptanz [0..1];
+  //association [1] Begruendung -> (geschaeftsjahr) StrafsteuerGeschaeftsjahr [0..1];
+
+  //----------------------------------------------
+
+  // Konto -> 1Budget (->*Budget)* -> *Buchung -> ?Begruendung -> ?Akzeptanz
+
+  class Akzeptanz {
+    Akzeptanzstatus akzeptanzstatus;
+    Optional<long> teilbetragCent;
+    Optional<ZonedDateTime> bearbeitung;
+    boolean istAktiv;
+    Optional<String> kommentar;
+  }
+
+  //----------------------------------------------
+
+  enum KommunikationsStatus {
+    KOM_STAT_NO_ACTION_NEEDED,       // Kein Handlungsbedarf
+    KOM_STAT_BEGR_FEHLT,             // Begründung fehlt
+    KOM_STAT_ANTW_FEHLT,             // Antwort fehlt
+    KOM_STAT_ANTW_CHANGED,           // Buchung oder Begründung wurden geändert
+    KOM_STAT_BEGR_CHANGED,           // Antwort wurde geändert
+    KOM_STAT_ANTW_BEGR_CHANGED,      // Antwort und Begründung wurde geändert
+    KOM_STAT_ANTW_FEHLT_CHANGED;     // Antwort Fehlt, andere Antwort wurde geändert
+  }
+
+  enum StrafsteuerStatus {
+    NONE,
+    SOME,
+    ALL;
+  }
+
+  enum Akzeptanzstatus {
+    OFFEN,
+    OK,
+    TEILOK,
+    NOTOK;
+  }
+
+  class StrafsteuerGeschaeftsjahr {
+    ZonedDateTime jahr;
+    boolean current;
+  }
+
+  class StrafsteuerSperrDatum {
+    ZonedDateTime sperrDatum;
+  }
+
+  //----------------------------------------------
+  // =============== MacocoUser ===============
+  //----------------------------------------------
+
+  class MacocoUser {
+                                     <<dbColumn = "unique=true">>
+    String username;
+    Optional<String> encodedPassword;
+    String passwordSaltBase64;
+    ZonedDateTime registrationDate;
+    Optional<String> initials;
+    MacocoUserActivationStatus activated;
+    boolean enabled;
+                                      <<dbColumn = "unique=true">>
+    String email;
+    boolean authentifiziert;
+    Optional<String> timID;
+    Optional<String> sapAccessToken;
+    Optional<String> sapRefreshToKen;
+
+  }
+
+  association  [*] MacocoUser -> (institute) Institut [*];
+
+  enum MacocoUserActivationStatus {
+    AKTIVIERT,
+    MAIL_NICHT_GESENDET("Mail nicht gesendet"),
+    MAIL_FEHLERHAFT("Mail fehlerhaft"),
+    MAIL_GESENDET("Mail gesendet");
+  }
+
+  // Favoriten
+  class Favorite {
+    String title;
+    String url;
+  }
+
+  association [1] MacocoUser -> (favorite) Favorite [*];
+
+  class RoleAssignment {
+  }
+
+  association [*] RoleAssignment -> (user) MacocoUser [1];
+  association [*] RoleAssignment -> (accessPolicy) AccessPolicy [1];
+
+  class AccessPolicy {
+    String roleName;
+    Optional<Long> objId;
+  }
+
+  class GroupedAccessPolicy {
+    String name;
+  }
+
+  association [*] GroupedAccessPolicy -> (user) MacocoUser [*];
+  association [1] GroupedAccessPolicy -> (policy) AccessPolicy [*];
+
+  //----------------------------------------------
+  // =============== Fristen ===============
+  //----------------------------------------------
+
+  class Frist {
+    String beschreibung;
+    Friststatus status;
+    Fristobjekt fristobjekt;
+    ZonedDateTime faelligkeitsdatum;
+    Optional<String> notiz;
+    Boolean manuellerEintrag;
+    Long bezugsobjektId;
+    String bezugsobjektName;
+    Optional<ZonedDateTime> aenderungsdatum;
+    boolean istAktiv;
+  }
+
+  association [*] Frist -> (zuweisung) Person [0..1];
+
+  association [1] Person -> Frist [*];
+  association [1] Konto -> Frist [*];
+  association [1] Projekt -> Frist [*];
+  association [1] Mittelabruf -> Frist [0..1];
+  association [1] Rechnungsstellung -> Frist [0..1];
+  association [1] Vertrag -> Frist [0..1];
+  association [1] Zulage -> Frist [0..1];
+
+  enum Friststatus {
+    PLANUNG,
+    IN_BEARBEITUNG,
+    ERLEDIGT;
+  }
+
+  enum Fristobjekt {
+    PERSON,
+    KONTO,
+    VERTRAGSVERLAENGERUNG("Vertragsverlängerung"),
+    ZULAGE,
+    RECHNUNG,
+    MITTELABRUF,
+    PROJEKT;
+  }
+
+  class DefaultFristen {
+    ZonedDateTime finanzenStartDatum;
+    Long finanzenFristinWeeks;
+    ZonedDateTime personalStartDatum;
+    Long personalFristinWeeks;
+  }
+
+  //----------------------------------------------
+  // ============= Einstellungen =================
+  //----------------------------------------------
+
+  class Setting {
+    String identifier;
+  }
+
+  class InstanzSetting extends Setting {
+    String value;
+  }
+
+  class UISetting extends Setting {
+    String seite;
+  }
+
+  association [0..1] MacocoUser -> (setting) UISetting [*];
+
+  class FilterSetting extends UISetting {
+    List<String> filterValues;
+  }
+
+  class TableSetting extends UISetting {
+    TableIdentifierTyp typ;
+    boolean zeigeInaktive;
+    int zeilenLimit;
+    Optional<String> gruppiereNach;
+    Optional<String> sortiereNach;
+    Optional<String> sortiereDir;
+    boolean isShowColor;
+  }
+
+  association [1] TableSetting -> (spalten) TableSettingSpalten [*];
+
+  enum TableIdentifierTyp {
+    DEFAULT,
+    USER,
+    INSTITUT;
+  }
+
+  class TableSettingSpalten {
+    String name;
+    boolean istAktiv;
+    long breite;
+  }
+
+  class ErweiterbareListen{
+    String bereich;
+    String feldbezeichnung;
+    List<String> inhalte;
+  }
+
+  //----------------------------------------------
+  // =============== Card Settings ===============
+  //----------------------------------------------
+
+  class CardSetting {
+    String page;
+    String identifier;
+    <<dbColumnDefinition="TEXT">>
+    String configuration;
+  }
+
+  association [*] CardSetting -> (benutzer) MacocoUser [0..1];
+
+  //----------------------------------------------
+  // =============== WZL ===============
+  //----------------------------------------------
+
+  class Elternzeit { // WZL
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    ZahlenWert umfang;
+  }
+
+  class Nebentaetigkeit { // WZL
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    ZahlenWert umfang;
+    Optional<String> arbeitgeber;
+    Optional<String> taetigkeitsbereich;
+  }
+
+  class Zulage  { // WZL
+    Optional<String> pspelement;
+    Optional<String> bezeichnung;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    Long arbeitgeberbrutto;
+    Long arbeitnehmerbrutto;
+  }
+
+  // WZL
+  enum Geschlecht { NONE(""), WEIBLICH("weiblich"), MAENNLICH("männlich"), DIVERS("divers"); }
+
+  // WZL
+  // -> DataSource
+  enum Titel { NONE(""), E1("Apl. Prof. Dr.") , E2("B.Sc.") , E3("Dipl.-Inform.") , E4("Dipl.-Ing."), E5("Dipl.-Ing. (FH)"),
+    E6("Dipl.-Ing. (RUS)"), E7("Dipl.-Kff.") , E8("Dipl.-Math."), E9("Dipl.-Phys.") , E10("Dipl.-Wirt. Ing.") , E11("Dr.")  , E12("Dr. phil."),
+    E13("Dr. rer. nat."), E14("Dr. rer. pol."), E15("Dr.-Ing."), E16("M.A.") , E17("M.Eng."), E18("M.Sc."), E19("PhD"), E20("Prof. Dr.-Ing."); }
+
+  // WZL
+  // -> DataSource
+  enum Berufsgruppe { NONE(""), E1("Akademischer Direktor"), E2("Angestellter in der DV"), E3("Auszubildende/r"), E4("Bibl.-Beschäftiger"),
+    E5("Elektriker"), E6("Elektroniker"), E7("Elektrotechniker"), E8("Fachinformatiker"), E9("Fachinformatiker"), E10("Industriemechaniker"),
+    E11("Lagerarbeiter"), E12("Mechaniker"), E13("Meister"), E14("Praktikant, SV-frei"), E15("Programmierer"), E16("Stud. Hilfskraft"),
+    E17("Techn. Beschäftigter"), E18("Techn. Zeichner"), E19("Techniker"), E20("Universitätsprofessor"), E21("Verw. Beschäftigter"), E22("Werkstoffprüfer"),
+    E23("Wiss. Beschäftigter"), E24("Wiss. Hilfskraft Bachelor"), E25("Wiss. Hilfskraft Master"); }
+
+  // WZL
+  enum Aktion { NONE(""), ANFRAGE_VERSENDET("Anfrage versendet"), ERINNERUNG_VERSENDET("Erinnerung versendet"),
+    ZUR_UNTERSCHRIFT_BEIM_VORGESETZTEN("Zur Unterschrift beim Vorgesetzten"),
+    BEI_ZHV_VORGELEGT("Bei ZHV vorgelegt"), VON_ZHV_BESTAETIGT("Von ZHV bestätigt"); }
+
+  // WZL
+  // -> DataSource
+  enum Vertragsgrundlage { NONE(""), E1("sonst. Befristungen (gleicht Auszubildenden)"), E2("unbefristet"), E3("unbefr. (Beamter aL)"), E4("§14 Abs. 2 TzBfG"),
+    E5("Elternzeitvertretung"), E6("Befristung SHK"), E7("Mehrbedarf sonstiger"), E8("Mehrb. Forschungspr."), E9("§2(5)Nr.3WZVG MuS-EZ"),
+    E10("§2 WZVG DM (NP)"), E11("§2 WZVG KiBetr NP"), E12("WZVG-Postdoc-Quali."), E13("WZVG-N-Gr._Leiter"), E14("WZVG-Wiss.-Quali NP"),
+    E15("§2 WZVG DM (VP)"), E16("§2 WZVG KiBetr VP"), E17("WZVG-Promotion"), E18("WZVG-sonst.Wiss-Qual"), E19("Befristung WHB"), E20("Befristung WHK"),
+    E21("§2 (1) S.2 WZVG nPr"), E22("§14(1) Nr.2 TzBfG-Üb"), E23("befr. Arbeitszeitänderung"), E24("Übernahme nach Ausbildung"); }
+
+  association [1] Person -> (elternzeiten) Elternzeit [*]; // WZL
+  association [1] Person -> (nebentaetigkeiten) Nebentaetigkeit[*];  // WZL
+  association [1] Person -> (zulagen) Zulage [*];  // WZL
+
+  // WZL Personal Export
+  class PersonalExportData {
+  }
+  association [1] PersonalExportData -> (entries) PersonalExportDataEntry [*];
+
+  class PersonalExportDataEntry {
+    String personalnummer;
+    Optional<String> vorsatzwort;
+    String nachname;
+    String vorname;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    String pspElement;
+    Long prozentsatz;
+  }
+
+   class PersonalExportEinstellungen {
+     String pspElement;
+     List<String> bezeichnungen;
+     ZonedDateTime startmonat;
+     ZonedDateTime endmonat;
+   }
+
+  class Organigramm {
+    boolean istStabstelle;
+    boolean istAktiv;
+    String bezeichnung;
+  }
+
+  <<noOrphanRemoval>>
+  association [0..1] Organigramm (parent) <-> (child) Organigramm [*];
+
+  association [1] Organigramm -> (leiter) OrganigrammPersonInfo [*];
+  association [1] Organigramm -> (stellvertreter) OrganigrammPersonInfo [*];
+  association [1] Organigramm -> (mitarbeiter) OrganigrammPersonInfo [*];
+
+  class OrganigrammPersonInfo {
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    Optional<ZahlenWert> umfang;
+  }
+
+  association [*] OrganigrammPersonInfo -> Person [1];
+
+  //----------------------------------------------
+  // =============== WZL END ===============
+  //----------------------------------------------
+
+
+  // Druckeinstellungen
+  class DruckEinstellungenProjekt {
+    Long projektId;
+    Integer jahr;
+    Integer monat;
+    Optional<String> mittelabrufnummer;
+    Optional<String> belegnummer;
+  }
+
+  association [1] DruckEinstellungenProjekt -> (druckEinstellungenPersonen) DruckEinstellungenPerson [*];
+
+  class DruckEinstellungenPerson {
+    Long personId;
+    Optional<ZahlenWert> stundensatz;
+  }
+
+  class BlacklistedToken {
+    <<dbColumnDefinition="TEXT">> // have more than 255 characters
+    String token;
+    ZonedDateTime addedAt;
+    ZonedDateTime expiresAt;
+  }
+
+  class RefreshToken {
+    long userId;
+    String token;
+  }
+
+  // NotificationCenter
+  class UserNotification {
+    UserNotificationType notificationType;
+    String title;
+
+    <<dbColumnDefinition="TEXT">>
+    String message;
+    ZonedDateTime timeStamp;
+
+    // clickable
+    Optional<String> link; // fuer Router
+
+    boolean seen;
+    boolean pinned;
+  }
+
+  enum UserNotificationType { SUCCESS, INFO, WARNING, DANGER; }
+
+  association [1] MacocoUser -> (notification) UserNotification [*];
+
+  //----------------------------------------------
+  // =============== Command Logs ================
+  //----------------------------------------------
+  class AccessIdentifier {
+  }
+
+  class CommandLog {
+    ZonedDateTime timestamp;
+    List<String> diff;
+    String affectedArea;
+    String affectedObject;
+  }
+
+  association [1] CommandLog -> (executor) MacocoUser [0..1]; // TODO: In den Migrationsskript für 2.9.0 -> 2.10.0 : früher war association [1] CommandLog -> (executor) MacocoUser [1];
+  association [1] CommandLog -> (permission) AccessIdentifier [*];
+
+  //----------------------------------------------
+  // =============== Dokumente ===================
+  //----------------------------------------------
+
+  // Bei Änderung PermissionCheckHelper.doesUserHavePermissionForDokument updaten
+  enum DokumentGroup {
+    PERSONAL("personal"),
+    KONTO("konto");
+  }
+
+  class Dokument {
+    DokumentGroup groupName;
+    Long associationId;       // ID des Objektes an dem das Dokument hängt
+    ZonedDateTime datum;      // Upload-Datum
+    String bezeichnung;
+    String dateiFormat;
+    Long fileSize;
+    Optional<String> anmerkung;
+    boolean istAktiv;
+  }
+
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/mill/LanguageInfrastructureConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/mill/LanguageInfrastructureConc.cd
@@ -1,0 +1,8 @@
+classdiagram LanguageInfrastructureConc {
+
+  <<ref="MillProduct">> class G1Parser;
+  <<ref="MillProduct">> class G1Traverser;
+  <<ref="MillProduct">> class ASTFooBuilder;
+
+  <<ref="Mill">> class G1Mill;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/mill/MillOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/mill/MillOut.cd
@@ -1,0 +1,17 @@
+classdiagram LanguageInfrastructureConc {
+
+  <<ref="MillProduct">> class G1Parser;
+  <<ref="MillProduct">> class G1Traverser;
+  <<ref="MillProduct">> class ASTFooBuilder;
+
+  <<ref="Mill">> class G1Mill {
+    static void init();
+    static void initMe(G1Mill me);
+    <<ref="MillRef.Mill._MillProduct">> G1Parser _G1Parser();
+    <<ref="MillRef.Mill._MillProduct">> G1Traverser _G1Traverser();
+    <<ref="MillRef.Mill._MillProduct">> ASTFooBuilder _ASTFooBuilder();
+    <<ref="MillRef.Mill.millProduct">> static G1Parser g1Parser();
+    <<ref="MillRef.Mill.millProduct">> static G1Traverser g1Traverser();
+    <<ref="MillRef.Mill.millProduct">> static ASTFooBuilder aSTFooBuilder();
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/mill/MillRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/mill/MillRef.cd
@@ -1,0 +1,11 @@
+classdiagram MillRef {
+
+  class MillProduct;
+
+	class Mill {
+    static void init();
+    static void initMe(Mill me);
+    <<forEach="MillProduct">> MillProduct _MillProduct();
+    <<forEach="MillProduct">> static MillProduct millProduct();
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/StaticDelegatorConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/StaticDelegatorConc.cd
@@ -1,0 +1,8 @@
+classdiagram StaticDelegatorConc {
+
+  <<ref="StaticDelegator">> class MyLanguageMill {
+    <<ref="StaticDelegator.method">> static void foo();
+    <<ref="StaticDelegator.method">> static int getId();
+    <<ref="StaticDelegator.method">> static void doSomething();
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/StaticDelegatorOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/StaticDelegatorOut.cd
@@ -1,0 +1,12 @@
+classdiagram StaticDelegatorConc {
+
+  <<ref="StaticDelegator">> class MyLanguageMill {
+    <<ref="method">> static void foo();
+    <<ref="method">> static int getId();
+    <<ref="method">> static void doSomething();
+
+    <<ref="StaticDelegatorRef.StaticDelegator._method">> void _foo();
+    <<ref="StaticDelegatorRef.StaticDelegator._method">> int _getId();
+    <<ref="StaticDelegatorRef.StaticDelegator._method">> void _doSomething();
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/StaticDelegatorRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/StaticDelegatorRef.cd
@@ -1,0 +1,7 @@
+classdiagram StaticDelegatorRef {
+
+  class StaticDelegator {
+    <<forEach="StaticDelegator.method">> any _method();
+    static any method();
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsConc.cd
@@ -1,0 +1,8 @@
+classdiagram InstanceMethodExistsConc {
+
+  <<ref="StaticDelegator">> class MyLanguageMill {
+    <<ref="StaticDelegator._method">> int _foo;
+    <<ref="StaticDelegator._method">> int _getId;
+    <<ref="StaticDelegator._method">> boolean _doSomething;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/InstanceMethodExistsOut.cd
@@ -1,0 +1,12 @@
+classdiagram InstanceMethodExistsConc {
+
+  <<ref="StaticDelegator">> class MyLanguageMill {
+    <<ref="StaticDelegator._method">> int _foo;
+    <<ref="StaticDelegator._method">> int _getId;
+    <<ref="StaticDelegator._method">> boolean _doSomething;
+
+    <<ref="StaticDelegatorRef.StaticDelegator.method">> static int foo;
+    <<ref="StaticDelegatorRef.StaticDelegator.method">> static int getId;
+    <<ref="StaticDelegatorRef.StaticDelegator.method">> static boolean doSomething;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/StaticDelegatorRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/StaticDelegatorRef.cd
@@ -1,0 +1,12 @@
+classdiagram StaticDelegatorRef {
+
+  /*
+   * Because there is not yet a "method forEach method" completion implementation, we test the
+   * same pattern with attributes.
+   */
+
+  class StaticDelegator {
+    <<forEach="StaticDelegator.method">> any _method;
+    static any method;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/StaticExistsConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/StaticExistsConc.cd
@@ -1,0 +1,8 @@
+classdiagram StaticExistsConc {
+
+  <<ref="StaticDelegator">> class MyLanguageMill {
+    <<ref="StaticDelegator.method">> static int foo;
+    <<ref="StaticDelegator.method">> static int getId;
+    <<ref="StaticDelegator.method">> static boolean doSomething;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/StaticExistsOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/staticDelegator/attrWorkaround/StaticExistsOut.cd
@@ -1,0 +1,12 @@
+classdiagram StaticExistsConc {
+
+  <<ref="StaticDelegator">> class MyLanguageMill {
+    <<ref="StaticDelegator.method">> static int foo;
+    <<ref="StaticDelegator.method">> static int getId;
+    <<ref="StaticDelegator.method">> static boolean doSomething;
+
+    <<ref="StaticDelegatorRef.StaticDelegator._method">> int _foo;
+    <<ref="StaticDelegatorRef.StaticDelegator._method">> int _getId;
+    <<ref="StaticDelegatorRef.StaticDelegator._method">> boolean _doSomething;
+  }
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/transitiveDependencies/TransitiveDependenciesConc.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/transitiveDependencies/TransitiveDependenciesConc.cd
@@ -1,0 +1,5 @@
+classdiagram TransitiveDependenciesConc {
+
+  <<ref="DataClass">> class Employee;
+  <<ref="DataClass">> class Department;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/transitiveDependencies/TransitiveDependenciesOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/transitiveDependencies/TransitiveDependenciesOut.cd
@@ -1,0 +1,11 @@
+classdiagram TransitiveDependenciesConc {
+
+  <<ref="DataClass">> class Employee;
+  <<ref="DataClass">> class Department;
+
+  <<ref="TransitiveDependenciesRef.DataClassBuilder">> class EmployeeBuilder;
+  <<ref="TransitiveDependenciesRef.DataClassBuilder">> class DepartmentBuilder;
+
+  <<ref="TransitiveDependenciesRef.DataClassBuilderFactory">> class EmployeeBuilderFactory;
+  <<ref="TransitiveDependenciesRef.DataClassBuilderFactory">> class DepartmentBuilderFactory;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/transitiveDependencies/TransitiveDependenciesRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/transitiveDependencies/TransitiveDependenciesRef.cd
@@ -1,0 +1,8 @@
+classdiagram TransitiveDependenciesRef {
+
+  class DataClass;
+
+  <<forEach="DataClass">> class DataClassBuilder;
+
+  <<forEach="DataClassBuilder">> class DataClassBuilderFactory;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/transitiveDependencies/TransitiveDependenciesSwappedOrderRef.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/evaluation/transitiveDependencies/TransitiveDependenciesSwappedOrderRef.cd
@@ -1,0 +1,10 @@
+classdiagram TransitiveDependenciesRef {
+
+  <<forEach="DataClassBuilder">> class DataClassBuilderFactory;
+
+  class DataClass;
+
+  <<forEach="DataClass">> class DataClassBuilder;
+
+
+}

--- a/cddiff/src/test/resources/de/monticore/cdconcretization/helper/HelperOut.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconcretization/helper/HelperOut.cd
@@ -4,7 +4,7 @@ classdiagram HelperConc {
   <<ref="B">> class C;
   <<ref="B">> class D;
 
-  association A (roleNameLeft_A) <-> (roleNameRight_B) B;
-  association A (roleNameLeft_A) <-> (roleNameRight_C) C;
-  association A (roleNameLeft_A) <-> (roleNameRight_D) D;
+  association A (roleNameLeft) <-> (roleNameRight_B) B;
+  association A (roleNameLeft) <-> (roleNameRight_C) C;
+  association A (roleNameLeft) <-> (roleNameRight_D) D;
 }

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/Reference.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/Reference.cd
@@ -1,0 +1,8 @@
+classdiagram Reference {
+
+  class Account;
+  class Transaction;
+
+  association Transaction -> (source) Account [1];
+  association Transaction -> (target) Account [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/ReferenceExplicitAssocName.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/ReferenceExplicitAssocName.cd
@@ -1,0 +1,8 @@
+classdiagram ReferenceExplicitAssocName {
+
+  class Account;
+  class Transaction;
+
+  association transactionSource Transaction -> (source) Account [1];
+  association transactionTarget Transaction -> (target) Account [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/invalid/BothMissing.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/invalid/BothMissing.cd
@@ -1,0 +1,5 @@
+classdiagram BothExist {
+
+  class Account;
+  class Transaction;
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/invalid/DifferentRoleNames.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/invalid/DifferentRoleNames.cd
@@ -1,0 +1,11 @@
+classdiagram BothExist {
+
+  class Account;
+  class Transaction;
+
+  // NOTE: for this does case DO NOT use something like 'sourceAccount' as role name, because
+  // this would be matched to the correct reference assoc because of the "role prefix if present"
+  // matching strategy.
+  association Transaction -> (srcAcc) Account [1];
+  association Transaction -> (tgtAcc) Account [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/invalid/OneRoleMissing1.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/invalid/OneRoleMissing1.cd
@@ -1,0 +1,7 @@
+classdiagram BothExist {
+
+  class Account;
+  class Transaction;
+
+  association Transaction -> (source) Account [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/invalid/OneRoleMissing2.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/invalid/OneRoleMissing2.cd
@@ -1,0 +1,7 @@
+classdiagram BothExist {
+
+  class Account;
+  class Transaction;
+
+  association Transaction -> (source) Account [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/valid/DifferentRoleNamesSTMapped.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/valid/DifferentRoleNamesSTMapped.cd
@@ -1,0 +1,8 @@
+classdiagram DifferentRoleNamesSTMapped {
+
+  class Account;
+  class Transaction;
+
+  <<ref="transactionSource">> association Transaction -> (sourceAccount) Account [1];
+  <<ref="transactionTarget">> association Transaction -> (targetAccount) Account [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/valid/ExactSame.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/associations/sameTypeMultipleRoles/valid/ExactSame.cd
@@ -1,0 +1,8 @@
+classdiagram BothExist {
+
+  class Account;
+  class Transaction;
+
+  association Transaction -> (source) Account [1];
+  association Transaction -> (target) Account [1];
+}

--- a/cddiff/src/test/resources/de/monticore/cdconformance/evaluation/MaCoCo.cd
+++ b/cddiff/src/test/resources/de/monticore/cdconformance/evaluation/MaCoCo.cd
@@ -1,0 +1,1454 @@
+/* (c) https://github.com/MontiCore/monticore */
+/* adapted and customized by (c) MaCoCo, ein RWTH Aachen projekt */
+
+package de.macoco.be.domain;
+
+import java.lang.String;
+import java.lang.Long;
+import java.lang.Integer;
+import java.lang.Boolean;
+
+import java.time.ZonedDateTime;
+
+classdiagram MaCoCo {
+
+  //----------------------------------------------
+  //--------------- PERSONAL ---------------------
+  //----------------------------------------------
+
+  /**
+   * Person ist die Zentrale Klasse des Personal-Komplexes.
+   **/
+  class Person {
+    String vorname;
+    Optional<String> vorsatzwort;
+    String nachname;
+    String kuerzel;       // Abgeleitet analog wie bei SAP: 3 Vor- 3 Nachnamenbuchstaben
+    Optional<String> personalnummer;
+    Optional<ZonedDateTime> gebDatum;
+    Optional<ZonedDateTime> beschBeginn;
+    Optional<ZonedDateTime> beschEnde;
+    List<String> kommentar;
+    boolean istAktiv;
+    boolean istStundenzettelpflichtig = false;
+    Optional<ZonedDateTime> stundenzettelpflichtigVon;
+    Optional<ZonedDateTime> stundenzettelpflichtigBis; // TODO: brauchen wir nicht mehr
+    Optional<Long> ueberStundenUebertrag;
+    boolean darfWochenendarbeiten;
+    // Start WZL:
+    Optional<ZonedDateTime> hoechstbeschaeftigungBis;
+    List<String> staatsangehoerigkeiten;
+    Optional<String> telefonnummer;
+    Optional<ZonedDateTime> arbeitserlaubnisBis;
+    boolean extern;
+    Optional<String> titel;
+    Optional<String> rufname;
+    Optional<String> adresse;
+    Optional<String> email;
+    Optional<String> geburtsname;
+    Optional<String> geschlecht;
+    Optional<String> lBVNummer;
+    Optional<ZonedDateTime> entfristung;
+    <<dbColumnDefinition="TEXT">>
+    Optional<String> qualifikationstitel;
+    boolean speicherungGewuenscht = false;
+    <<dbColumnDefinition="TEXT">>
+    Optional<String> urlaubskommentar;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [1] Person -> (anstellungsarten) Anstellungsart [*];
+  association [*] Person -> (vorgesetzte) Person [*];
+  association [1] Person -> (notiz) Freitext [0..1];
+
+  //Für Studentenzettel:
+  association [1] Person -> (jahresurlaubstage) Jahresurlaub [*];
+  association [1] Person -> (zusatzurlaubstage) Sonderurlaub [*];
+  association [1] Person -> (stundenzettel) Stundenzettel [*];
+  association [1] Person -> (abwesenheiten) Abwesenheit [*];
+
+    <<nocascade>>
+  association [1] Person -> (user) MacocoUser [0..1];
+
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart
+
+  class Anstellungsart {
+    BeschaeftigungsArt beschArt;
+  }
+
+  association [1] Anstellungsart -> (vertraege) Vertrag [*];
+  association [1] Anstellungsart -> (anstellungsformen) Anstellungsform [*];
+
+  enum BeschaeftigungsArt {
+    WiMi("Wissenschaftliche/r Mitarbeiter/in (WiMi)"),
+    HiWi("Hilfskraft (HiWi)"),
+    BTV("Beschäftigte/r in Technik und Verwaltung (BTV)"),
+    BEAMTE("Beamte/r"),
+    AZUBI("Azubi/ne"),
+    PLAN;
+  }
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> *Vertrag
+  // eine direkte Verbindung zwischen Person und Vertrag existiert nicht.
+
+  class Vertrag {       // spiegelt den Vertrag der Hochschule wieder
+    ZonedDateTime vertragsBeginn;
+    ZonedDateTime vertragsEnde;
+    boolean aenderungsvertrag;
+    /String vertragsStatus; // Aktiv, Planung, Abgelaufen // TODO: change String to enum
+    List<String> kommentar;
+    ZahlenWert planUmfang;
+    Optional<Long> arbeitsstundenProWoche; //Stundenzettel
+    boolean kuendigungsschutz;  // WZL
+    Optional<String> vertragsgrundlage;  // WZL / TODO: change to enum
+    Optional<String> aktion;  // WZL / TODO: change to enum
+    Optional<ZonedDateTime> aktionsDatum;  // WZL / TODO: change to enum
+  }
+
+  association [1] Vertrag -> (kostenstellen) Kostenstelle [*];
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> Anstellungsform
+
+  /**
+   * Beschreibt alle wesentlichen Merkmale einer Anstellung.
+   * Entgeltgruppe, Stufe, etc.
+   **/
+  class Anstellungsform {
+    boolean erstanstellung;
+    Optional<String> entgeltGruppe; // { TVL-13}  Für Hiwis: {SHK (default), WHB, WHK}
+    Optional<String> erfahrungsStufe; // 1- 6 ; sowie Spezialfälle (TVL Ü+);
+    boolean unbefristet;
+    ZonedDateTime anstellungVon;
+    Optional<ZonedDateTime> anstellungBis;
+    long gehaltCent;  // evtl. Schätzgehalt in Zukunft
+    boolean istEigenerReferenzwert;
+    List<String> kommentar;
+    Optional<String> berufsgruppe; // WZL / TODO: change to enum
+    Optional<String> aktion;  // WZL / TODO: change to enum
+    Optional<ZonedDateTime> aktionsDatum;  // WZL / TODO: change to enum
+  }
+
+  //----------------------------------------------
+  // Person -> *Anstellungsart -> *Vertrag -> *Kostenstelle
+
+  class Kostenstelle {
+    ZonedDateTime verbuchungsBeginn;
+    ZonedDateTime verbuchungsEnde;
+    KostenstelleBezeichnung bezeichnung;
+    List<String> kommentar;
+    ZahlenWert beschaeftigungsUmfang;
+    boolean buchungenNeuErzeugen;
+    boolean buchungenLoeschen;
+    boolean gesperrt;
+  }
+
+  enum KostenstelleBezeichnung {
+    NONE(""),
+    AN_INSTITUT("An-Institut"),
+    GMBH("GmbH"),
+    ANDERER_LEHRSTUHL,
+    ANDERES_INSTITUT,
+    VORUEBERGEHEND_ABWESEND("Vorübergehend Abwesend"),
+    ANDERE_FINANZIERUNG;
+  }
+
+  enum Zuweisungsart {
+    KONTO("Kontenzuweisung"),
+    STELLENZUWEISUNG,
+    PLANSTELLE,
+    SONSTIGES;
+  }
+
+  association [*] Kostenstelle -> (personalBudget) Budget [0..1];
+  association Kostenstelle -> (stellenzuweisung) Stellenzuweisung [0..1];
+  association Kostenstelle -> (planstelle) Planstelle [0..1];
+                              <<nocascade>>
+  association [0..1] Kostenstelle -> (personalBuchungen) Buchung [*];
+
+  // Person -> *Anstellungsart -> *Vertrag -> *Kostenstelle -> ?Planstelle
+
+  class Planstelle {
+    String bezeichnung;
+    Optional<String> minEntgeltgruppe;
+    Optional<String> minEntgeltstufe;
+    Optional<String> maxEntgeltgruppe;
+    Optional<String> maxEntgeltstufe;
+    Optional<ZonedDateTime> verfuegbarVon;
+    Optional<ZonedDateTime> verfuegbarBis;
+    Optional<String> kommentar;
+    ZahlenWert planUmfang;
+    boolean aktiv;
+  }
+
+  association Planstelle -> (konto) Konto [0..1];
+
+  //----------------------------------------------
+
+  /**
+   * Repräsentiert verschiedene Arten von monetären Haben
+   * @attribute wert ist jeweils unterschiedlich zu interpretieren:
+   * EURO heisst, der wert ist in Cent angegeben
+   * STUNDE heisst: er ist in Stunden angegeben
+   *    (und das obwohl jedes Monat, Jahr unterschiedliche Stundenzahlen hat)
+   * PROZENT heisst er ist zwischen 0 und 100 angegeben (100%)
+   * NONE
+   **/
+  class ZahlenWert {
+    ZahlenTyp zahlenTyp;
+    long wert;
+  }
+
+  enum ZahlenTyp {EURO, STUNDE, PROZENT, NONE; }
+
+  //----------------------------------------------
+  //------------- Alerts -------------------------
+  //----------------------------------------------
+
+  // Konto -> *MailAlert
+
+  class MailAlert {
+    String name;
+                                    <<dbColumnDefinition="TEXT">>
+    String alertCondition;
+                                    <<dbColumnDefinition="TEXT">>
+    String mailBody;
+    int repetitions;
+    ZonedDateTime firstAlert;
+    ZonedDateTime lastAlert;
+
+    Optional<String> receipients;
+    Optional<String> ccs;
+    Optional<String> bccs;
+
+    // extra Attribute zur Speicherung einiger Werte (vom System unbenutzt)
+    long a1;
+    long a2;
+    boolean flag1;
+    boolean flag2;
+    String s1;
+    String s2;
+  }
+
+  //----------------------------------------------
+  // ============ Finanz-Datenstruktur ===========
+  //----------------------------------------------
+
+  /**
+   * Hauptklasse; das Konto, von der alle anderen abhängen.
+   * Hat mehrere Varianten (Subklassen)
+   */
+  abstract class Konto {
+    String name;
+    Optional<String> pspElement;
+    Optional<String> kontotyp;  // unterschiedlich je nach Kontoart
+    Optional<ZonedDateTime> sapDatum;
+    Optional<String> internesAktenzeichen;
+    boolean istPlanKonto;
+    boolean istVerbuchungsKonto;
+    boolean istAktiv;
+    Optional<String> vergabeVerordnung;
+    Optional<String> farbe;
+    Optional<ZonedDateTime> aenderungsdatum;
+    /Optional<ZonedDateTime> optStartDatum;
+    /Optional<ZonedDateTime> optEndDatum;
+    /Geschaeftsvorgang gueltigerGeschaeftsvorgang;
+  }
+
+  <<treatAsBidirectional>>
+  association [1] Konto (konto) -> (gesamtBudget) Budget [0..1];
+  association [1] Konto -> (kommentare) Freitext [*];
+  association [1] Konto -> (notiz) Freitext [0..1];
+  association [1] Konto <-> MailAlert [*];
+  association [1] Konto -> (abgleichsKonto) ExternKonto [0..1];
+
+  abstract class ErweitertesKonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<ZonedDateTime> bewilligungsDatum;    // Bewilligungsdatum ist im Industrieprojekt nur mandatory, wenn kein Sammelkonto
+    Optional<ZonedDateTime> verlaengertBisDatum;
+    Optional<ZonedDateTime> aufstockungsDatum;
+    Optional<Long> foerderquote;
+    // human names: "Aktenzeichen (RWTH)"
+    // Drittmittel: "Förderkennzeichen",
+    Optional<String> aktenzeichen;
+    Optional<Long> finanzierteKomplettsumme;
+    // human names:
+    // Drittmittel: "Aktenzeichen (Fördergeber)",
+    // Industrieprojekt: "Bestellnummer",
+    // Sonstiges: "Bestellnummer/Aktenzeichen (Fördergeber)"
+    Optional<String> referenzSponsor;
+    boolean hatProgrammpauschale;
+  }
+
+
+  class Drittmittelprojekt extends ErweitertesKonto {
+  }
+
+  association [*] Drittmittelprojekt -> (fachlicherVerantwortlicher) Person [*];
+
+  class Haushaltskonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+  }
+
+  class Industrieprojekt extends ErweitertesKonto {
+    Optional<String> auftraggeber;
+    boolean istSammelkonto;
+    Optional<Long> mehrwertsteuer;
+  }
+
+  association [*] Industrieprojekt -> (fachlicherVerantwortlicher) Person [*];
+
+  class Sonstiges extends ErweitertesKonto {
+    Optional<String> auftraggeber;
+    Geschaeftsvorgang geschaeftsvorgang;
+    Optional<Long> mehrwertsteuer;
+    boolean istSammelkonto;
+  }
+
+
+  enum AbrechnungsInterval {
+    GESAMTE_PROJEKTLAUFZEIT("Gesamte Projektlaufzeit"),
+    JAEHRLICH("Jährlich"),
+    HALBJAEHRLICH("Halbjährlich"),
+    QUARTALSWEISE("Quartalsweise"),
+    MONATLICH("Monatlich");
+  }
+
+  association [1] Konto -> OrganigrammKonto [*];
+
+  class OrganigrammKonto {
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    Optional<ZahlenWert> umfang;
+  }
+
+  association [*] OrganigrammKonto -> Organigramm [1];
+
+  class ZeitlicheVerbuchungskontoZuordnung {
+  	Optional<Long> programmPauschale;
+  	Optional<Long> gemeinkostensatz;
+  	Optional<ZonedDateTime> startDate;
+  	Optional<ZonedDateTime> endDate;
+  	boolean istHauptVerbuchungskonto;
+  }
+
+  association [1] ErweitertesKonto -> (verbuchungskontoZuordnung) ZeitlicheVerbuchungskontoZuordnung [*];
+  association [*] ZeitlicheVerbuchungskontoZuordnung -> (verbuchungskonto) Konto [0..1];
+
+  //----------------------------------------------
+
+  // ------ Budget ------
+  // Konto -> 1Budget
+  // Konto -> 1Budget -> *Budget
+  // Konto -> 1Budget -> *Budget -> *Budget
+
+  /**
+   * Ein Budget erlaubt es ein Konto nach verschiedenen
+   * Strukturierungskriterien zu zerlegen. Budgets sind nur auf drei Ebenen
+   * erlaubt: 1 Hauptbudget, * OberBudgets, ** Unterbudgets.
+   * Die Budget-Struktur stellt einen Baum der maximalen Tiefe 3 dar.
+   */
+
+  class Budget {
+    String typ; // name
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<String> kommentar;
+    Optional<long> budgetRahmenCent; // wird im Gesamtbudget als Bewilligungssumme interpretiert
+    Optional<long> eigenAnteilCent;
+    List<long> jahresBudgets;
+    boolean proportionaleVerteilung;
+    boolean forOverheads; // das erste Budget (gesamtBudget.getUnterbudgets[0])
+    Optional<String> budgetKategorie;
+    /int budgetDepth;
+  }
+
+  association [*] Budget -> Konto [1];
+  association [0..1] Budget (elternBudget) <-> (unterBudget) Budget [*];
+  association [1] Budget (budget) <-> (buchungseintrag) Buchungseintrag [*];
+  association [1] Budget (budget) <-> (stellenzuweisung) Stellenzuweisung [*];
+  <<noOrphanRemoval, noRemoveCascade>>
+  association [0..1] Budget -> Organigramm [0..1];
+
+  //----------------------------------------------
+
+  // ------ Buchungseinträge ------
+  // Konto -> 1Budget (->*Budget)* -> *Buchung
+
+  /**
+   * Buchungen aller Arten: gemeinsame Oberklasse
+   */
+  abstract class Buchungseintrag {
+    ZonedDateTime datum;
+    Optional<String> buchungseintragText; // human name: Buchung: "Buchungstext", Rechnung: "Rechnungsgrund", Mittelabruf: "Anmerkung", Mittelzuweisung: "Grund"
+    long betragCent;                          // human name: "Betrag", Rechnung: "Rechnungsbetrag", Konten mit Programmpauschale: "Rechnungsbetrag (inkl Pauschale)"
+    boolean istAktiv;
+    Optional<ZonedDateTime> aenderungsdatum;
+    /Geschaeftsvorgang gueltigerGeschaeftsvorgang;
+    /String lfdeNummer;
+  }
+
+  class Buchung extends Buchungseintrag {
+    ZonedDateTime belegdatum;
+    String zahlungsgrund; //Belegpositionstext
+    Optional<String> kreditorDebitor;
+    List<String> sachkonto;
+    Optional<ZonedDateTime> buchungsdatum;
+    BuchungsStatus status;
+    List<String> belegnummern;
+    List<String> auftragsnummer;
+    Optional<String> bereich;
+    Optional<String> projekt;
+    Optional<ZonedDateTime> geschaeftsjahr;
+    Optional<Long> steuer;
+    Optional<Long> skonto;
+    Optional<Long> gez_Skonto;
+    Optional<String> erfasser;
+    Optional<String> belegart;
+    Optional<String> referenz;
+    Optional<String> stornonummer;
+    Optional<String> stkz;
+    Optional<ZonedDateTime> erfassungsdatum;
+    Optional<ZonedDateTime> ausgleichsdatum;
+    long betragCentOriginal; // Bei Abweichungen von BetragCent kann nun eine Absicht ueberprueft werden
+    boolean budgetChangedManually; // s.o.
+    Optional<String> kostenarten;
+    /Optional<Integer> bezugsdatumJahr;
+  }
+
+  class Rechnungsstellung extends Buchungseintrag {
+    Optional<ZonedDateTime> rechnungsdatum;
+    Optional<String> rechnungsnummer;
+    RechnungsstellungStatus status;
+    List<String> belegnummern;
+    Optional<Long> gemeinkosten;
+    Optional<Long> honorierung;
+    Optional<String> projekt;
+    Optional<String> debitor;
+    Optional<Long> mehrwertsteuer;
+    Optional<ZonedDateTime> zahlungsziel;
+  }
+
+  class Mittelzuweisung extends Buchungseintrag {
+    Optional<ZonedDateTime> verfallDatum;
+    Optional<String> kennung;
+    MittelzuweisungStatus status;
+  }
+
+  class Mittelabruf extends Buchungseintrag {
+    ZonedDateTime abrufdatum;
+    MittelabrufStatus status;
+    String zeitraum;
+    Optional<Long> pauschaleManuell; // Präsent, falls die Pauschale manuell geändert wurde
+  }
+
+  // ------ Stellenzuweisung ------
+
+  // Konto -> 1Budget (->*Budget)* -> *Stellenzuweisung
+
+  class Stellenzuweisung {
+    ZonedDateTime erstellDatum;         // aktuelles Datum
+    Optional<ZonedDateTime> startDatum; // Datum, zu welchem die Stelle beginnt
+    Optional<ZonedDateTime> endDatum;   // Datum, zu welchem die Stelle endet
+    long wert;
+    String kennung;
+    StellenzuweisungStatus status;
+    ZahlenWert stellenumfang;
+    boolean istAktiv;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  enum Geschaeftsvorgang {
+    NONE,
+    MITTELABRUF,
+    ZUWEISUNG,
+    RECHNUNG;
+  }
+
+  enum BuchungsStatus {
+    EINGEREICHT,
+    SAP("SAP"),
+    SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    FEHLERHAFT;
+  }
+
+  enum RechnungsstellungStatus {
+    OFFENE_RECHNUNG,
+    SAP("SAP"),
+     SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG;
+  }
+
+  enum MittelzuweisungStatus {
+    BESCHEID_ERHALTEN ("Bescheid erhalten"),
+    SAP("SAP"),
+    SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    FEHLERHAFT;
+  }
+
+  enum MittelabrufStatus {
+    ABGERUFEN,
+    SAP("SAP"),
+     SAP_STORNIERT("SAP(Storniert)"),
+    PLANUNG,
+    EINGEREICHT;
+  }
+
+  enum StellenzuweisungStatus {
+    BESETZT,
+    TEILBESETZT,
+    UNBESETZT,
+    PLANUNG;
+  }
+
+  enum VertragStatus {
+    AKTIV,
+    PLANUNG,
+    ABGELAUFEN;
+  }
+
+  //----------------------------------------------
+  // =============== SAPii ===============
+  //----------------------------------------------
+
+  class SAPVerbindung {
+    SAPverbindungsStatus status;
+  }
+
+  class Anfrage {
+    String ikz;
+    String bezeichner;
+    boolean letzteAnfrageErfolgreich;
+  }
+
+  enum SAPverbindungsStatus {
+    VERBUNDEN,
+    GETRENNT,
+    PROBLEM;
+  }
+
+  enum SAPimportMode {
+    DEFAULT,
+    F1KONTO;
+  }
+
+  association [1] SAPVerbindung -> (authorizedBy) MacocoUser [*];
+  association [1] MacocoUser -> (anfragen) Anfrage [*];
+  association [1] Anfrage -> (filteredKonten) PSPImportFilter [*];
+
+  //----------------------------------------------
+
+  class AbgleichsBuchung extends Buchung {
+      AbgleichsStatus abgleichsStatus;
+      Optional<String> abgleichKommentar;
+      String positionsNummer;
+      boolean deactivated;
+  }
+
+    enum AbgleichsStatus {
+      ABGESCHLOSSEN,            // Der Abgleich dieser Buchung ist Abgeschlossen
+      TEILWEISE_ABGESCHLOSSEN,  // Der Abgleich wurde schon Bearbeitet es fehlen jedoch Summen
+      ABWEICHEND,               // Der Abgleich ist Vollständig mit Abweichenden Summen
+      OFFEN,                    // Der Abgleich wurde noch nicht gesetzt
+      VORGESCHLAGEN;            // Der Abgleich wurde vom System vorgeschlagen
+    }
+
+  class AbgleichsGruppe {
+    String bezeichnung;
+  }
+                                <<nocascade>>
+  association AbgleichsGruppe -> (buchungen) Buchung [*];
+                                <<nocascade>>
+  association AbgleichsGruppe -> (abgleichsBuchungen) AbgleichsBuchung [*];
+                                 <<nocascade>>
+  association AbgleichsGruppe -> (konto) Konto [1];
+
+  // ------ Freitext ------
+
+  class Freitext {
+    Optional<ZonedDateTime> erstellDatum;
+    Optional<ZonedDateTime> bearbeitetDatum;
+                                    <<dbColumnDefinition="TEXT">>
+    Optional<String> text;
+  }
+
+  class Legende {
+    LegendeTyp type;
+    String expression;
+      <<dbColumnDefinition="TEXT">>
+    String description;
+  }
+
+  enum LegendeTyp {
+    KONTO_FARBE;
+  }
+
+  //----------------------------------------------
+  // =============== Projekte ===============
+  //----------------------------------------------
+
+  abstract class Projekt {
+    String name;
+    String kuerzel;
+    Optional<Long> minPM;
+    Optional<Long> maxPM;
+    Optional<Long> finanzPM;
+    Optional<ZonedDateTime> laufzeitVon;
+    Optional<ZonedDateTime> laufzeitBis;
+    Optional<String> kommentar;
+    Optional<String> foerdergeberAZ;
+    ProjektStatus status;
+    boolean istAktiv;
+    boolean lockedForStundenzettel;   // Das gesamte Projekt ist gesperrt
+    List<ZonedDateTime> lockedMonths; // Stellen die Ausnahme aus der Lock-Regelung für das gesamte Projekt dar
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [1] Projekt -> Aufwand [*];
+  association [1] Projekt -> Arbeitspaket [*];
+  association [1] Projekt -> Anstellung [*];
+  association [*] Projekt -> Konto [0..1];
+  association [*] Projekt -> (hauptverantwortlich) Person [*];
+  association [1] Projekt -> (notiz) Freitext [0..1];
+
+  class Auftragsprojekt extends Projekt {
+    Optional<String> nummer;
+    ProjektTyp typ;
+    Optional<String> regelung;
+  }
+
+  class Organisation extends Projekt {
+  }
+
+  class Lehre extends Projekt {
+    Optional<Long> stunden;
+  }
+
+  class Arbeitspaket {
+    String nummer; // könnte auch 1.1 sein
+    String name;
+    Optional<String>  beschreibung;
+    Optional<ZonedDateTime> beginnDatum;
+    Optional<ZonedDateTime> endeDatum;
+    Optional<Long> pMs;
+    Optional<Long> stunden;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  class Aufwand {
+    /long pM;
+    ZahlenWert umfang;
+    ZonedDateTime laufzeitVon;
+    ZonedDateTime laufzeitBis;
+    Optional<ZonedDateTime> aenderungsdatum;
+  }
+
+  association [*] Aufwand -> Person [0..1];
+
+  class Anstellung {
+    Optional<String> bezeichnung;
+    ZahlenWert umfang;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    boolean verfaellt;
+    Optional<Stellentyp> min;
+    Optional<Stellentyp> max;
+    /long pM;
+    BeschaeftigungsArt beschaeftigungsArt;
+  }
+
+  association [*] Anstellung -> Person [0..1];
+
+  class Stellentyp {
+    Optional<String> entgeltgruppe;
+    Optional<String> entgeltstufe;
+  }
+
+  enum ProjektStatus {
+    IN_DEFINITION,
+    BEANTRAGT,
+    GENEHMIGT,
+    ABGELEHNT,
+    LAUFEND,
+    FACHLICH_ABGESCHLOSSEN("Fachlich abgeschlossen"),
+    ENDBERICHT_EINGEREICHT("Endbericht eingereicht"),
+    INPRUEFUNG("In Prüfung"),
+    GEPRUEFT("Geprüft"),
+    ABGERECHNET,
+    ABGESCHLOSSEN,
+    ARCHIVIERT;
+  }
+
+  enum ProjektArt {
+    AUFTRAG,
+    ORGANISATION,
+    LEHRE,
+    NONE;
+  }
+
+  enum ProjektTyp {
+    HOHEITLICH,
+    INDUSTRIE,
+    UNIVERSITAET("Universität"),
+    SONSTIGE;
+  }
+
+  enum Vergabeverordnung {
+    VOL_A ("VOL/A"),
+    VOB_A ("VOB/A"),
+    UVGO_NRW ("UVgO NRW"),
+    UVGO_BUND ("UVgO Bund"),
+    NONE (" ");
+  }
+
+  //----------------------------------------------
+  // =============== Stundenzettel ===============
+  //----------------------------------------------
+
+  class Stundenzettel {
+    StundenzettelStatus status;
+    ZonedDateTime zeit;
+    Optional<Long> abgegebenVonUserId;
+    Optional<ZonedDateTime> abgabeDatum;
+  }
+
+  association [1] Stundenzettel -> (eintraege) StundenzettelEintrag [*];
+
+  class StundenzettelEintrag {
+    ZonedDateTime uhrzeitVon;
+    Optional<ZonedDateTime> uhrzeitBis;
+    Optional<String> beschreibung;
+    /long stunden;
+    StundenzettelProjekt pauseOderSonstiges;
+  }
+
+  association [*] StundenzettelEintrag ->  Projekt [0..1];
+  association [*] StundenzettelEintrag ->  Arbeitspaket [0..1];
+
+  class StundenzettelHistorieEintrag {
+    ZonedDateTime bearbeitungsdatum;
+    Optional<Long> editorId;
+    Optional<String> editedBy;
+    String monat;
+    int jahr;
+    String changeOperation;
+  }
+
+  enum StundenzettelChangeOperation {
+    INVALID,
+    ABGEGEBEN("Abgegeben"),
+    INTERN_GEPRUEFT("Intern Geprüft"),
+    INTERN_ABGESCHLOSSEN("Intern Abgeschlossen");
+  }
+
+  association [1] Person ->  StundenzettelHistorieEintrag [*];
+
+  class Abwesenheit {
+    Abwesenheitsgrund grund;
+    ZonedDateTime  datumVon;
+    ZonedDateTime datumBis;
+    Optional<String> kommentar;
+    Optional<ZonedDateTime> uhrzeitVon;
+    Optional<ZonedDateTime> uhrzeitBis;
+    Optional<Long> minutenProTag;
+    /long tageGesamt;
+  }
+
+  class Dienstreise extends Abwesenheit {
+    Optional<String> reisenummer;
+    Optional<String> dienstreisegrund;
+    Optional<String> reiseziel;
+    Optional<Long> gesamtkosten;
+    Optional<String> status;
+    Optional<String> statusText;
+  }
+
+  association [*] Abwesenheit -> Konto [0..1];
+
+  association [1] Abwesenheit -> UrlaubsGenehmigung [0..1];
+
+  association [*] Dienstreise -> Budget [0..1];
+
+  class Arbeitstage {
+    ZonedDateTime guiltigAb;
+    ZonedDateTime guiltigBis;
+    List<Integer> wochenTage; // 0..4 (Montag-Freitag)
+  }
+
+  association [1] Person -> Arbeitstage [*];
+
+  class Jahresurlaub {
+    int jahr;
+    long tageAnzahl;
+    Optional<Long> stundenAnzahl;
+    boolean istManuellerEintrag;
+  }
+
+  class UrlaubsGenehmigung {
+    Optional<ZonedDateTime> beantragt;
+    Optional<ZonedDateTime> genehmigt;
+    Optional<ZonedDateTime> geprueft;
+    Optional<ZonedDateTime> storniert;
+    Urlaubssstatus status;
+    Stornierungsstatus stornierungsStatus;
+  }
+
+  class Sonderurlaub {  // Für WZL: Zusatzurlaub umbenennen in Sonderurlaub und neues Feld anzahl
+    ZonedDateTime  datumVon;
+    ZonedDateTime datumBis;
+    long anzahl;
+  }
+
+  class UrlaubEinstellungen {
+    boolean urlaubsanspruchInStunden;
+  }
+
+  enum Abwesenheitsgrund {
+    U_URLAUB,
+    D_DIENSTREISE,
+    S_SONSTIGE;
+    /*
+    Z_ZUSATZURLAUB,
+    A_ARBEITSUNFALL,
+    AB_ABGELTUNG,
+    E_ELTERNZEIT,
+    F_FREISTELLUNG,
+    K_KRANKHEIT,
+    KU_KUR,
+    S_SONSTIGES;*/
+  }
+
+  enum Urlaubssstatus {
+    NONE,
+    BEANTRAGT,
+    GEPRUEFT("Geprüft"),
+    PRUEFUNG_ABGELEHNT("Prüfung abgelehnt"),
+    GENEHMIGT,
+    GENEHMIGUNG_ABGELEHNT;
+  }
+
+  enum Stornierungsstatus {
+    NONE,
+    VERBOTEN,
+    STORNIERUNGSANTRAG,
+    STORNIERT;
+  }
+
+  enum Abrechnungsstatus {
+    OFFEN,
+    ABZURECHNEN,
+    ABGERECHNET,
+    STORNIERT;
+  }
+
+  enum StundenzettelStatus {
+    IN_ERFASSUNG,
+    INTERN_INPRUEFUNG("Intern in Prüfung"),
+    INTERN_ABGESCHLOSSEN,
+    DRITTMITTELABTEILUNG_INPRUEFUNG("Drittmittelabteilung in Prüfung"),
+    DRITTMITTELABTEILUNG_ABGESCHLOSSEN,
+    ENDBERICHT_EINGEREICHT,
+    GEPRUEFT("Geprüft"),
+    FOERDERGEBER_ABGESCHLOSSEN("Fördergeber abgeschlossen"),
+    ABGESCHLOSSEN;
+  }
+
+  enum StundenzettelProjekt {
+    PAUSE,
+    SONSTIGE,
+    NONE;
+  }
+
+  association [*] F1Konto -> (institut) Institut [0..1];
+
+  class ExternKonto extends Konto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    Optional<String> importVermerk;
+    AbgleichType abgleichVerhalten;
+  }
+
+  enum AbgleichType {
+    IGNORE,
+    MANUEL,
+    AUTO_COPY;
+  }
+
+  association [*] ExternKonto -> (institut) Institut [0..1];
+
+  class PSPImportFilter{
+    boolean importThisPSPelement;
+    boolean importBookings;
+    String name;
+    String pspElement;
+    Optional<ZonedDateTime> startDate;
+  }
+
+  association [*] PSPImportFilter -> (targetPSP) Konto [0..1];
+
+  //----------------------------------------------
+  // Reports
+
+  class EventReport {
+    ZonedDateTime eventStart;
+    Optional<ZonedDateTime> eventEnd;
+    /EventStatus status;
+    String message; // <a href="wiki/BuchungImport">BuchungImport</a>: Nutzer 'netz' hat die Datei '.....' importiert
+  }
+
+  class EventReportEntry {
+    EventType type;
+    Optional<Long> targetId; // click -> navigate to id
+    Optional<Integer> count;
+    <<dbColumnDefinition="TEXT">>
+    String message; // Zeile 4 Fehler ...... Zeile 5 .....
+    EventStatus status;
+  }
+  association [1] EventReport -> (entries) EventReportEntry [*];
+
+  class ImportReport extends EventReport {
+  }
+
+  class ImportReportEntry extends EventReportEntry {
+  }
+
+
+  class PersonalExportReport extends EventReport {
+    Long dataId;
+
+    ZonedDateTime datenStart;
+    ZonedDateTime datenEnd;
+    Long countData;
+    /Long countError;
+    EventStatus exportStatus;
+  }
+
+  class PersonalExportReportEntry extends EventReportEntry {
+    Optional<String> vorsatzwort;
+    String vorname;
+    String nachname;
+    BeschaeftigungsArt beschaeftigungsArt;
+    ZonedDateTime monat;
+  }
+
+  enum EventStatus {
+    // Import
+    SUCCESS("erfolgreich"),
+    ERROR("fehlerhaft"),
+    INFO("erfolgreich"), // success + special
+    CREATED("erstellt"),
+    UPDATED("upgedated"),
+    IGNORED("ignoriert"),
+    IN_PROGRESS("in bearbeitung"),
+
+    // Personal Export
+    SENT("verschickt"),
+    CORRECT("sachlich korrekt");
+  }
+
+  enum EventType {
+    IMPORT_KONTO("Konten"),
+    IMPORT_BUCHUNG("Buchungs"),
+    IMPORT_PERSON("Personen"),
+    IMPORT_INSTITUT("Instituts"),
+    IMPORT_NUTZER("Nutzer"),
+    IMPORT_VERTRAG("Vertrags"),
+    EXPORT_FINANZEN_KONTO("Konten"),
+    EXPORT_FINANZEN_PLANSTELLE("Planstellen"),
+    EXPORT_FINANZEN_VERTRAG("Vertragabdeckungs");
+  }
+
+
+  //----------------------------------------------
+  // =============== Fakultät 1 DS ===============
+  //----------------------------------------------
+
+  // Institut
+  <<dbColumn = "unique=true">>
+  class Institut {
+    String institutsKennZiffer;
+    String institutsName;
+    String professorName;
+    boolean lokalInstitut;
+  }
+
+  // Fachgruppe
+  enum Fachgruppe {
+    MATHEMATIK,
+    INFORMATIK,
+    PHYSIK,
+    CHEMIE,
+    BIOLOGIE;
+  }
+
+  //SAP-Abschöpfung von Geschäftsjahr
+  class GeschaeftsjahrSAPAbschoepfung {
+    String fachgruppe;
+    String institutsKennZiffer;
+    String institutsName;
+    String pspElement;
+    long gesamtSAPAbschoepfung;
+  }
+
+  class SAPAbschoepfung {
+    Long betragCent;
+    ZonedDateTime year;
+  }
+
+  association [1] GeschaeftsjahrSAPAbschoepfung -> (sapAbschoepfung) SAPAbschoepfung [*];
+
+
+  // Konto
+  class F1Konto extends Haushaltskonto {
+    Optional<ZonedDateTime> startDatum;
+    Optional<ZonedDateTime> endDatum;
+    long originalBudgetCent;
+    long sonstigeZuweisungenCent;
+    long resteCent;
+    long aktuellerKontostandCent;
+    long kontoRahmenCent;
+    KommunikationsStatus kommunikationsStatus;
+    StrafsteuerStatus strafsteuerStatus;
+    long strafsteuerBasisCent;
+    long strafsteuerSAPCent;
+    long strafsteuerCent;
+    long strafsteuerBerechnungsGrundlageCent;
+    Optional<Long> kontoStandBeginnGeschaeftsjahr;
+  }
+
+  // Konto -> 1Budget (->*Budget)* -> *Buchung -> ?Begruendung
+
+  // Buchungen werden hier noch erweitert:
+  association [1] Buchung -> (begruendung) Begruendung [0..1];
+
+  class Begruendung {
+    String text;
+    ZonedDateTime erstellung;
+    Optional<ZonedDateTime> letzteBearbeitung;
+    Optional<StrafsteuerGeschaeftsjahr> geschaeftsjahr;
+  }
+
+  association [1] Begruendung -> (akzeptanz) Akzeptanz [0..1];
+  //association [1] Begruendung -> (geschaeftsjahr) StrafsteuerGeschaeftsjahr [0..1];
+
+  //----------------------------------------------
+
+  // Konto -> 1Budget (->*Budget)* -> *Buchung -> ?Begruendung -> ?Akzeptanz
+
+  class Akzeptanz {
+    Akzeptanzstatus akzeptanzstatus;
+    Optional<long> teilbetragCent;
+    Optional<ZonedDateTime> bearbeitung;
+    boolean istAktiv;
+    Optional<String> kommentar;
+  }
+
+  //----------------------------------------------
+
+  enum KommunikationsStatus {
+    KOM_STAT_NO_ACTION_NEEDED,       // Kein Handlungsbedarf
+    KOM_STAT_BEGR_FEHLT,             // Begründung fehlt
+    KOM_STAT_ANTW_FEHLT,             // Antwort fehlt
+    KOM_STAT_ANTW_CHANGED,           // Buchung oder Begründung wurden geändert
+    KOM_STAT_BEGR_CHANGED,           // Antwort wurde geändert
+    KOM_STAT_ANTW_BEGR_CHANGED,      // Antwort und Begründung wurde geändert
+    KOM_STAT_ANTW_FEHLT_CHANGED;     // Antwort Fehlt, andere Antwort wurde geändert
+  }
+
+  enum StrafsteuerStatus {
+    NONE,
+    SOME,
+    ALL;
+  }
+
+  enum Akzeptanzstatus {
+    OFFEN,
+    OK,
+    TEILOK,
+    NOTOK;
+  }
+
+  class StrafsteuerGeschaeftsjahr {
+    ZonedDateTime jahr;
+    boolean current;
+  }
+
+  class StrafsteuerSperrDatum {
+    ZonedDateTime sperrDatum;
+  }
+
+  //----------------------------------------------
+  // =============== MacocoUser ===============
+  //----------------------------------------------
+
+  class MacocoUser {
+                                     <<dbColumn = "unique=true">>
+    String username;
+    Optional<String> encodedPassword;
+    String passwordSaltBase64;
+    ZonedDateTime registrationDate;
+    Optional<String> initials;
+    MacocoUserActivationStatus activated;
+    boolean enabled;
+                                      <<dbColumn = "unique=true">>
+    String email;
+    boolean authentifiziert;
+    Optional<String> timID;
+    Optional<String> sapAccessToken;
+    Optional<String> sapRefreshToKen;
+
+  }
+
+  association  [*] MacocoUser -> (institute) Institut [*];
+
+  enum MacocoUserActivationStatus {
+    AKTIVIERT,
+    MAIL_NICHT_GESENDET("Mail nicht gesendet"),
+    MAIL_FEHLERHAFT("Mail fehlerhaft"),
+    MAIL_GESENDET("Mail gesendet");
+  }
+
+  // Favoriten
+  class Favorite {
+    String title;
+    String url;
+  }
+
+  association [1] MacocoUser -> (favorite) Favorite [*];
+
+  class RoleAssignment {
+  }
+
+  association [*] RoleAssignment -> (user) MacocoUser [1];
+  association [*] RoleAssignment -> (accessPolicy) AccessPolicy [1];
+
+  class AccessPolicy {
+    String roleName;
+    Optional<Long> objId;
+  }
+
+  class GroupedAccessPolicy {
+    String name;
+  }
+
+  association [*] GroupedAccessPolicy -> (user) MacocoUser [*];
+  association [1] GroupedAccessPolicy -> (policy) AccessPolicy [*];
+
+  //----------------------------------------------
+  // =============== Fristen ===============
+  //----------------------------------------------
+
+  class Frist {
+    String beschreibung;
+    Friststatus status;
+    Fristobjekt fristobjekt;
+    ZonedDateTime faelligkeitsdatum;
+    Optional<String> notiz;
+    Boolean manuellerEintrag;
+    Long bezugsobjektId;
+    String bezugsobjektName;
+    Optional<ZonedDateTime> aenderungsdatum;
+    boolean istAktiv;
+  }
+
+  association [*] Frist -> (zuweisung) Person [0..1];
+
+  association [1] Person -> Frist [*];
+  association [1] Konto -> Frist [*];
+  association [1] Projekt -> Frist [*];
+  association [1] Mittelabruf -> Frist [0..1];
+  association [1] Rechnungsstellung -> Frist [0..1];
+  association [1] Vertrag -> Frist [0..1];
+  association [1] Zulage -> Frist [0..1];
+
+  enum Friststatus {
+    PLANUNG,
+    IN_BEARBEITUNG,
+    ERLEDIGT;
+  }
+
+  enum Fristobjekt {
+    PERSON,
+    KONTO,
+    VERTRAGSVERLAENGERUNG("Vertragsverlängerung"),
+    ZULAGE,
+    RECHNUNG,
+    MITTELABRUF,
+    PROJEKT;
+  }
+
+  class DefaultFristen {
+    ZonedDateTime finanzenStartDatum;
+    Long finanzenFristinWeeks;
+    ZonedDateTime personalStartDatum;
+    Long personalFristinWeeks;
+  }
+
+  //----------------------------------------------
+  // ============= Einstellungen =================
+  //----------------------------------------------
+
+  class Setting {
+    String identifier;
+  }
+
+  class InstanzSetting extends Setting {
+    String value;
+  }
+
+  class UISetting extends Setting {
+    String seite;
+  }
+
+  association [0..1] MacocoUser -> (setting) UISetting [*];
+
+  class FilterSetting extends UISetting {
+    List<String> filterValues;
+  }
+
+  class TableSetting extends UISetting {
+    TableIdentifierTyp typ;
+    boolean zeigeInaktive;
+    int zeilenLimit;
+    Optional<String> gruppiereNach;
+    Optional<String> sortiereNach;
+    Optional<String> sortiereDir;
+    boolean isShowColor;
+  }
+
+  association [1] TableSetting -> (spalten) TableSettingSpalten [*];
+
+  enum TableIdentifierTyp {
+    DEFAULT,
+    USER,
+    INSTITUT;
+  }
+
+  class TableSettingSpalten {
+    String name;
+    boolean istAktiv;
+    long breite;
+  }
+
+  class ErweiterbareListen{
+    String bereich;
+    String feldbezeichnung;
+    List<String> inhalte;
+  }
+
+  //----------------------------------------------
+  // =============== Card Settings ===============
+  //----------------------------------------------
+
+  class CardSetting {
+    String page;
+    String identifier;
+    <<dbColumnDefinition="TEXT">>
+    String configuration;
+  }
+
+  association [*] CardSetting -> (benutzer) MacocoUser [0..1];
+
+  //----------------------------------------------
+  // =============== WZL ===============
+  //----------------------------------------------
+
+  class Elternzeit { // WZL
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    ZahlenWert umfang;
+  }
+
+  class Nebentaetigkeit { // WZL
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    ZahlenWert umfang;
+    Optional<String> arbeitgeber;
+    Optional<String> taetigkeitsbereich;
+  }
+
+  class Zulage  { // WZL
+    Optional<String> pspelement;
+    Optional<String> bezeichnung;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    Long arbeitgeberbrutto;
+    Long arbeitnehmerbrutto;
+  }
+
+  // WZL
+  enum Geschlecht { NONE(""), WEIBLICH("weiblich"), MAENNLICH("männlich"), DIVERS("divers"); }
+
+  // WZL
+  // -> DataSource
+  enum Titel { NONE(""), E1("Apl. Prof. Dr.") , E2("B.Sc.") , E3("Dipl.-Inform.") , E4("Dipl.-Ing."), E5("Dipl.-Ing. (FH)"),
+    E6("Dipl.-Ing. (RUS)"), E7("Dipl.-Kff.") , E8("Dipl.-Math."), E9("Dipl.-Phys.") , E10("Dipl.-Wirt. Ing.") , E11("Dr.")  , E12("Dr. phil."),
+    E13("Dr. rer. nat."), E14("Dr. rer. pol."), E15("Dr.-Ing."), E16("M.A.") , E17("M.Eng."), E18("M.Sc."), E19("PhD"), E20("Prof. Dr.-Ing."); }
+
+  // WZL
+  // -> DataSource
+  enum Berufsgruppe { NONE(""), E1("Akademischer Direktor"), E2("Angestellter in der DV"), E3("Auszubildende/r"), E4("Bibl.-Beschäftiger"),
+    E5("Elektriker"), E6("Elektroniker"), E7("Elektrotechniker"), E8("Fachinformatiker"), E9("Fachinformatiker"), E10("Industriemechaniker"),
+    E11("Lagerarbeiter"), E12("Mechaniker"), E13("Meister"), E14("Praktikant, SV-frei"), E15("Programmierer"), E16("Stud. Hilfskraft"),
+    E17("Techn. Beschäftigter"), E18("Techn. Zeichner"), E19("Techniker"), E20("Universitätsprofessor"), E21("Verw. Beschäftigter"), E22("Werkstoffprüfer"),
+    E23("Wiss. Beschäftigter"), E24("Wiss. Hilfskraft Bachelor"), E25("Wiss. Hilfskraft Master"); }
+
+  // WZL
+  enum Aktion { NONE(""), ANFRAGE_VERSENDET("Anfrage versendet"), ERINNERUNG_VERSENDET("Erinnerung versendet"),
+    ZUR_UNTERSCHRIFT_BEIM_VORGESETZTEN("Zur Unterschrift beim Vorgesetzten"),
+    BEI_ZHV_VORGELEGT("Bei ZHV vorgelegt"), VON_ZHV_BESTAETIGT("Von ZHV bestätigt"); }
+
+  // WZL
+  // -> DataSource
+  enum Vertragsgrundlage { NONE(""), E1("sonst. Befristungen (gleicht Auszubildenden)"), E2("unbefristet"), E3("unbefr. (Beamter aL)"), E4("§14 Abs. 2 TzBfG"),
+    E5("Elternzeitvertretung"), E6("Befristung SHK"), E7("Mehrbedarf sonstiger"), E8("Mehrb. Forschungspr."), E9("§2(5)Nr.3WZVG MuS-EZ"),
+    E10("§2 WZVG DM (NP)"), E11("§2 WZVG KiBetr NP"), E12("WZVG-Postdoc-Quali."), E13("WZVG-N-Gr._Leiter"), E14("WZVG-Wiss.-Quali NP"),
+    E15("§2 WZVG DM (VP)"), E16("§2 WZVG KiBetr VP"), E17("WZVG-Promotion"), E18("WZVG-sonst.Wiss-Qual"), E19("Befristung WHB"), E20("Befristung WHK"),
+    E21("§2 (1) S.2 WZVG nPr"), E22("§14(1) Nr.2 TzBfG-Üb"), E23("befr. Arbeitszeitänderung"), E24("Übernahme nach Ausbildung"); }
+
+  association [1] Person -> (elternzeiten) Elternzeit [*]; // WZL
+  association [1] Person -> (nebentaetigkeiten) Nebentaetigkeit[*];  // WZL
+  association [1] Person -> (zulagen) Zulage [*];  // WZL
+
+  // WZL Personal Export
+  class PersonalExportData {
+  }
+  association [1] PersonalExportData -> (entries) PersonalExportDataEntry [*];
+
+  class PersonalExportDataEntry {
+    String personalnummer;
+    Optional<String> vorsatzwort;
+    String nachname;
+    String vorname;
+    ZonedDateTime von;
+    ZonedDateTime bis;
+    String pspElement;
+    Long prozentsatz;
+  }
+
+   class PersonalExportEinstellungen {
+     String pspElement;
+     List<String> bezeichnungen;
+     ZonedDateTime startmonat;
+     ZonedDateTime endmonat;
+   }
+
+  class Organigramm {
+    boolean istStabstelle;
+    boolean istAktiv;
+    String bezeichnung;
+  }
+
+  <<noOrphanRemoval>>
+  association [0..1] Organigramm (parent) <-> (child) Organigramm [*];
+
+  association [1] Organigramm -> (leiter) OrganigrammPersonInfo [*];
+  association [1] Organigramm -> (stellvertreter) OrganigrammPersonInfo [*];
+  association [1] Organigramm -> (mitarbeiter) OrganigrammPersonInfo [*];
+
+  class OrganigrammPersonInfo {
+    Optional<ZonedDateTime> von;
+    Optional<ZonedDateTime> bis;
+    Optional<ZahlenWert> umfang;
+  }
+
+  association [*] OrganigrammPersonInfo -> Person [1];
+
+  //----------------------------------------------
+  // =============== WZL END ===============
+  //----------------------------------------------
+
+
+  // Druckeinstellungen
+  class DruckEinstellungenProjekt {
+    Long projektId;
+    Integer jahr;
+    Integer monat;
+    Optional<String> mittelabrufnummer;
+    Optional<String> belegnummer;
+  }
+
+  association [1] DruckEinstellungenProjekt -> (druckEinstellungenPersonen) DruckEinstellungenPerson [*];
+
+  class DruckEinstellungenPerson {
+    Long personId;
+    Optional<ZahlenWert> stundensatz;
+  }
+
+  class BlacklistedToken {
+    <<dbColumnDefinition="TEXT">> // have more than 255 characters
+    String token;
+    ZonedDateTime addedAt;
+    ZonedDateTime expiresAt;
+  }
+
+  class RefreshToken {
+    long userId;
+    String token;
+  }
+
+  // NotificationCenter
+  class UserNotification {
+    UserNotificationType notificationType;
+    String title;
+
+    <<dbColumnDefinition="TEXT">>
+    String message;
+    ZonedDateTime timeStamp;
+
+    // clickable
+    Optional<String> link; // fuer Router
+
+    boolean seen;
+    boolean pinned;
+  }
+
+  enum UserNotificationType { SUCCESS, INFO, WARNING, DANGER; }
+
+  association [1] MacocoUser -> (notification) UserNotification [*];
+
+  //----------------------------------------------
+  // =============== Command Logs ================
+  //----------------------------------------------
+  class AccessIdentifier {
+  }
+
+  class CommandLog {
+    ZonedDateTime timestamp;
+    List<String> diff;
+    String affectedArea;
+    String affectedObject;
+  }
+
+  association [1] CommandLog -> (executor) MacocoUser [0..1]; // TODO: In den Migrationsskript für 2.9.0 -> 2.10.0 : früher war association [1] CommandLog -> (executor) MacocoUser [1];
+  association [1] CommandLog -> (permission) AccessIdentifier [*];
+
+  //----------------------------------------------
+  // =============== Dokumente ===================
+  //----------------------------------------------
+
+  // Bei Änderung PermissionCheckHelper.doesUserHavePermissionForDokument updaten
+  enum DokumentGroup {
+    PERSONAL("personal"),
+    KONTO("konto");
+  }
+
+  class Dokument {
+    DokumentGroup groupName;
+    Long associationId;       // ID des Objektes an dem das Dokument hängt
+    ZonedDateTime datum;      // Upload-Datum
+    String bezeichnung;
+    String dateiFormat;
+    Long fileSize;
+    Optional<String> anmerkung;
+    boolean istAktiv;
+  }
+
+}


### PR DESCRIPTION
**Merge after https://github.com/MontiCore/cd4analysis/pull/69**

### Fixed
- `ImplicitRoleNameAssocIncStrategy` accidentally derived roles from existing ROLE names instead of existing CLASS names. Also reused logic for implicit role name from  `CDDiffUtil` - we missed that in a previous code review
- only add type to association role as suffix if total incarnations of type > 1 (see change test cases and https://git.rwth-aachen.de/se-student/theses/ma-jorden/master-theses/-/issues/13)

### Evaluation
- Test MaCoCo CD conforms to itself
- Complete empty CD with MaCoCo CD as reference model
- Tests showing transitive forEach-dependencies work, but only if in syntactical order -> future work
- Mill pattern reference model
- static delegator pattern showing some limitations
- add commented-out `update` method to CRUDBackend