### PR TITLE
4835 improve error handling guava

### DIFF
--- a/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/ODBuilder.java
+++ b/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/ODBuilder.java
@@ -19,7 +19,7 @@ import java.util.*;
 
 /** This class is used to generate elements for object diagrams. */
 public class ODBuilder implements IODBuilder {
-
+  
   /**
    * Creates a new attribute with a given value. This is used only when a constant is added to an
    * enumeration.
@@ -43,7 +43,7 @@ public class ODBuilder implements IODBuilder {
     Verify.verify(attribute.isPresent(), "Attribute value must be present");
     return attribute.get();
   }
-
+  
   /**
    * Creates a new attribute without a value.
    *
@@ -64,7 +64,7 @@ public class ODBuilder implements IODBuilder {
     Verify.verify(attribute.isPresent(), "Attribute value must be present");
     return attribute.get();
   }
-
+  
   /**
    * Create a new ASTODObject.
    *
@@ -79,22 +79,22 @@ public class ODBuilder implements IODBuilder {
       Collection<ASTODAttribute> attrs) {
     ASTODNamedObjectBuilder objectBuilder = ODBasisMill.oDNamedObjectBuilder().setModifier(
         ODBasisMill.modifierBuilder().build()).setName(id);
-
+    
     objectBuilder.setName(id);
-
+    
     objectBuilder.setModifier(OD4ReportMill.modifierBuilder().setStereotype(OD4ReportMill
         .stereotypeBuilder().addValues(OD4ReportMill.stereoValueBuilder().setName("instanceof")
             .setContent(String.join(", ", types)).setText(OD4ReportMill.stringLiteralBuilder()
                 .setSource(String.join(", ", types)).build()).build()).build()).build());
-
+    
     objectBuilder.setMCObjectType(ODBasisMill.mCQualifiedTypeBuilder().setMCQualifiedName(
         ODBasisMill.mCQualifiedNameBuilder().setPartsList(Collections.singletonList(type)).build())
         .build());
-
+    
     objectBuilder.setODAttributesList(new ArrayList<>(attrs));
     return objectBuilder.build();
   }
-
+  
   /**
    * Create a new link between two objects.
    *
@@ -109,21 +109,21 @@ public class ODBuilder implements IODBuilder {
   public ASTODLink buildLink(ASTODObject srcObj, String roleNameSrc, String roleNameTgt,
       ASTODObject trgObj, AssocDirection direction) {
     ASTODLinkBuilder linkBuilder = ODLinkMill.oDLinkBuilder();
-
+    
     ASTODLinkLeftSideBuilder leftSideBuilder = ODLinkMill.oDLinkLeftSideBuilder().setModifier(
         ODBasisMill.modifierBuilder().build()).setODLinkQualifierAbsent().setRole(roleNameSrc);
     ASTODLinkRightSideBuilder rightSideBuilder = ODLinkMill.oDLinkRightSideBuilder().setModifier(
         ODBasisMill.modifierBuilder().build()).setODLinkQualifierAbsent().setRole(roleNameTgt);
-
+    
     ASTODNameBuilder nameBuilder = ODBasisMill.oDNameBuilder().setName(srcObj.getName());
     ASTODNameBuilder nameBuilder1 = ODBasisMill.oDNameBuilder().setName(trgObj.getName());
-
+    
     leftSideBuilder.setReferenceNamesList(Collections.singletonList(nameBuilder.build()));
     rightSideBuilder.setReferenceNamesList(Collections.singletonList(nameBuilder1.build()));
-
+    
     linkBuilder.setODLinkLeftSide(leftSideBuilder.build());
     linkBuilder.setODLinkRightSide(rightSideBuilder.build());
-
+    
     if (direction == AssocDirection.BiDirectional)
       linkBuilder.setODLinkDirection(ODLinkMill.oDBiDirBuilder().build()); // bidirektional
     else if (direction == AssocDirection.LeftToRight) {
@@ -132,10 +132,10 @@ public class ODBuilder implements IODBuilder {
     else if (direction == AssocDirection.RightToLeft) {
       linkBuilder.setODLinkDirection(ODLinkMill.oDRightToLeftDirBuilder().build());
     }
-
+    
     linkBuilder.setLink(true); // nur links
-
+    
     return linkBuilder.build();
   }
-
+  
 }

--- a/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/ODBuilder.java
+++ b/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/ODBuilder.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.syn2semdiff.odgen;
 
+import com.google.common.base.Verify;
 import de.monticore.cddiff.syn2semdiff.datastructures.AssocDirection;
 import de.monticore.od4report.OD4ReportMill;
 import de.monticore.odbasis.ODBasisMill;
@@ -18,7 +19,7 @@ import java.util.*;
 
 /** This class is used to generate elements for object diagrams. */
 public class ODBuilder implements IODBuilder {
-  
+
   /**
    * Creates a new attribute with a given value. This is used only when a constant is added to an
    * enumeration.
@@ -38,10 +39,11 @@ public class ODBuilder implements IODBuilder {
     catch (Exception exception) {
       Log.error("Attributes couldn't be created");
     }
-    assert Objects.requireNonNull(attribute).isPresent();
+    Verify.verifyNotNull(attribute, "Attribute is null");
+    Verify.verify(attribute.isPresent(), "Attribute value must be present");
     return attribute.get();
   }
-  
+
   /**
    * Creates a new attribute without a value.
    *
@@ -58,10 +60,11 @@ public class ODBuilder implements IODBuilder {
     catch (Exception exception) {
       Log.error("Attributes couldn't be created");
     }
-    assert Objects.requireNonNull(attribute).isPresent();
+    Verify.verifyNotNull(attribute, "Attribute is null");
+    Verify.verify(attribute.isPresent(), "Attribute value must be present");
     return attribute.get();
   }
-  
+
   /**
    * Create a new ASTODObject.
    *
@@ -76,22 +79,22 @@ public class ODBuilder implements IODBuilder {
       Collection<ASTODAttribute> attrs) {
     ASTODNamedObjectBuilder objectBuilder = ODBasisMill.oDNamedObjectBuilder().setModifier(
         ODBasisMill.modifierBuilder().build()).setName(id);
-    
+
     objectBuilder.setName(id);
-    
+
     objectBuilder.setModifier(OD4ReportMill.modifierBuilder().setStereotype(OD4ReportMill
         .stereotypeBuilder().addValues(OD4ReportMill.stereoValueBuilder().setName("instanceof")
             .setContent(String.join(", ", types)).setText(OD4ReportMill.stringLiteralBuilder()
                 .setSource(String.join(", ", types)).build()).build()).build()).build());
-    
+
     objectBuilder.setMCObjectType(ODBasisMill.mCQualifiedTypeBuilder().setMCQualifiedName(
         ODBasisMill.mCQualifiedNameBuilder().setPartsList(Collections.singletonList(type)).build())
         .build());
-    
+
     objectBuilder.setODAttributesList(new ArrayList<>(attrs));
     return objectBuilder.build();
   }
-  
+
   /**
    * Create a new link between two objects.
    *
@@ -106,21 +109,21 @@ public class ODBuilder implements IODBuilder {
   public ASTODLink buildLink(ASTODObject srcObj, String roleNameSrc, String roleNameTgt,
       ASTODObject trgObj, AssocDirection direction) {
     ASTODLinkBuilder linkBuilder = ODLinkMill.oDLinkBuilder();
-    
+
     ASTODLinkLeftSideBuilder leftSideBuilder = ODLinkMill.oDLinkLeftSideBuilder().setModifier(
         ODBasisMill.modifierBuilder().build()).setODLinkQualifierAbsent().setRole(roleNameSrc);
     ASTODLinkRightSideBuilder rightSideBuilder = ODLinkMill.oDLinkRightSideBuilder().setModifier(
         ODBasisMill.modifierBuilder().build()).setODLinkQualifierAbsent().setRole(roleNameTgt);
-    
+
     ASTODNameBuilder nameBuilder = ODBasisMill.oDNameBuilder().setName(srcObj.getName());
     ASTODNameBuilder nameBuilder1 = ODBasisMill.oDNameBuilder().setName(trgObj.getName());
-    
+
     leftSideBuilder.setReferenceNamesList(Collections.singletonList(nameBuilder.build()));
     rightSideBuilder.setReferenceNamesList(Collections.singletonList(nameBuilder1.build()));
-    
+
     linkBuilder.setODLinkLeftSide(leftSideBuilder.build());
     linkBuilder.setODLinkRightSide(rightSideBuilder.build());
-    
+
     if (direction == AssocDirection.BiDirectional)
       linkBuilder.setODLinkDirection(ODLinkMill.oDBiDirBuilder().build()); // bidirektional
     else if (direction == AssocDirection.LeftToRight) {
@@ -129,10 +132,10 @@ public class ODBuilder implements IODBuilder {
     else if (direction == AssocDirection.RightToLeft) {
       linkBuilder.setODLinkDirection(ODLinkMill.oDRightToLeftDirBuilder().build());
     }
-    
+
     linkBuilder.setLink(true); // nur links
-    
+
     return linkBuilder.build();
   }
-  
+
 }

--- a/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/Package.java
+++ b/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/Package.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.syn2semdiff.odgen;
 
+import com.google.common.base.Verify;
 import de.monticore.cdassociation._ast.ASTCDAssociation;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDClass;
@@ -16,7 +17,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class Package {
-  
+
   private final ASTODObject leftObject;
   private final boolean isProcessedLeft;
   private final ASTODObject rightObject;
@@ -26,7 +27,7 @@ public class Package {
   private final ClassSide side;
   private final ODBuilder ODBuilder = new ODBuilder();
   private final ODGenHelper odGenHelper;
-  
+
   public Package(ASTCDClass leftObject, String idSrc, ASTCDClass rightObject, String idTgt,
       ASTCDAssociation association, ClassSide side, boolean isProcessedLeft,
       boolean isProcessedRight, Syn2SemDiffHelper helper, ODGenHelper odGenHelper) {
@@ -36,28 +37,28 @@ public class Package {
     this.rightObject = ODBuilder.buildObj(idTgt, rightObject.getSymbol().getInternalQualifiedName(),
         odGenHelper.getSuperTypes(rightObject), getAttributesOD(rightObject, helper));
     this.association = ODBuilder.buildLink(this.leftObject, CDDiffUtil.inferRole(association
-        .getLeft()), CDDiffUtil.inferRole(association.getRight()), this.rightObject, Objects
-            .requireNonNull(Syn2SemDiffHelper.getDirection(association)));
+        .getLeft()), CDDiffUtil.inferRole(association.getRight()), this.rightObject, Verify
+            .verifyNotNull(Syn2SemDiffHelper.getDirection(association)));
     this.astcdAssociation = association;
     this.side = side;
     this.isProcessedLeft = isProcessedLeft;
     this.isProcessedRight = isProcessedRight;
   }
-  
+
   public Package(ASTODObject leftObject, ASTODObject rightObject, ASTCDAssociation association,
       ClassSide side, boolean isProcessedLeft, boolean isProcessedRight, ODGenHelper odGenHelper) {
     this.leftObject = leftObject;
     this.rightObject = rightObject;
     this.association = ODBuilder.buildLink(this.leftObject, CDDiffUtil.inferRole(association
-        .getLeft()), CDDiffUtil.inferRole(association.getRight()), this.rightObject, Objects
-            .requireNonNull(Syn2SemDiffHelper.getDirection(association)));
+        .getLeft()), CDDiffUtil.inferRole(association.getRight()), this.rightObject, Verify
+            .verifyNotNull(Syn2SemDiffHelper.getDirection(association)));
     this.astcdAssociation = association;
     this.side = side;
     this.isProcessedLeft = isProcessedLeft;
     this.isProcessedRight = isProcessedRight;
     this.odGenHelper = null;
   }
-  
+
   public Package(ASTCDClass leftObject, String idSrc, ASTODObject rightObject,
       ASTCDAssociation association, ClassSide side, boolean isProcessedLeft,
       boolean isProcessedRight, Syn2SemDiffHelper helper, ODGenHelper odGenHelper) {
@@ -66,14 +67,14 @@ public class Package {
         odGenHelper.getSuperTypes(leftObject), getAttributesOD(leftObject, helper));
     this.rightObject = rightObject;
     this.association = ODBuilder.buildLink(this.leftObject, CDDiffUtil.inferRole(association
-        .getLeft()), CDDiffUtil.inferRole(association.getRight()), this.rightObject, Objects
-            .requireNonNull(Syn2SemDiffHelper.getDirection(association)));
+        .getLeft()), CDDiffUtil.inferRole(association.getRight()), this.rightObject, Verify
+            .verifyNotNull(Syn2SemDiffHelper.getDirection(association)));
     this.astcdAssociation = association;
     this.side = side;
     this.isProcessedLeft = isProcessedLeft;
     this.isProcessedRight = isProcessedRight;
   }
-  
+
   public Package(ASTODObject leftObject, ASTCDClass rightObject, String idTgt,
       ASTCDAssociation association, ClassSide side, boolean isProcessedLeft,
       boolean isProcessedRight, Syn2SemDiffHelper helper, ODGenHelper odGenHelper) {
@@ -82,14 +83,14 @@ public class Package {
     this.rightObject = ODBuilder.buildObj(idTgt, rightObject.getSymbol().getInternalQualifiedName(),
         odGenHelper.getSuperTypes(rightObject), getAttributesOD(rightObject, helper));
     this.association = ODBuilder.buildLink(this.leftObject, CDDiffUtil.inferRole(association
-        .getLeft()), CDDiffUtil.inferRole(association.getRight()), this.rightObject, Objects
-            .requireNonNull(Syn2SemDiffHelper.getDirection(association)));
+        .getLeft()), CDDiffUtil.inferRole(association.getRight()), this.rightObject, Verify
+            .verifyNotNull(Syn2SemDiffHelper.getDirection(association)));
     this.astcdAssociation = association;
     this.side = side;
     this.isProcessedLeft = isProcessedLeft;
     this.isProcessedRight = isProcessedRight;
   }
-  
+
   public Package(ASTODObject leftObject, ODGenHelper odGenHelper) {
     this.leftObject = leftObject;
     this.rightObject = null;
@@ -100,7 +101,7 @@ public class Package {
     this.isProcessedRight = false;
     this.odGenHelper = odGenHelper;
   }
-  
+
   public Package(ASTCDClass astcdClass, String id, Syn2SemDiffHelper helper,
       ODGenHelper odGenHelper) {
     this.odGenHelper = odGenHelper;
@@ -113,21 +114,21 @@ public class Package {
     this.isProcessedLeft = false;
     this.isProcessedRight = false;
   }
-  
+
   public ASTODObject getLeftObject() { return leftObject; }
-  
+
   public ASTODObject getRightObject() { return rightObject; }
-  
+
   public ASTODLink getAssociation() { return association; }
-  
+
   public ASTCDAssociation getAstcdAssociation() { return astcdAssociation; }
-  
+
   public ClassSide getSide() { return side; }
-  
+
   public boolean isProcessedLeft() { return isProcessedLeft; }
-  
+
   public boolean isProcessedRight() { return isProcessedRight; }
-  
+
   public List<ASTODAttribute> getAttributesOD(ASTCDClass astcdClass, Syn2SemDiffHelper helper) {
     List<ASTCDAttribute> attributes = helper.getAllAttr(astcdClass).b;
     List<ASTODAttribute> odAttributes = new ArrayList<>();
@@ -144,5 +145,5 @@ public class Package {
     }
     return odAttributes;
   }
-  
+
 }

--- a/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/Package.java
+++ b/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/Package.java
@@ -14,10 +14,9 @@ import de.monticore.odlink._ast.ASTODLink;
 import edu.mit.csail.sdg.alloy4.Pair;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public class Package {
-
+  
   private final ASTODObject leftObject;
   private final boolean isProcessedLeft;
   private final ASTODObject rightObject;
@@ -27,7 +26,7 @@ public class Package {
   private final ClassSide side;
   private final ODBuilder ODBuilder = new ODBuilder();
   private final ODGenHelper odGenHelper;
-
+  
   public Package(ASTCDClass leftObject, String idSrc, ASTCDClass rightObject, String idTgt,
       ASTCDAssociation association, ClassSide side, boolean isProcessedLeft,
       boolean isProcessedRight, Syn2SemDiffHelper helper, ODGenHelper odGenHelper) {
@@ -44,7 +43,7 @@ public class Package {
     this.isProcessedLeft = isProcessedLeft;
     this.isProcessedRight = isProcessedRight;
   }
-
+  
   public Package(ASTODObject leftObject, ASTODObject rightObject, ASTCDAssociation association,
       ClassSide side, boolean isProcessedLeft, boolean isProcessedRight, ODGenHelper odGenHelper) {
     this.leftObject = leftObject;
@@ -58,7 +57,7 @@ public class Package {
     this.isProcessedRight = isProcessedRight;
     this.odGenHelper = null;
   }
-
+  
   public Package(ASTCDClass leftObject, String idSrc, ASTODObject rightObject,
       ASTCDAssociation association, ClassSide side, boolean isProcessedLeft,
       boolean isProcessedRight, Syn2SemDiffHelper helper, ODGenHelper odGenHelper) {
@@ -74,7 +73,7 @@ public class Package {
     this.isProcessedLeft = isProcessedLeft;
     this.isProcessedRight = isProcessedRight;
   }
-
+  
   public Package(ASTODObject leftObject, ASTCDClass rightObject, String idTgt,
       ASTCDAssociation association, ClassSide side, boolean isProcessedLeft,
       boolean isProcessedRight, Syn2SemDiffHelper helper, ODGenHelper odGenHelper) {
@@ -90,7 +89,7 @@ public class Package {
     this.isProcessedLeft = isProcessedLeft;
     this.isProcessedRight = isProcessedRight;
   }
-
+  
   public Package(ASTODObject leftObject, ODGenHelper odGenHelper) {
     this.leftObject = leftObject;
     this.rightObject = null;
@@ -101,7 +100,7 @@ public class Package {
     this.isProcessedRight = false;
     this.odGenHelper = odGenHelper;
   }
-
+  
   public Package(ASTCDClass astcdClass, String id, Syn2SemDiffHelper helper,
       ODGenHelper odGenHelper) {
     this.odGenHelper = odGenHelper;
@@ -114,21 +113,21 @@ public class Package {
     this.isProcessedLeft = false;
     this.isProcessedRight = false;
   }
-
+  
   public ASTODObject getLeftObject() { return leftObject; }
-
+  
   public ASTODObject getRightObject() { return rightObject; }
-
+  
   public ASTODLink getAssociation() { return association; }
-
+  
   public ASTCDAssociation getAstcdAssociation() { return astcdAssociation; }
-
+  
   public ClassSide getSide() { return side; }
-
+  
   public boolean isProcessedLeft() { return isProcessedLeft; }
-
+  
   public boolean isProcessedRight() { return isProcessedRight; }
-
+  
   public List<ASTODAttribute> getAttributesOD(ASTCDClass astcdClass, Syn2SemDiffHelper helper) {
     List<ASTCDAttribute> attributes = helper.getAllAttr(astcdClass).b;
     List<ASTODAttribute> odAttributes = new ArrayList<>();
@@ -145,5 +144,5 @@ public class Package {
     }
     return odAttributes;
   }
-
+  
 }

--- a/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/Syn2SemDiffHelper.java
+++ b/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/Syn2SemDiffHelper.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cddiff.syn2semdiff.odgen;
 
+import com.google.common.base.Verify;
 import com.google.common.collect.ArrayListMultimap;
 import de.monticore.cd.facade.MCQualifiedNameFacade;
 import de.monticore.cd4code.CD4CodeMill;
@@ -43,93 +44,93 @@ import static de.monticore.cddiff.ow2cw.CDInheritanceHelper.isSuperOf;
  * is also implemented in this class.
  */
 public class Syn2SemDiffHelper {
-  
+
   public Syn2SemDiffHelper(CDSynDiffMatches matches) {
     this.matches = matches;
   }
-  
+
   private CDSynDiffMatches matches;
-  
+
   /**
    * Map with all possible associations (as AssocStructs) for classes from srcCD where the given
    * class serves as source. The non-instantiatable classes and associations are removed after the
    * function findOverlappingAssocs().
    */
   private ArrayListMultimap<ASTCDType, AssocStruct> srcMap;
-  
+
   /**
    * Map with all possible associations (as AssocStructs) for classes from trgCd where the given
    * class serves as target. The non-instantiatable classes and associations are removed after the
    * function findOverlappingAssocs().
    */
   private ArrayListMultimap<ASTCDType, AssocStruct> tgtMap;
-  
+
   /**
    * Map with all subclasses of a class from srcCD. This is used to reduce the complexity for
    * computing the underlying inheritance tree.
    */
   private ArrayListMultimap<ASTCDType, ASTCDClass> srcSubMap;
-  
+
   /**
    * Map with all subclasses of a class from trgCD. This is used to reduce the complexity for
    * computing the underlying inheritance tree.
    */
   private ArrayListMultimap<ASTCDType, ASTCDClass> tgtSubMap;
-  
+
   /**
    * Set with all classes that are not instantiatable in srcCD. Those are classes that cannot exist
    * because of overlapping. The second possibility is that the class has an attribute and a
    * relation to the same class, e.g., int age and -> (age) Age.
    */
   private Set<ASTCDType> notInstClassesSrc;
-  
+
   /**
    * Set with all classes that are not instantiatable in trgCD. Those are classes that cannot exist
    * because of overlapping. The second possibility is that the class has an attribute and a
    * relation to the same class, e.g., int age and -> (age) Age.
    */
   private Set<ASTCDType> notInstClassesTgt;
-  
+
   /**
    * This is a copy of the srcCD so that it can be accessed from all classes for semantic
    * difference.
    */
   private ASTCDCompilationUnit srcCD;
-  
+
   /**
    * This is a copy of the trgCD so that it can be accessed from all classes for semantic
    * difference.
    */
   private ASTCDCompilationUnit tgtCD;
-  
+
   /**
    * Those are the matched classes from the analysis of the syntax. This way some functionalities
    * were moved to this helper class.
    */
   private List<Pair<ASTCDClass, ASTCDType>> matchedClasses;
-  
+
   /**
    * Those are the matched interfaces from the analysis of the syntax. This way some functionalities
    * were moved to this helper class.
    */
   private List<Pair<ASTCDInterface, ASTCDType>> matchedInterfaces;
-  
+
   /**
    * Those are the added associations from the analysis of the syntax. This way some functionalities
    * were moved to this helper class.
    */
   private List<ASTCDAssociation> addedAssocs;
-  
+
   /**
    * Those are the deleted associations from the analysis of the syntax. This way some
    * functionalities were moved to this helper class.
    */
   private List<ASTCDAssociation> deletedAssocs;
-  
+
   private BooleanMatchingStrategy<ASTCDAssociation> matcher;
   private List<CDAssocDiff> diffs;
   private List<MatchingStrategy> matchingStrategies;
-  
+
   // CHECKED
   public boolean isAttContainedInClass(ASTCDAttribute attribute, ASTCDType astcdClass) {
     int indexAttribute = attribute.getMCType().printType().lastIndexOf(".");
@@ -157,74 +158,74 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   public void setMatchedClasses(List<Pair<ASTCDClass, ASTCDType>> matchedClasses) {
     this.matchedClasses = matchedClasses;
   }
-  
+
   public List<Pair<ASTCDClass, ASTCDType>> getMatchedClasses() { return matchedClasses; }
-  
+
   public void setDiffs(List<CDAssocDiff> diffs) { this.diffs = diffs; }
-  
+
   public List<CDAssocDiff> getDiffs() { return diffs; }
-  
+
   public ArrayListMultimap<ASTCDType, AssocStruct> getSrcMap() { return srcMap; }
-  
+
   public ArrayListMultimap<ASTCDType, AssocStruct> getTgtMap() { return tgtMap; }
-  
+
   public ASTCDCompilationUnit getSrcCD() { return srcCD; }
-  
+
   public void setSrcCD(ASTCDCompilationUnit srcCD) { this.srcCD = srcCD; }
-  
+
   public ASTCDCompilationUnit getTgtCD() { return tgtCD; }
-  
+
   public void setTgtCD(ASTCDCompilationUnit tgtCD) { this.tgtCD = tgtCD; }
-  
+
   public Set<ASTCDType> getNotInstClassesSrc() { return notInstClassesSrc; }
-  
+
   public Set<ASTCDType> getNotInstClassesTgt() { return notInstClassesTgt; }
-  
+
   public ArrayListMultimap<ASTCDType, ASTCDClass> getSrcSubMap() { return srcSubMap; }
-  
+
   public ArrayListMultimap<ASTCDType, ASTCDClass> getTgtSubMap() { return tgtSubMap; }
-  
+
   public void setNotInstClassesSrc(Set<ASTCDType> notInstClassesSrc) {
     this.notInstClassesSrc = notInstClassesSrc;
   }
-  
+
   public void setNotInstClassesTgt(Set<ASTCDType> notInstClassesTgt) {
     this.notInstClassesTgt = notInstClassesTgt;
   }
-  
+
   public void updateSrc(ASTCDType astcdClass) {
     notInstClassesSrc.add(astcdClass);
   }
-  
+
   public void updateTgt(ASTCDType astcdClass) {
     notInstClassesTgt.add(astcdClass);
   }
-  
+
   public void setDeletedAssocs(List<ASTCDAssociation> deletedAssocs) {
     this.deletedAssocs = deletedAssocs;
   }
-  
+
   public void setAddedAssocs(List<ASTCDAssociation> addedAssocs) { this.addedAssocs = addedAssocs; }
-  
+
   public List<Pair<ASTCDInterface, ASTCDType>> getMatchedInterfaces() { return matchedInterfaces; }
-  
+
   public void setMatchedInterfaces(List<Pair<ASTCDInterface, ASTCDType>> matchedInterfaces) {
     this.matchedInterfaces = matchedInterfaces;
   }
-  
+
   public void setMatchingStrategies(List<MatchingStrategy> matchingStrategies) {
     this.matchingStrategies = matchingStrategies;
   }
-  
+
   public boolean isSubclassWithSuper(ASTCDType superClass, ASTCDType subClass) {
     return isSuperOf(superClass.getSymbol().getInternalQualifiedName(), subClass.getSymbol()
         .getInternalQualifiedName(), srcCD);
   }
-  
+
   /**
    * Get all needed associations from the src/tgtMap that use the given class as target. The
    * associations are strictly unidirectional. Needed associations - the cardinality must be at
@@ -239,14 +240,14 @@ public class Syn2SemDiffHelper {
       boolean makeConditionStrict) {
     List<AssocStruct> list = new ArrayList<>();
     ArrayListMultimap<ASTCDType, AssocStruct> map = isSource ? srcMap : tgtMap;
-    
+
     for (ASTCDType classToCheck : map.keySet()) {
       if (classToCheck != astcdClass) {
         for (AssocStruct assocStruct : map.get(classToCheck)) {
           Pair<ASTCDType, ASTCDType> connectedTypes;
           connectedTypes = Syn2SemDiffHelper.getConnectedTypes(assocStruct.getAssociation(),
               isSource ? srcCD : tgtCD);
-          
+
           if (assocStruct.getSide().equals(ClassSide.Left) && !assocStruct.getDirection().equals(
               AssocDirection.BiDirectional) && (makeConditionStrict || assocStruct.getAssociation()
                   .getLeft().getCDCardinality().isOne() || assocStruct.getAssociation().getLeft()
@@ -265,7 +266,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-  
+
   /**
    * Get all needed associations (including superclasses) from the src/tgtMap that use the given
    * class as target. The associations are strictly unidirectional. Needed associations - the
@@ -278,26 +279,26 @@ public class Syn2SemDiffHelper {
     List<AssocStruct> list = new ArrayList<>();
     Set<ASTCDType> superTypes = CDDiffUtil.getAllSuperTypes(astcdClass, isSource ? srcCD
         .getCDDefinition() : tgtCD.getCDDefinition());
-    
+
     for (ASTCDType astcdClass1 : superTypes) {
       list.addAll(getOtherAssocs(astcdClass1, isSource, false));
     }
-    
+
     return list;
   }
-  
+
   public List<AssocStruct> getAllOtherAssocsSpecCase(ASTCDType astcdClass, boolean isSource) {
     List<AssocStruct> list = new ArrayList<>();
     Set<ASTCDType> superTypes = CDDiffUtil.getAllSuperTypes(astcdClass, isSource ? srcCD
         .getCDDefinition() : tgtCD.getCDDefinition());
-    
+
     for (ASTCDType astcdClass1 : superTypes) {
       list.addAll(getOtherAssocs(astcdClass1, isSource, true));
     }
-    
+
     return list;
   }
-  
+
   /**
    * Find matched type in srcCD.
    *
@@ -315,7 +316,7 @@ public class Syn2SemDiffHelper {
       return Optional.empty();
     }
   }
-  
+
   /**
    * Find matched type in tgtCD.
    *
@@ -333,7 +334,7 @@ public class Syn2SemDiffHelper {
       return Optional.empty();
     }
   }
-  
+
   public Optional<ASTCDType> findMatchedClass(ASTCDClass astcdClass) {
     for (Pair<ASTCDClass, ASTCDType> pair : matchedClasses) {
       if (pair.a.equals(astcdClass)) {
@@ -342,7 +343,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   public Optional<ASTCDType> findMatchedSrc(ASTCDClass astcdClass) {
     for (Pair<ASTCDClass, ASTCDType> pair : matchedClasses) {
       if (pair.b.equals(astcdClass)) {
@@ -351,7 +352,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   public Optional<ASTCDType> findMatchedTypeSrc(ASTCDInterface astcdInterface) {
     for (Pair<ASTCDInterface, ASTCDType> pair : matchedInterfaces) {
       if (pair.b.equals(astcdInterface)) {
@@ -360,7 +361,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   public Optional<ASTCDType> findMatchedTypeTgt(ASTCDInterface astcdInterface) {
     for (Pair<ASTCDInterface, ASTCDType> pair : matchedInterfaces) {
       if (pair.a.equals(astcdInterface)) {
@@ -369,7 +370,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   public static AssocDirection getDirection(ASTCDAssociation association) {
     if (association.getCDAssocDir() == null) {
       return AssocDirection.Unspecified;
@@ -384,7 +385,7 @@ public class Syn2SemDiffHelper {
       return AssocDirection.LeftToRight;
     }
   }
-  
+
   /**
    * When merging associations, the role names of the bidirectional association are used instead of
    * the role names of the unidirectional.
@@ -416,7 +417,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   /**
    * Merge the cardinalities and the direction of two associations.
    *
@@ -435,19 +436,19 @@ public class Syn2SemDiffHelper {
     association.getAssociation().setCDAssocDir(direction);
     association.setDirection(getDirection(association.getAssociation()));
     if (association.getSide().equals(ClassSide.Left)) {
-      association.getAssociation().getLeft().setCDCardinality(createCardinality(Objects
-          .requireNonNull(cardinalityLeft)));
-      association.getAssociation().getRight().setCDCardinality(createCardinality(Objects
-          .requireNonNull(cardinalityRight)));
+      association.getAssociation().getLeft().setCDCardinality(createCardinality(Verify
+          .verifyNotNull(cardinalityLeft)));
+      association.getAssociation().getRight().setCDCardinality(createCardinality(Verify
+          .verifyNotNull(cardinalityRight)));
     }
     else {
-      association.getAssociation().getLeft().setCDCardinality(createCardinality(Objects
-          .requireNonNull(cardinalityRight)));
-      association.getAssociation().getRight().setCDCardinality(createCardinality(Objects
-          .requireNonNull(cardinalityLeft)));
+      association.getAssociation().getLeft().setCDCardinality(createCardinality(Verify
+          .verifyNotNull(cardinalityRight)));
+      association.getAssociation().getRight().setCDCardinality(createCardinality(Verify
+          .verifyNotNull(cardinalityLeft)));
     }
   }
-  
+
   /**
    * Modified version of the function inConflict in CDAssociationHelper. In the map, all association
    * that can be created from a class are saved in the values for this class (key). Because of that
@@ -461,7 +462,7 @@ public class Syn2SemDiffHelper {
   public static boolean isInConflict(AssocStruct association, AssocStruct superAssociation) {
     ASTCDAssociation srcAssoc = association.getAssociation();
     ASTCDAssociation targetAssoc = superAssociation.getAssociation();
-    
+
     if (association.getSide().equals(ClassSide.Left) && superAssociation.getSide().equals(
         ClassSide.Left)) {
       return matchRoleNames(srcAssoc.getRight(), targetAssoc.getRight());
@@ -478,10 +479,10 @@ public class Syn2SemDiffHelper {
         ClassSide.Right)) {
       return matchRoleNames(srcAssoc.getLeft(), targetAssoc.getLeft());
     }
-    
+
     return false;
   }
-  
+
   /**
    * Given the two associations, get the role name that causes the conflict
    *
@@ -492,7 +493,7 @@ public class Syn2SemDiffHelper {
   public static ASTCDRole getConflict(AssocStruct association, AssocStruct superAssociation) {
     ASTCDAssociation srcAssoc = association.getAssociation();
     ASTCDAssociation targetAssoc = superAssociation.getAssociation();
-    
+
     if (association.getSide().equals(ClassSide.Left) && superAssociation.getSide().equals(
         ClassSide.Left) && matchRoleNames(srcAssoc.getRight(), targetAssoc.getRight())) {
       return srcAssoc.getRight().getCDRole();
@@ -509,7 +510,7 @@ public class Syn2SemDiffHelper {
       return srcAssoc.getLeft().getCDRole();
     }
   }
-  
+
   /**
    * Merge the directions of two associations
    *
@@ -520,20 +521,20 @@ public class Syn2SemDiffHelper {
   public static ASTCDAssocDir mergeAssocDir(AssocStruct association, AssocStruct superAssociation) {
     AssocDirection dir1 = association.getDirection();
     AssocDirection dir2 = superAssociation.getDirection();
-    
+
     if (dir1.equals(AssocDirection.BiDirectional) || dir2.equals(AssocDirection.BiDirectional)) {
       return CD4CodeMill.cDBiDirBuilder().build();
     }
-    
+
     ClassSide side1 = association.getSide();
     ClassSide side2 = superAssociation.getSide();
-    
+
     boolean sameLogicalDirection = (dir1 == dir2 && side1 == side2) || (dir1
         == AssocDirection.LeftToRight && dir2 == AssocDirection.RightToLeft && side1
             == ClassSide.Left && side2 == ClassSide.Right) || (dir1 == AssocDirection.RightToLeft
                 && dir2 == AssocDirection.LeftToRight && side1 == ClassSide.Right && side2
                     == ClassSide.Left);
-    
+
     if (sameLogicalDirection) {
       switch (dir1) {
         case LeftToRight:
@@ -542,10 +543,10 @@ public class Syn2SemDiffHelper {
           return CD4CodeMill.cDRightToLeftDirBuilder().build();
       }
     }
-    
+
     return CD4CodeMill.cDBiDirBuilder().build();
   }
-  
+
   /**
    * Group corresponding cardinalities
    *
@@ -583,7 +584,7 @@ public class Syn2SemDiffHelper {
               .getAssociation().getLeft().getCDCardinality()));
     }
   }
-  
+
   /**
    * Transform the internal cardinality to original
    *
@@ -604,7 +605,7 @@ public class Syn2SemDiffHelper {
       return new ASTCDCardMult();
     }
   }
-  
+
   /**
    * Check if the associations allow 0 objects from target class
    *
@@ -616,15 +617,15 @@ public class Syn2SemDiffHelper {
     ASTCDCardinality assocCardinality = association.getSide().equals(ClassSide.Left) ? association
         .getAssociation().getRight().getCDCardinality() : association.getAssociation().getLeft()
             .getCDCardinality();
-    
+
     ASTCDCardinality superAssocCardinality = superAssociation.getSide().equals(ClassSide.Left)
         ? superAssociation.getAssociation().getRight().getCDCardinality() : superAssociation
             .getAssociation().getLeft().getCDCardinality();
-    
+
     return (assocCardinality.isMult() || assocCardinality.isOpt()) && (superAssocCardinality
         .isMult() || superAssocCardinality.isOpt());
   }
-  
+
   public boolean isAdded(AssocStruct assocStruct, AssocStruct assocStruct2, ASTCDType astcdClass,
       Set<DeleteStruct> set) {
     for (DeleteStruct deleteStruct : set) {
@@ -637,7 +638,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Similar to the function above, but the now the classes must be the target of the association.
    *
@@ -663,7 +664,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   /**
    * Check if all matched subclasses in tgtCD/srcCD of a class from srcCD/tgtCD have the same
    * association or a subassociation.
@@ -676,12 +677,12 @@ public class Syn2SemDiffHelper {
       boolean isSource) {
     List<ASTCDClass> subClasses = isSource ? tgtSubMap.get(type) : srcSubMap.get(type);
     List<ASTCDType> subTypes = getTypes(subClasses, isSource);
-    
+
     for (ASTCDType subClass : subTypes) {
       boolean isContained = false;
       List<AssocStruct> assocList = isSource ? srcMap.get(subClass) : getAllOtherAssocs(subClass,
           false);
-      
+
       for (AssocStruct assocStruct : assocList) {
         if (isSource) {
           if (sameAssociationTypeSrcTgt(assocStruct, association)) {
@@ -696,14 +697,14 @@ public class Syn2SemDiffHelper {
           }
         }
       }
-      
+
       if (!isContained) {
         return Optional.ofNullable(subClass);
       }
     }
     return Optional.empty();
   }
-  
+
   /**
    * Check if all matched subclasses in srcCD of a class from trgCD are target of the same
    * association.
@@ -729,7 +730,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   /**
    * Check if the classes are in an inheritance relation. For this, the matched classes in
    * srcCD/tgtCD of the tgtClass/srcClass are compared with isSuper() to the srcClass.
@@ -743,7 +744,7 @@ public class Syn2SemDiffHelper {
         type2);
     Optional<ASTCDType> type1Matched = isSource ? findMatchedTypeTgt(type1) : findMatchedTypeSrc(
         type1);
-    
+
     return typeToMatch.filter(astcdType -> isSuperOf(astcdType.getSymbol()
         .getInternalQualifiedName(), type1.getSymbol().getInternalQualifiedName(),
         (ICD4CodeArtifactScope) (isSource ? srcCD.getEnclosingScope() : tgtCD.getEnclosingScope())))
@@ -752,7 +753,7 @@ public class Syn2SemDiffHelper {
                 type1Matched.get())) : (typeToMatch.isPresent() && srcSubMap.get(type1).contains(
                     typeToMatch.get())));
   }
-  
+
   /**
    * Check if the srcType has the given association from srcCD.
    *
@@ -768,7 +769,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Check if the srcType has the given association from tgtCD.
    *
@@ -784,7 +785,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   public boolean classHasAssociationTgtSrcRev(AssocStruct tgtStruct, ASTCDType srcType) {
     for (AssocStruct assocStruct1 : srcMap.get(srcType)) {
       if (sameAssociationTypeSrcTgtRev(assocStruct1, tgtStruct)) {
@@ -793,7 +794,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Check if the tgtType has the given association from srcCD.
    *
@@ -809,7 +810,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Check if the srcType is target of the given association from srcCD.
    *
@@ -825,7 +826,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Check if the tgtType is target of the given association from srcCD.
    *
@@ -841,7 +842,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Check if the srcType is target of the given association from tgtCD.
    *
@@ -857,7 +858,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   public boolean classIsTargetTgtSrcRev(AssocStruct association, ASTCDType srcType) {
     for (AssocStruct assocStruct : getAllOtherAssocs(srcType, true)) {
       if (sameAssociationTypeSrcTgtRev(assocStruct, association)) {
@@ -866,10 +867,10 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   public List<ASTCDType> getTypes(List<? extends ASTCDType> types, boolean isSource) {
     List<ASTCDType> resultTypes = new ArrayList<>();
-    
+
     for (ASTCDType astcdType : types) {
       if (astcdType instanceof ASTCDClass) {
         Optional<ASTCDType> matched = isSource ? findMatchedSrc((ASTCDClass) astcdType)
@@ -884,7 +885,7 @@ public class Syn2SemDiffHelper {
     }
     return resultTypes;
   }
-  
+
   /**
    * Check if two associations are exactly the same.
    *
@@ -907,7 +908,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Check if the target classes of the two associations are in an inheritance relation
    *
@@ -942,7 +943,7 @@ public class Syn2SemDiffHelper {
           (ICD4CodeArtifactScope) compilationUnit.getEnclosingScope());
     }
   }
-  
+
   public boolean inheritanceTgt(AssocStruct assocStruct, AssocStruct assocStruct1) {
     if (assocStruct.getSide().equals(ClassSide.Left) && assocStruct1.getSide().equals(
         ClassSide.Left)) {
@@ -964,7 +965,7 @@ public class Syn2SemDiffHelper {
           getConnectedTypes(assocStruct.getAssociation(), srcCD).a, false);
     }
   }
-  
+
   /**
    * Get all attributes that need to be added from inheritance structure to an object of a given
    * type
@@ -983,7 +984,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(astcdClass, attributes);
   }
-  
+
   public Pair<ASTCDType, List<ASTCDAttribute>> getAllAttrTgt(ASTCDType astcdClass) {
     List<ASTCDAttribute> attributes = new ArrayList<>();
     Set<ASTCDType> classes = getAllSuper(astcdClass, (ICD4CodeArtifactScope) tgtCD
@@ -995,7 +996,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(astcdClass, attributes);
   }
-  
+
   /**
    * Check if the srcAssoc has the same type as the srcAssoc1 - direction, role names and the
    * cardinalities of srcAssoc are sub-intervals of the cardinalities of srcAssoc1.
@@ -1014,7 +1015,7 @@ public class Syn2SemDiffHelper {
       return compareAssociations(srcAssocSuper, srcAssocSub, false);
     }
   }
-  
+
   private boolean compareAssociations(AssocStruct superAssoc, AssocStruct subAssoc,
       boolean sameSides) {
     // Compare role names, cardinality, and direction for both sides (left and right)
@@ -1044,7 +1045,7 @@ public class Syn2SemDiffHelper {
                                                                     .getAssociation().getLeft()
                                                                     .getCDCardinality()));
   }
-  
+
   /**
    * Check if the srcAssoc has the same type as the tgtAssoc - direction, role names and the
    * cardinalities of srcAssoc are sub-intervals of the cardinalities of tgtAssoc.
@@ -1062,7 +1063,7 @@ public class Syn2SemDiffHelper {
         .equals(ClassSide.Right);
     boolean isRightLeft = srcAssocSub.getSide().equals(ClassSide.Right) && tgtAssocSuper.getSide()
         .equals(ClassSide.Left);
-    
+
     if (isLeftLeft || isRightRight) {
       return matchRoleNames(srcAssocSub.getAssociation().getLeft(), tgtAssocSuper.getAssociation()
           .getLeft()) && matchRoleNames(srcAssocSub.getAssociation().getRight(), tgtAssocSuper
@@ -1097,10 +1098,10 @@ public class Syn2SemDiffHelper {
                                                       .getAssociation().getLeft()
                                                       .getCDCardinality()));
     }
-    
+
     return false;
   }
-  
+
   public boolean sameAssociationTypeSrcTgtRev(AssocStruct srcAssocSub, AssocStruct tgtAssocSuper) {
     boolean isLeftLeft = srcAssocSub.getSide().equals(ClassSide.Left) && tgtAssocSuper.getSide()
         .equals(ClassSide.Left);
@@ -1110,7 +1111,7 @@ public class Syn2SemDiffHelper {
         .equals(ClassSide.Right);
     boolean isRightLeft = srcAssocSub.getSide().equals(ClassSide.Right) && tgtAssocSuper.getSide()
         .equals(ClassSide.Left);
-    
+
     if (isLeftRight || isRightLeft) {
       return matchRoleNames(srcAssocSub.getAssociation().getLeft(), tgtAssocSuper.getAssociation()
           .getLeft()) && matchRoleNames(srcAssocSub.getAssociation().getRight(), tgtAssocSuper
@@ -1145,10 +1146,10 @@ public class Syn2SemDiffHelper {
                                                       .getAssociation().getLeft()
                                                       .getCDCardinality()));
     }
-    
+
     return false;
   }
-  
+
   /**
    * Given the following two cardinalities, find their intersection
    *
@@ -1202,7 +1203,7 @@ public class Syn2SemDiffHelper {
     }
     return null;
   }
-  
+
   /**
    * This is the same function from CDDefinition, but it compares the classes based on the qualified
    * name of the class.
@@ -1214,7 +1215,7 @@ public class Syn2SemDiffHelper {
     List<ASTCDAssociation> result = new ArrayList<>();
     List<ASTCDAssociation> associationsList = isSource ? srcCD.getCDDefinition()
         .getCDAssociationsList() : tgtCD.getCDDefinition().getCDAssociationsList();
-    
+
     for (ASTCDAssociation association : associationsList) {
       if (association.getLeftQualifiedName().getQName().equals(type.getSymbol()
           .getInternalQualifiedName()) && association.getCDAssocDir()
@@ -1228,7 +1229,7 @@ public class Syn2SemDiffHelper {
     }
     return result;
   }
-  
+
   /**
    * Compute what associations can be used from a class (associations that were from the class and
    * superAssociations). For each class and each possible association we save the direction and also
@@ -1244,28 +1245,28 @@ public class Syn2SemDiffHelper {
     findNonInstantiableClasses();
     checkRoleNameConflicts();
   }
-  
+
   private void processSourceTypes() {
     List<ASTCDType> srcTypes = getTypes(srcCD);
     for (ASTCDType astcdClass : srcTypes) {
       processAssociations(astcdClass, getCDAssociationsListForType(astcdClass, true), true);
     }
   }
-  
+
   private void processTargetTypes() {
     List<ASTCDType> tgtTypes = getTypes(tgtCD);
     for (ASTCDType astcdClass : tgtTypes) {
       processAssociations(astcdClass, getCDAssociationsListForType(astcdClass, false), false);
     }
   }
-  
+
   private List<ASTCDType> getTypes(ASTCDCompilationUnit compilationUnit) {
     List<ASTCDType> types = new ArrayList<>();
     types.addAll(compilationUnit.getCDDefinition().getCDClassesList());
     types.addAll(compilationUnit.getCDDefinition().getCDInterfacesList());
     return types;
   }
-  
+
   private void processAssociations(ASTCDType astcdClass, List<ASTCDAssociation> associations,
       boolean isSource) {
     for (ASTCDAssociation astcdAssociation : associations) {
@@ -1273,10 +1274,10 @@ public class Syn2SemDiffHelper {
           : tgtCD);
       if (pair.a == null)
         continue;
-      
+
       ASTCDAssociation copyAssoc = createVirtualAssociation(astcdAssociation);
       updateAssociationRoles(copyAssoc, astcdAssociation);
-      
+
       if (isSource) {
         handleAssociationMapping(astcdClass, astcdAssociation, pair, copyAssoc, srcMap);
       }
@@ -1285,14 +1286,14 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   private ASTCDAssociation createVirtualAssociation(ASTCDAssociation original) {
     ASTCDAssociation copyAssoc = original.deepClone();
     copyAssoc.setName(" ");
     ensureCardinalities(copyAssoc);
     return copyAssoc;
   }
-  
+
   private void ensureCardinalities(ASTCDAssociation assoc) {
     if (!assoc.getLeft().isPresentCDCardinality()) {
       assoc.getLeft().setCDCardinality(CD4CodeMill.cDCardMultBuilder().build());
@@ -1304,14 +1305,14 @@ public class Syn2SemDiffHelper {
       assoc.getLeft().setCDCardinality(CD4CodeMill.cDCardOneBuilder().build());
     }
   }
-  
+
   private void updateAssociationRoles(ASTCDAssociation copyAssoc, ASTCDAssociation original) {
     copyAssoc.getLeft().setCDRole(CD4CodeMill.cDRoleBuilder().setName(CDDiffUtil.inferRole(original
         .getLeft())).build());
     copyAssoc.getRight().setCDRole(CD4CodeMill.cDRoleBuilder().setName(CDDiffUtil.inferRole(original
         .getRight())).build());
   }
-  
+
   private void handleAssociationMapping(ASTCDType astcdClass, ASTCDAssociation original,
       Pair<ASTCDType, ASTCDType> pair, ASTCDAssociation copyAssoc,
       ArrayListMultimap<ASTCDType, AssocStruct> map) {
@@ -1326,7 +1327,7 @@ public class Syn2SemDiffHelper {
           false, null));
     }
   }
-  
+
   private AssocStruct createAssocStruct(ASTCDAssociation assoc, ASTCDAssociation original,
       ASTCDType astcdType, ASTCDType connectedType, ClassSide side, Boolean isSuperAssoc,
       ASTCDType superClass) {
@@ -1336,34 +1337,34 @@ public class Syn2SemDiffHelper {
     }
     return new AssocStruct(assoc, direction, side, true, superClass, connectedType, original);
   }
-  
+
   private AssocDirection determineAssocDirection(ASTCDAssociation assoc, ClassSide side) {
     if (assoc.getCDAssocDir().isBidirectional()) {
       return AssocDirection.BiDirectional;
     }
     return side == ClassSide.Left ? AssocDirection.LeftToRight : AssocDirection.RightToLeft;
   }
-  
+
   private void inheritAssociations(ASTCDCompilationUnit compilationUnit, boolean isSource) {
     List<ASTCDType> types = getTypes(compilationUnit);
     for (ASTCDType astcdClass : types) {
       Set<ASTCDType> superTypes = CDDiffUtil.getAllSuperTypes(astcdClass, compilationUnit
           .getCDDefinition());
       superTypes.remove(astcdClass);
-      
+
       for (ASTCDType superClass : superTypes) {
         List<ASTCDAssociation> associations = getCDAssociationsListForType(superClass, isSource);
         for (ASTCDAssociation assoc : associations) {
           Pair<ASTCDType, ASTCDType> pair = getConnectedTypes(assoc, compilationUnit);
           if (pair.a == null)
             continue;
-          
+
           processInheritedAssociation(astcdClass, assoc, superClass, pair, isSource);
         }
       }
     }
   }
-  
+
   private void processInheritedAssociation(ASTCDType subClass, ASTCDAssociation assoc,
       ASTCDType superClass, Pair<ASTCDType, ASTCDType> pair, boolean isSource) {
     ArrayListMultimap<ASTCDType, AssocStruct> map = isSource ? srcMap : tgtMap;
@@ -1380,14 +1381,14 @@ public class Syn2SemDiffHelper {
           superClass));
     }
   }
-  
+
   private ASTCDAssociation createInheritedAssoc(ASTCDAssociation original, ASTCDType subClass,
       ClassSide side) {
     ASTCDAssociation assoc = original.deepClone();
     assoc.setName(" ");
     updateAssociationRoles(assoc, original);
     ensureCardinalities(assoc);
-    
+
     if (side == ClassSide.Left) {
       assoc.getLeft().setMCQualifiedType(createQualifiedType(subClass));
     }
@@ -1396,17 +1397,17 @@ public class Syn2SemDiffHelper {
     }
     return assoc;
   }
-  
+
   private ASTMCQualifiedType createQualifiedType(ASTCDType type) {
     return CD4CodeMill.mCQualifiedTypeBuilder().setMCQualifiedName(MCQualifiedNameFacade
         .createQualifiedName(type.getSymbol().getInternalQualifiedName())).build();
   }
-  
+
   private void findNonInstantiableClasses() {
     findDuplicateAttributes(srcCD, notInstClassesSrc, true);
     findDuplicateAttributes(tgtCD, notInstClassesTgt, false);
   }
-  
+
   private void findDuplicateAttributes(ASTCDCompilationUnit compilationUnit,
       Set<ASTCDType> notInstClasses, boolean isSource) {
     for (ASTCDClass astcdClass : compilationUnit.getCDDefinition().getCDClassesList()) {
@@ -1424,12 +1425,12 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   private void checkRoleNameConflicts() {
     checkRoleNameConflicts(srcCD, notInstClassesSrc, true);
     checkRoleNameConflicts(tgtCD, notInstClassesTgt, false);
   }
-  
+
   private void checkRoleNameConflicts(ASTCDCompilationUnit compilationUnit,
       Set<ASTCDType> notInstClasses, boolean isSource) {
     for (ASTCDClass astcdClass : compilationUnit.getCDDefinition().getCDClassesList()) {
@@ -1443,7 +1444,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   /** Compute the subtypes for each type in the diagrams. */
   public void setSubMaps() {
     srcSubMap = ArrayListMultimap.create();
@@ -1453,13 +1454,13 @@ public class Syn2SemDiffHelper {
         srcSubMap.put(astcdClass, subClass);
       }
     }
-    
+
     for (ASTCDClass astcdClass : tgtCD.getCDDefinition().getCDClassesList()) {
       for (ASTCDClass subClass : getSpannedInheritance(tgtCD, astcdClass)) {
         tgtSubMap.put(astcdClass, subClass);
       }
     }
-    
+
     List<ASTCDInterface> interfaces = srcCD.getCDDefinition().getCDInterfacesList();
     for (ASTCDInterface astcdInterface : interfaces) {
       for (ASTCDClass astcdClass : srcCD.getCDDefinition().getCDClassesList()) {
@@ -1479,13 +1480,13 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   // Helper method to process interfaces and classes for superclass relationship
   private void processInterfacesAndClasses(ASTCDCompilationUnit cdUnit,
       ArrayListMultimap<ASTCDType, ASTCDClass> subMap) {
     List<ASTCDInterface> interfaces = cdUnit.getCDDefinition().getCDInterfacesList();
     List<ASTCDClass> classes = cdUnit.getCDDefinition().getCDClassesList();
-    
+
     for (ASTCDInterface astcdInterface : interfaces) {
       for (ASTCDClass astcdClass : classes) {
         if (CDInheritanceHelper.isSuperOf(astcdInterface.getSymbol().getInternalQualifiedName(),
@@ -1495,14 +1496,14 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   private boolean sameRoleNameAndClass(String roleName, ASTCDClass astcdClass, boolean isSource) {
     String roleName1 = roleName.substring(0, 1).toUpperCase() + roleName.substring(1);
-    
+
     // Determine which map and CD to use based on whether it's source or target
     ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
     ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-    
+
     for (AssocStruct assocStruct : mapToUse.get(astcdClass)) {
       if (assocStruct.getSide().equals(ClassSide.Left)) {
         if (CDDiffUtil.inferRole(assocStruct.getAssociation().getRight()).equals(roleName)
@@ -1521,7 +1522,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Get the classes that are connected with the association. The function returns null if the
    * associated objects aren't classes.
@@ -1542,7 +1543,7 @@ public class Syn2SemDiffHelper {
     Log.error("Could not resolve types of :" + CD4CodeMill.prettyPrint(association, false));
     return new Pair<>(null, null);
   }
-  
+
   /**
    * Compute the types that extend a given class.
    *
@@ -1563,7 +1564,7 @@ public class Syn2SemDiffHelper {
     subclasses.remove(astcdClass);
     return subclasses;
   }
-  
+
   /**
    * Check if the first cardinality is contained in the second cardinality.
    *
@@ -1588,7 +1589,7 @@ public class Syn2SemDiffHelper {
       return false;
     }
   }
-  
+
   public static AssocCardinality cardToEnum(ASTCDCardinality cardinality) {
     if (cardinality.isOne()) {
       return AssocCardinality.One;
@@ -1603,7 +1604,7 @@ public class Syn2SemDiffHelper {
       return AssocCardinality.Multiple;
     }
   }
-  
+
   /**
    * Get the minimal non-abstract subclass(strict subclass) of a given type. The minimal subclass is
    * the subclass with the least amount of attributes and associations(ingoing and outgoing).
@@ -1615,11 +1616,11 @@ public class Syn2SemDiffHelper {
   public Optional<ASTCDClass> minSubClass(ASTCDType baseClass, boolean isSource) {
     ArrayListMultimap<ASTCDType, ASTCDClass> subMap = isSource ? srcSubMap : tgtSubMap;
     Set<ASTCDType> notInstClasses = isSource ? notInstClassesSrc : notInstClassesTgt;
-    
+
     List<ASTCDClass> subClasses = subMap.get(baseClass);
     int lowestCount = Integer.MAX_VALUE;
     ASTCDClass subclassWithLowestCount = null;
-    
+
     for (ASTCDClass subclass : subClasses) {
       if (!subclass.getModifier().isAbstract() && !notInstClasses.contains(subclass)) {
         int attributeCount;
@@ -1632,23 +1633,23 @@ public class Syn2SemDiffHelper {
         int associationCount = getAssociationCount(subclass, isSource);
         int otherAssocsCount = getAllOtherAssocs(subclass, isSource).size();
         int totalCount = attributeCount + associationCount + otherAssocsCount;
-        
+
         if (totalCount < lowestCount) {
           lowestCount = totalCount;
           subclassWithLowestCount = subclass;
         }
       }
     }
-    
+
     return Optional.ofNullable(subclassWithLowestCount);
   }
-  
+
   public int getAssociationCount(ASTCDType astcdClass, boolean isSource) {
     int count = 0;
     // Determine which map and CD to use based on whether it's source or target
     ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
     ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-    
+
     for (AssocStruct assocStruct : mapToUse.get(astcdClass)) {
       if (assocStruct.getSide().equals(ClassSide.Left)) {
         if ((assocStruct.getAssociation().getRight().getCDCardinality().isAtLeastOne()
@@ -1671,7 +1672,7 @@ public class Syn2SemDiffHelper {
     }
     return count;
   }
-  
+
   /**
    * Check if the directions match in reverse.
    *
@@ -1697,7 +1698,7 @@ public class Syn2SemDiffHelper {
                           AssocDirection.RightToLeft) && tgtStruct.a.getDirection().equals(
                               AssocDirection.LeftToRight)));
   }
-  
+
   public static boolean matchDirection(AssocStruct srcStruct,
       Pair<AssocStruct, ClassSide> tgtStruct) {
     if (((srcStruct.getSide().equals(ClassSide.Left) && tgtStruct.b.equals(ClassSide.Left))
@@ -1715,7 +1716,7 @@ public class Syn2SemDiffHelper {
                           AssocDirection.RightToLeft) && tgtStruct.a.getDirection().equals(
                               AssocDirection.LeftToRight)));
   }
-  
+
   public boolean sameAssocStruct(AssocStruct srcStruct, AssocStruct tgtStruct) {
     return CDDiffUtil.inferRole(srcStruct.getAssociation().getLeft()).equals(CDDiffUtil.inferRole(
         tgtStruct.getAssociation().getLeft())) && CDDiffUtil.inferRole(srcStruct.getAssociation()
@@ -1725,7 +1726,7 @@ public class Syn2SemDiffHelper {
         && matchRoleNames(srcStruct.getAssociation().getRight(), tgtStruct.getAssociation()
             .getRight());
   }
-  
+
   public boolean sameAssocStructInReverse(AssocStruct struct, AssocStruct tgtStruct) {
     return CDDiffUtil.inferRole(struct.getAssociation().getLeft()).equals(CDDiffUtil.inferRole(
         tgtStruct.getAssociation().getRight())) && CDDiffUtil.inferRole(struct.getAssociation()
@@ -1734,7 +1735,7 @@ public class Syn2SemDiffHelper {
         && matchRoleNames(struct.getAssociation().getLeft(), tgtStruct.getAssociation().getRight())
         && matchRoleNames(struct.getAssociation().getRight(), tgtStruct.getAssociation().getLeft());
   }
-  
+
   /**
    * Compare associations. If for a pair of associations one of them is a subassociation and a loop
    * association, the other one is marked so that it won't be looked at for generation of object
@@ -1753,7 +1754,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   public boolean sameAssociationSpec(ASTCDAssociation association, ASTCDAssociation association2) {
     Pair<ASTCDCardinality, ASTCDCardinality> cardinalities = getCardinality(association2);
     Pair<ASTCDType, ASTCDType> conncected1 = getConnectedTypes(association, srcCD);
@@ -1769,12 +1770,12 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   public boolean isLoopStruct(AssocStruct assocStruct) {
     Pair<ASTCDType, ASTCDType> pair = getConnectedTypes(assocStruct.getAssociation(), srcCD);
     return pair.a.equals(pair.b);
   }
-  
+
   /**
    * Delete all associations that use the given type as target.
    *
@@ -1785,9 +1786,9 @@ public class Syn2SemDiffHelper {
     // Select the map and CD to use based on whether it's source or target
     ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
     ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-    
+
     List<Pair<ASTCDType, List<AssocStruct>>> toDelete = new ArrayList<>();
-    
+
     for (ASTCDType toCheck : mapToUse.keySet()) {
       if (toCheck != astcdType) {
         List<AssocStruct> toDeleteStructs = new ArrayList<>();
@@ -1806,7 +1807,7 @@ public class Syn2SemDiffHelper {
         toDelete.add(new Pair<>(toCheck, toDeleteStructs));
       }
     }
-    
+
     // Remove the structures from the map
     for (Pair<ASTCDType, List<AssocStruct>> pair : toDelete) {
       for (AssocStruct struct : pair.b) {
@@ -1814,7 +1815,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   /**
    * Delete the association from the other associated type.
    *
@@ -1826,7 +1827,7 @@ public class Syn2SemDiffHelper {
       // Select the appropriate map and CD based on the isSource flag
       ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
       ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-      
+
       if (assocStruct.getSide().equals(ClassSide.Left)) {
         // Get the associated types on the right side
         ASTCDType connectedTypeB = getConnectedTypes(assocStruct.getAssociation(), cdToUse).b;
@@ -1857,7 +1858,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   /**
    * This function is used when the object diagrams are derived under simple semantics. The function
    * changes the stereotype to contain only the base type of the object without the superclasses.
@@ -1881,7 +1882,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   /**
    * Get the cardinalities of an association.
    *
@@ -1897,7 +1898,7 @@ public class Syn2SemDiffHelper {
     else {
       left = association.getLeft().getCDCardinality();
     }
-    
+
     if (!association.getRight().isPresentCDCardinality()) {
       right = new ASTCDCardMult();
     }
@@ -1906,7 +1907,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(left, right);
   }
-  
+
   /**
    * Get the matching AssocStructs for a given pair. The id 'unmodifiedAssoc' is used to identify
    * the association in the map.
@@ -1928,7 +1929,7 @@ public class Syn2SemDiffHelper {
     else if (getAssocStructByUnmod(srcCLasses.b, srcAssoc, true).isPresent()) {
       srcStruct = getAssocStructByUnmod(srcCLasses.b, srcAssoc, true).get();
     }
-    
+
     if (!reversed && getAssocStructByUnmod(tgtCLasses.a, tgtAssoc, false).isPresent()) {
       tgtStruct = getAssocStructByUnmod(tgtCLasses.a, tgtAssoc, false).get();
     }
@@ -1937,7 +1938,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(srcStruct, tgtStruct);
   }
-  
+
   /**
    * Get the matching AssocStructs for a given association in srcCD/tgtCD.
    *
@@ -1951,7 +1952,7 @@ public class Syn2SemDiffHelper {
     // Select the appropriate map and CD based on the isSource flag
     ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
     ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-    
+
     // Iterate through the AssocStructs for the given ASTCDType
     for (AssocStruct struct : mapToUse.get(astcdType)) {
       if (sameAssociation(struct.getUnmodifiedAssoc(), association, cdToUse)) {
@@ -1960,7 +1961,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   /**
    * Check if the superclasses of the given one are the same in the source and target diagram.
    *
@@ -1999,7 +2000,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Delete associations from srcMap with a specific role name
    *
@@ -2034,7 +2035,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   public boolean isOtherSideNeeded(AssocStruct assocStruct) {
     if (assocStruct.getSide().equals(ClassSide.Left) && (assocStruct.getAssociation().getRight()
         .getCDCardinality().isOne() || assocStruct.getAssociation().getRight().getCDCardinality()
@@ -2045,7 +2046,7 @@ public class Syn2SemDiffHelper {
         .getCDCardinality().isOne() || assocStruct.getAssociation().getLeft().getCDCardinality()
             .isAtLeastOne());
   }
-  
+
   /**
    * Check for all compositions if a subcomponent cannot be instantiated. If this is the case, the
    * composite class cannot be instantiated either.
@@ -2067,7 +2068,7 @@ public class Syn2SemDiffHelper {
         }
       }
     }
-    
+
     for (ASTCDType astcdType : tgtMap.keySet()) {
       for (ASTCDAssociation association : getCDAssociationsListForType(astcdType, false)) {
         Pair<ASTCDType, ASTCDType> pair = Syn2SemDiffHelper.getConnectedTypes(association, tgtCD);
@@ -2085,7 +2086,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   /**
    * Delete associations from trgMap with a specific role name
    *
@@ -2120,7 +2121,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   public List<AssocStruct> deletedAssocsForClass(ASTCDType astcdClass) {
     List<AssocStruct> list = new ArrayList<>();
     for (ASTCDAssociation association : deletedAssocs) {
@@ -2129,7 +2130,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-  
+
   /**
    * Search for an association in srcCD that can't be matched with an association in tgtCD.
    *
@@ -2192,12 +2193,12 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-  
+
   public boolean containedInList(AssocStruct srcStruct, AssocStruct tgtAssocStruct) {
     return diffs.stream().anyMatch(obj -> obj.getSrcElem() == srcStruct.getUnmodifiedAssoc() && obj
         .getTgtElem() == tgtAssocStruct.getUnmodifiedAssoc());
   }
-  
+
   /**
    * Search for an association in tgtCD that can't be matched with an association in srcCD.
    *
@@ -2248,7 +2249,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-  
+
   public List<AssocStruct> addedAssocsForClass(ASTCDType astcdClass) {
     List<AssocStruct> list = new ArrayList<>();
     for (ASTCDAssociation association : addedAssocs) {
@@ -2257,7 +2258,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-  
+
   /**
    * Get two non-abstract subclasses for a given pair.
    *
@@ -2319,7 +2320,7 @@ public class Syn2SemDiffHelper {
     }
     return null;
   }
-  
+
   public static ASTCDClass getCDClass(ASTCDCompilationUnit compilationUnit, String className) {
     for (ASTCDClass astcdClass : compilationUnit.getCDDefinition().getCDClassesList()) {
       if (astcdClass.getSymbol().getInternalQualifiedName().equals(className)) {
@@ -2328,7 +2329,7 @@ public class Syn2SemDiffHelper {
     }
     return null;
   }
-  
+
   /**
    * Check what the changes to the stereotype of a class are.
    *
@@ -2350,7 +2351,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(abstractChange, singletonChange);
   }
-  
+
   /**
    * Sort the associations for a given type so that pairs aren't duplicated.
    *
@@ -2424,13 +2425,13 @@ public class Syn2SemDiffHelper {
     }
     return new OverlappingAssocsDirect(directOverlappingAssocs, directOverlappingNoRelation);
   }
-  
+
   public OverlappingAssocsDirect computeDirectForTypeNew(ASTCDType astcdType,
       ArrayListMultimap<ASTCDType, AssocStruct> map, ASTCDCompilationUnit compilationUnit) {
-    
+
     Set<Pair<AssocStruct, AssocStruct>> directOverlappingAssocs = new HashSet<>();
     Set<Pair<AssocStruct, AssocStruct>> directOverlappingNoRelation = new HashSet<>();
-    
+
     List<AssocStruct> assocStructs = map.get(astcdType);
     for (AssocStruct assoc1 : assocStructs) {
       for (AssocStruct assoc2 : assocStructs) {
@@ -2440,17 +2441,17 @@ public class Syn2SemDiffHelper {
                 compilationUnit);
             Pair<ASTCDType, ASTCDType> types2 = getConnectedTypes(assoc2.getAssociation(),
                 compilationUnit);
-            
+
             if (areTypesValid(types1, types2)) {
               AssocStruct sub = assoc1;
               AssocStruct sup = assoc2;
-              
+
               if (isSwappable(assoc1, assoc2, types1, types2)) {
                 sub = assoc2;
                 sup = assoc1;
               }
               updateAssocUsage(sub, sup, compilationUnit);
-              
+
               directOverlappingAssocs.add(new Pair<>(sub, sup));
             }
           }
@@ -2459,17 +2460,17 @@ public class Syn2SemDiffHelper {
     }
     return new OverlappingAssocsDirect(directOverlappingAssocs, directOverlappingNoRelation);
   }
-  
+
   private boolean pairExists(Set<Pair<AssocStruct, AssocStruct>> set, AssocStruct a,
       AssocStruct b) {
     return set.stream().anyMatch(pair -> (pair.a == b && pair.b == a));
   }
-  
+
   private boolean areTypesValid(Pair<ASTCDType, ASTCDType> pair1,
       Pair<ASTCDType, ASTCDType> pair2) {
     return pair1.a != null && pair1.b != null && pair2.a != null && pair2.b != null;
   }
-  
+
   private boolean isSwappable(AssocStruct assoc1, AssocStruct assoc2,
       Pair<ASTCDType, ASTCDType> pair1, Pair<ASTCDType, ASTCDType> pair2) {
     return assoc1.getSide().equals(ClassSide.Left) && assoc2.getSide().equals(ClassSide.Left)
@@ -2480,7 +2481,7 @@ public class Syn2SemDiffHelper {
                     pair2.a) || assoc1.getSide().equals(ClassSide.Right) && assoc2.getSide().equals(
                         ClassSide.Left) && pair1.a.equals(pair2.b) && pair1.b.equals(pair2.a);
   }
-  
+
   private void updateAssocUsage(AssocStruct sub, AssocStruct sup,
       ASTCDCompilationUnit compilationUnit) {
     setOtherSideUsage(sub, AssocType.SUB, compilationUnit);
@@ -2492,7 +2493,7 @@ public class Syn2SemDiffHelper {
       sup.setUsedAs(AssocType.SUPER);
     }
   }
-  
+
   /**
    * Get the pairs of duplicated associations for a given type
    *
@@ -2523,7 +2524,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-  
+
   public void setOtherSideUsage(AssocStruct assocStruct, AssocType assocType,
       ASTCDCompilationUnit compilationUnit) {
     if (assocStruct.getDirection().equals(AssocDirection.BiDirectional)) {
@@ -2553,34 +2554,34 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   public void filterMatched() {
     matchedClasses.removeIf(pair -> !pair.a.getSymbol().getInternalQualifiedName().equals(pair.b
         .getSymbol().getInternalQualifiedName()));
-    
+
     matchedInterfaces.removeIf(pair -> !pair.a.getSymbol().getInternalQualifiedName().equals(pair.b
         .getSymbol().getInternalQualifiedName()));
   }
-  
+
   public void setMatcher() {
     matcher = new CachedMatches<>(matches.getAssocMatches());
   }
-  
+
   public List<Pair<ASTCDClass, List<AssocStruct>>> sortDiffs(
       List<Pair<ASTCDClass, AssocStruct>> input) {
     Map<ASTCDClass, List<AssocStruct>> resultMap = new HashMap<>();
-    
+
     for (Pair<ASTCDClass, AssocStruct> pair : input) {
       ASTCDClass cdClass = pair.a;
       AssocStruct assocStruct = pair.b;
-      
+
       resultMap.computeIfAbsent(cdClass, key -> new ArrayList<>()).add(assocStruct);
     }
-    
+
     return resultMap.entrySet().stream().map(entry -> new Pair<>(entry.getKey(), entry.getValue()))
         .collect(Collectors.toList());
   }
-  
+
   public Optional<Pair<ASTCDClass, List<AssocStruct>>> getPair(
       List<Pair<ASTCDClass, List<AssocStruct>>> list, ASTCDClass astcdClass) {
     for (Pair<ASTCDClass, List<AssocStruct>> pair : list) {
@@ -2590,7 +2591,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   /**
    * This function is used to treat duplicated associations BEFORE the overlapping associations.
    * This was needed as otherwise overlapping associations would be treated twice and eventually
@@ -2605,22 +2606,22 @@ public class Syn2SemDiffHelper {
     Set<ASTCDType> tgtToDelete = new HashSet<>();
     Set<Pair<ASTCDType, ASTCDRole>> tgtAssocsToDelete = new HashSet<>();
     Set<DeleteStruct> tgtAssocsToMergeWithDelete = new HashSet<>();
-    
+
     // Process source associations
     processAssociationMap(srcMap, srcCD, srcAssocsToMergeWithDelete, srcAssocsToDelete, srcToDelete,
         true);
-    
+
     // Process target associations
     processAssociationMap(tgtMap, tgtCD, tgtAssocsToMergeWithDelete, tgtAssocsToDelete, tgtToDelete,
         false);
-    
+
     // Handle deletions and merges for src
     handleDeletionsAndMerges(srcToDelete, srcAssocsToMergeWithDelete, srcAssocsToDelete, true);
-    
+
     // Handle deletions and merges for tgt
     handleDeletionsAndMerges(tgtToDelete, tgtAssocsToMergeWithDelete, tgtAssocsToDelete, false);
   }
-  
+
   // Helper method to process associations
   private void processAssociationMap(ArrayListMultimap<ASTCDType, AssocStruct> assocMap,
       ASTCDCompilationUnit cdType, Set<DeleteStruct> assocsToMergeWithDelete,
@@ -2645,7 +2646,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   // Determine if association is mergable
   private boolean isMergable(AssocStruct association, AssocStruct superAssoc, ASTCDType astcdClass,
       Set<DeleteStruct> assocsToMergeWithDelete, boolean isSrc) {
@@ -2654,14 +2655,14 @@ public class Syn2SemDiffHelper {
         || isInConflict(association, superAssoc) && inInheritanceRelation(association, superAssoc,
             isSrc ? srcCD : tgtCD);
   }
-  
+
   // Determine if association is deletable
   private boolean isDeletable(AssocStruct association, AssocStruct superAssoc, boolean isSrc) {
     return isInConflict(association, superAssoc) && !inInheritanceRelation(association, superAssoc,
         isSrc ? srcCD : tgtCD) && !getConnectedTypes(association.getAssociation(), isSrc ? srcCD
             : tgtCD).equals(getConnectedTypes(superAssoc.getAssociation(), isSrc ? srcCD : tgtCD));
   }
-  
+
   // Handle deletions and merges for src or tgt
   private void handleDeletionsAndMerges(Set<ASTCDType> toDelete,
       Set<DeleteStruct> assocsToMergeWithDelete, Set<Pair<ASTCDType, ASTCDRole>> assocsToDelete,
@@ -2686,7 +2687,7 @@ public class Syn2SemDiffHelper {
     removeAssociations(assocsToMergeWithDelete, isSrc);
     deleteAssociations(assocsToDelete, isSrc);
   }
-  
+
   // Delete a class and its subclasses
   private void deleteClassAndSubclasses(ASTCDType astcdClass, boolean isSrc) {
     if (isSrc) {
@@ -2706,7 +2707,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   // Remove associations
   private void removeAssociations(Set<DeleteStruct> assocsToMergeWithDelete, boolean isSrc) {
     for (DeleteStruct pair : assocsToMergeWithDelete) {
@@ -2718,7 +2719,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   // Delete associations
   private void deleteAssociations(Set<Pair<ASTCDType, ASTCDRole>> assocsToDelete, boolean isSrc) {
     for (Pair<ASTCDType, ASTCDRole> pair : assocsToDelete) {
@@ -2730,7 +2731,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   /**
    * Get a non-abstract class for changed type.
    *
@@ -2747,7 +2748,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-  
+
   /**
    * Check if an attribute is conatined in a class in tgtCD.
    *
@@ -2781,7 +2782,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-  
+
   /**
    * Delete associations from subclasses in tgtCD.
    *
@@ -2803,7 +2804,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   /**
    * Delete associations from subclasses in srcCD.
    *
@@ -2823,7 +2824,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-  
+
   public List<Pair<ASTCDClass, List<ASTCDAttribute>>> transform(
       List<Pair<ASTCDClass, ASTCDAttribute>> list) {
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> result = new ArrayList<>();
@@ -2832,7 +2833,7 @@ public class Syn2SemDiffHelper {
     }
     return result;
   }
-  
+
   /**
    * Sort the added and deleted attributes for a given type. This reduces the number of generated
    * diff-witnesses.
@@ -2842,7 +2843,7 @@ public class Syn2SemDiffHelper {
   public void sortTypeDiff(TypeDiffStruct typeDiffStruct) {
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> added = new ArrayList<>();
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> deleted = new ArrayList<>();
-    
+
     if (typeDiffStruct.getAddedAttributes() != null && !typeDiffStruct.getAddedAttributes()
         .isEmpty()) {
       added.addAll(typeDiffStruct.getAddedAttributes());
@@ -2851,33 +2852,33 @@ public class Syn2SemDiffHelper {
         .isEmpty()) {
       deleted.addAll(typeDiffStruct.getDeletedAttributes());
     }
-    
+
     Map<ASTCDClass, AddedDeletedAtt> classAttributeMap = new HashMap<>();
-    
+
     for (Pair<ASTCDClass, List<ASTCDAttribute>> pair : added) {
       ASTCDClass clazz = pair.a;
       List<ASTCDAttribute> attribute = pair.b;
-      
+
       if (!classAttributeMap.containsKey(clazz)) {
         classAttributeMap.put(clazz, new AddedDeletedAtt());
       }
       classAttributeMap.get(clazz).getAddedAttributes().addAll(attribute);
     }
-    
+
     for (Pair<ASTCDClass, List<ASTCDAttribute>> pair : deleted) {
       ASTCDClass clazz = pair.a;
       List<ASTCDAttribute> attribute = pair.b;
-      
+
       if (!classAttributeMap.containsKey(clazz)) {
         classAttributeMap.put(clazz, new AddedDeletedAtt());
       }
       classAttributeMap.get(clazz).getDeletedAttributes().addAll(attribute);
     }
-    
+
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> addedNew = new ArrayList<>();
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> deletedNew = new ArrayList<>();
     List<Pair<ASTCDClass, AddedDeletedAtt>> addedDeleted = new ArrayList<>();
-    
+
     // Remove AddedDeletedAtt if no deleted attributes are present
     for (Map.Entry<ASTCDClass, AddedDeletedAtt> astcdClass : classAttributeMap.entrySet()) {
       if (astcdClass.getValue().getDeletedAttributes().isEmpty()) {
@@ -2895,5 +2896,5 @@ public class Syn2SemDiffHelper {
     typeDiffStruct.setAddedAttributes(addedNew);
     typeDiffStruct.setDeletedAttributes(deletedNew);
   }
-  
+
 }

--- a/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/Syn2SemDiffHelper.java
+++ b/cddiff/src/main/java/de/monticore/cddiff/syn2semdiff/odgen/Syn2SemDiffHelper.java
@@ -44,93 +44,93 @@ import static de.monticore.cddiff.ow2cw.CDInheritanceHelper.isSuperOf;
  * is also implemented in this class.
  */
 public class Syn2SemDiffHelper {
-
+  
   public Syn2SemDiffHelper(CDSynDiffMatches matches) {
     this.matches = matches;
   }
-
+  
   private CDSynDiffMatches matches;
-
+  
   /**
    * Map with all possible associations (as AssocStructs) for classes from srcCD where the given
    * class serves as source. The non-instantiatable classes and associations are removed after the
    * function findOverlappingAssocs().
    */
   private ArrayListMultimap<ASTCDType, AssocStruct> srcMap;
-
+  
   /**
    * Map with all possible associations (as AssocStructs) for classes from trgCd where the given
    * class serves as target. The non-instantiatable classes and associations are removed after the
    * function findOverlappingAssocs().
    */
   private ArrayListMultimap<ASTCDType, AssocStruct> tgtMap;
-
+  
   /**
    * Map with all subclasses of a class from srcCD. This is used to reduce the complexity for
    * computing the underlying inheritance tree.
    */
   private ArrayListMultimap<ASTCDType, ASTCDClass> srcSubMap;
-
+  
   /**
    * Map with all subclasses of a class from trgCD. This is used to reduce the complexity for
    * computing the underlying inheritance tree.
    */
   private ArrayListMultimap<ASTCDType, ASTCDClass> tgtSubMap;
-
+  
   /**
    * Set with all classes that are not instantiatable in srcCD. Those are classes that cannot exist
    * because of overlapping. The second possibility is that the class has an attribute and a
    * relation to the same class, e.g., int age and -> (age) Age.
    */
   private Set<ASTCDType> notInstClassesSrc;
-
+  
   /**
    * Set with all classes that are not instantiatable in trgCD. Those are classes that cannot exist
    * because of overlapping. The second possibility is that the class has an attribute and a
    * relation to the same class, e.g., int age and -> (age) Age.
    */
   private Set<ASTCDType> notInstClassesTgt;
-
+  
   /**
    * This is a copy of the srcCD so that it can be accessed from all classes for semantic
    * difference.
    */
   private ASTCDCompilationUnit srcCD;
-
+  
   /**
    * This is a copy of the trgCD so that it can be accessed from all classes for semantic
    * difference.
    */
   private ASTCDCompilationUnit tgtCD;
-
+  
   /**
    * Those are the matched classes from the analysis of the syntax. This way some functionalities
    * were moved to this helper class.
    */
   private List<Pair<ASTCDClass, ASTCDType>> matchedClasses;
-
+  
   /**
    * Those are the matched interfaces from the analysis of the syntax. This way some functionalities
    * were moved to this helper class.
    */
   private List<Pair<ASTCDInterface, ASTCDType>> matchedInterfaces;
-
+  
   /**
    * Those are the added associations from the analysis of the syntax. This way some functionalities
    * were moved to this helper class.
    */
   private List<ASTCDAssociation> addedAssocs;
-
+  
   /**
    * Those are the deleted associations from the analysis of the syntax. This way some
    * functionalities were moved to this helper class.
    */
   private List<ASTCDAssociation> deletedAssocs;
-
+  
   private BooleanMatchingStrategy<ASTCDAssociation> matcher;
   private List<CDAssocDiff> diffs;
   private List<MatchingStrategy> matchingStrategies;
-
+  
   // CHECKED
   public boolean isAttContainedInClass(ASTCDAttribute attribute, ASTCDType astcdClass) {
     int indexAttribute = attribute.getMCType().printType().lastIndexOf(".");
@@ -158,74 +158,74 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   public void setMatchedClasses(List<Pair<ASTCDClass, ASTCDType>> matchedClasses) {
     this.matchedClasses = matchedClasses;
   }
-
+  
   public List<Pair<ASTCDClass, ASTCDType>> getMatchedClasses() { return matchedClasses; }
-
+  
   public void setDiffs(List<CDAssocDiff> diffs) { this.diffs = diffs; }
-
+  
   public List<CDAssocDiff> getDiffs() { return diffs; }
-
+  
   public ArrayListMultimap<ASTCDType, AssocStruct> getSrcMap() { return srcMap; }
-
+  
   public ArrayListMultimap<ASTCDType, AssocStruct> getTgtMap() { return tgtMap; }
-
+  
   public ASTCDCompilationUnit getSrcCD() { return srcCD; }
-
+  
   public void setSrcCD(ASTCDCompilationUnit srcCD) { this.srcCD = srcCD; }
-
+  
   public ASTCDCompilationUnit getTgtCD() { return tgtCD; }
-
+  
   public void setTgtCD(ASTCDCompilationUnit tgtCD) { this.tgtCD = tgtCD; }
-
+  
   public Set<ASTCDType> getNotInstClassesSrc() { return notInstClassesSrc; }
-
+  
   public Set<ASTCDType> getNotInstClassesTgt() { return notInstClassesTgt; }
-
+  
   public ArrayListMultimap<ASTCDType, ASTCDClass> getSrcSubMap() { return srcSubMap; }
-
+  
   public ArrayListMultimap<ASTCDType, ASTCDClass> getTgtSubMap() { return tgtSubMap; }
-
+  
   public void setNotInstClassesSrc(Set<ASTCDType> notInstClassesSrc) {
     this.notInstClassesSrc = notInstClassesSrc;
   }
-
+  
   public void setNotInstClassesTgt(Set<ASTCDType> notInstClassesTgt) {
     this.notInstClassesTgt = notInstClassesTgt;
   }
-
+  
   public void updateSrc(ASTCDType astcdClass) {
     notInstClassesSrc.add(astcdClass);
   }
-
+  
   public void updateTgt(ASTCDType astcdClass) {
     notInstClassesTgt.add(astcdClass);
   }
-
+  
   public void setDeletedAssocs(List<ASTCDAssociation> deletedAssocs) {
     this.deletedAssocs = deletedAssocs;
   }
-
+  
   public void setAddedAssocs(List<ASTCDAssociation> addedAssocs) { this.addedAssocs = addedAssocs; }
-
+  
   public List<Pair<ASTCDInterface, ASTCDType>> getMatchedInterfaces() { return matchedInterfaces; }
-
+  
   public void setMatchedInterfaces(List<Pair<ASTCDInterface, ASTCDType>> matchedInterfaces) {
     this.matchedInterfaces = matchedInterfaces;
   }
-
+  
   public void setMatchingStrategies(List<MatchingStrategy> matchingStrategies) {
     this.matchingStrategies = matchingStrategies;
   }
-
+  
   public boolean isSubclassWithSuper(ASTCDType superClass, ASTCDType subClass) {
     return isSuperOf(superClass.getSymbol().getInternalQualifiedName(), subClass.getSymbol()
         .getInternalQualifiedName(), srcCD);
   }
-
+  
   /**
    * Get all needed associations from the src/tgtMap that use the given class as target. The
    * associations are strictly unidirectional. Needed associations - the cardinality must be at
@@ -240,14 +240,14 @@ public class Syn2SemDiffHelper {
       boolean makeConditionStrict) {
     List<AssocStruct> list = new ArrayList<>();
     ArrayListMultimap<ASTCDType, AssocStruct> map = isSource ? srcMap : tgtMap;
-
+    
     for (ASTCDType classToCheck : map.keySet()) {
       if (classToCheck != astcdClass) {
         for (AssocStruct assocStruct : map.get(classToCheck)) {
           Pair<ASTCDType, ASTCDType> connectedTypes;
           connectedTypes = Syn2SemDiffHelper.getConnectedTypes(assocStruct.getAssociation(),
               isSource ? srcCD : tgtCD);
-
+          
           if (assocStruct.getSide().equals(ClassSide.Left) && !assocStruct.getDirection().equals(
               AssocDirection.BiDirectional) && (makeConditionStrict || assocStruct.getAssociation()
                   .getLeft().getCDCardinality().isOne() || assocStruct.getAssociation().getLeft()
@@ -266,7 +266,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-
+  
   /**
    * Get all needed associations (including superclasses) from the src/tgtMap that use the given
    * class as target. The associations are strictly unidirectional. Needed associations - the
@@ -279,26 +279,26 @@ public class Syn2SemDiffHelper {
     List<AssocStruct> list = new ArrayList<>();
     Set<ASTCDType> superTypes = CDDiffUtil.getAllSuperTypes(astcdClass, isSource ? srcCD
         .getCDDefinition() : tgtCD.getCDDefinition());
-
+    
     for (ASTCDType astcdClass1 : superTypes) {
       list.addAll(getOtherAssocs(astcdClass1, isSource, false));
     }
-
+    
     return list;
   }
-
+  
   public List<AssocStruct> getAllOtherAssocsSpecCase(ASTCDType astcdClass, boolean isSource) {
     List<AssocStruct> list = new ArrayList<>();
     Set<ASTCDType> superTypes = CDDiffUtil.getAllSuperTypes(astcdClass, isSource ? srcCD
         .getCDDefinition() : tgtCD.getCDDefinition());
-
+    
     for (ASTCDType astcdClass1 : superTypes) {
       list.addAll(getOtherAssocs(astcdClass1, isSource, true));
     }
-
+    
     return list;
   }
-
+  
   /**
    * Find matched type in srcCD.
    *
@@ -316,7 +316,7 @@ public class Syn2SemDiffHelper {
       return Optional.empty();
     }
   }
-
+  
   /**
    * Find matched type in tgtCD.
    *
@@ -334,7 +334,7 @@ public class Syn2SemDiffHelper {
       return Optional.empty();
     }
   }
-
+  
   public Optional<ASTCDType> findMatchedClass(ASTCDClass astcdClass) {
     for (Pair<ASTCDClass, ASTCDType> pair : matchedClasses) {
       if (pair.a.equals(astcdClass)) {
@@ -343,7 +343,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   public Optional<ASTCDType> findMatchedSrc(ASTCDClass astcdClass) {
     for (Pair<ASTCDClass, ASTCDType> pair : matchedClasses) {
       if (pair.b.equals(astcdClass)) {
@@ -352,7 +352,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   public Optional<ASTCDType> findMatchedTypeSrc(ASTCDInterface astcdInterface) {
     for (Pair<ASTCDInterface, ASTCDType> pair : matchedInterfaces) {
       if (pair.b.equals(astcdInterface)) {
@@ -361,7 +361,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   public Optional<ASTCDType> findMatchedTypeTgt(ASTCDInterface astcdInterface) {
     for (Pair<ASTCDInterface, ASTCDType> pair : matchedInterfaces) {
       if (pair.a.equals(astcdInterface)) {
@@ -370,7 +370,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   public static AssocDirection getDirection(ASTCDAssociation association) {
     if (association.getCDAssocDir() == null) {
       return AssocDirection.Unspecified;
@@ -385,7 +385,7 @@ public class Syn2SemDiffHelper {
       return AssocDirection.LeftToRight;
     }
   }
-
+  
   /**
    * When merging associations, the role names of the bidirectional association are used instead of
    * the role names of the unidirectional.
@@ -417,7 +417,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   /**
    * Merge the cardinalities and the direction of two associations.
    *
@@ -448,7 +448,7 @@ public class Syn2SemDiffHelper {
           .verifyNotNull(cardinalityLeft)));
     }
   }
-
+  
   /**
    * Modified version of the function inConflict in CDAssociationHelper. In the map, all association
    * that can be created from a class are saved in the values for this class (key). Because of that
@@ -462,7 +462,7 @@ public class Syn2SemDiffHelper {
   public static boolean isInConflict(AssocStruct association, AssocStruct superAssociation) {
     ASTCDAssociation srcAssoc = association.getAssociation();
     ASTCDAssociation targetAssoc = superAssociation.getAssociation();
-
+    
     if (association.getSide().equals(ClassSide.Left) && superAssociation.getSide().equals(
         ClassSide.Left)) {
       return matchRoleNames(srcAssoc.getRight(), targetAssoc.getRight());
@@ -479,10 +479,10 @@ public class Syn2SemDiffHelper {
         ClassSide.Right)) {
       return matchRoleNames(srcAssoc.getLeft(), targetAssoc.getLeft());
     }
-
+    
     return false;
   }
-
+  
   /**
    * Given the two associations, get the role name that causes the conflict
    *
@@ -493,7 +493,7 @@ public class Syn2SemDiffHelper {
   public static ASTCDRole getConflict(AssocStruct association, AssocStruct superAssociation) {
     ASTCDAssociation srcAssoc = association.getAssociation();
     ASTCDAssociation targetAssoc = superAssociation.getAssociation();
-
+    
     if (association.getSide().equals(ClassSide.Left) && superAssociation.getSide().equals(
         ClassSide.Left) && matchRoleNames(srcAssoc.getRight(), targetAssoc.getRight())) {
       return srcAssoc.getRight().getCDRole();
@@ -510,7 +510,7 @@ public class Syn2SemDiffHelper {
       return srcAssoc.getLeft().getCDRole();
     }
   }
-
+  
   /**
    * Merge the directions of two associations
    *
@@ -521,20 +521,20 @@ public class Syn2SemDiffHelper {
   public static ASTCDAssocDir mergeAssocDir(AssocStruct association, AssocStruct superAssociation) {
     AssocDirection dir1 = association.getDirection();
     AssocDirection dir2 = superAssociation.getDirection();
-
+    
     if (dir1.equals(AssocDirection.BiDirectional) || dir2.equals(AssocDirection.BiDirectional)) {
       return CD4CodeMill.cDBiDirBuilder().build();
     }
-
+    
     ClassSide side1 = association.getSide();
     ClassSide side2 = superAssociation.getSide();
-
+    
     boolean sameLogicalDirection = (dir1 == dir2 && side1 == side2) || (dir1
         == AssocDirection.LeftToRight && dir2 == AssocDirection.RightToLeft && side1
             == ClassSide.Left && side2 == ClassSide.Right) || (dir1 == AssocDirection.RightToLeft
                 && dir2 == AssocDirection.LeftToRight && side1 == ClassSide.Right && side2
                     == ClassSide.Left);
-
+    
     if (sameLogicalDirection) {
       switch (dir1) {
         case LeftToRight:
@@ -543,10 +543,10 @@ public class Syn2SemDiffHelper {
           return CD4CodeMill.cDRightToLeftDirBuilder().build();
       }
     }
-
+    
     return CD4CodeMill.cDBiDirBuilder().build();
   }
-
+  
   /**
    * Group corresponding cardinalities
    *
@@ -584,7 +584,7 @@ public class Syn2SemDiffHelper {
               .getAssociation().getLeft().getCDCardinality()));
     }
   }
-
+  
   /**
    * Transform the internal cardinality to original
    *
@@ -605,7 +605,7 @@ public class Syn2SemDiffHelper {
       return new ASTCDCardMult();
     }
   }
-
+  
   /**
    * Check if the associations allow 0 objects from target class
    *
@@ -617,15 +617,15 @@ public class Syn2SemDiffHelper {
     ASTCDCardinality assocCardinality = association.getSide().equals(ClassSide.Left) ? association
         .getAssociation().getRight().getCDCardinality() : association.getAssociation().getLeft()
             .getCDCardinality();
-
+    
     ASTCDCardinality superAssocCardinality = superAssociation.getSide().equals(ClassSide.Left)
         ? superAssociation.getAssociation().getRight().getCDCardinality() : superAssociation
             .getAssociation().getLeft().getCDCardinality();
-
+    
     return (assocCardinality.isMult() || assocCardinality.isOpt()) && (superAssocCardinality
         .isMult() || superAssocCardinality.isOpt());
   }
-
+  
   public boolean isAdded(AssocStruct assocStruct, AssocStruct assocStruct2, ASTCDType astcdClass,
       Set<DeleteStruct> set) {
     for (DeleteStruct deleteStruct : set) {
@@ -638,7 +638,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Similar to the function above, but the now the classes must be the target of the association.
    *
@@ -664,7 +664,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   /**
    * Check if all matched subclasses in tgtCD/srcCD of a class from srcCD/tgtCD have the same
    * association or a subassociation.
@@ -677,12 +677,12 @@ public class Syn2SemDiffHelper {
       boolean isSource) {
     List<ASTCDClass> subClasses = isSource ? tgtSubMap.get(type) : srcSubMap.get(type);
     List<ASTCDType> subTypes = getTypes(subClasses, isSource);
-
+    
     for (ASTCDType subClass : subTypes) {
       boolean isContained = false;
       List<AssocStruct> assocList = isSource ? srcMap.get(subClass) : getAllOtherAssocs(subClass,
           false);
-
+      
       for (AssocStruct assocStruct : assocList) {
         if (isSource) {
           if (sameAssociationTypeSrcTgt(assocStruct, association)) {
@@ -697,14 +697,14 @@ public class Syn2SemDiffHelper {
           }
         }
       }
-
+      
       if (!isContained) {
         return Optional.ofNullable(subClass);
       }
     }
     return Optional.empty();
   }
-
+  
   /**
    * Check if all matched subclasses in srcCD of a class from trgCD are target of the same
    * association.
@@ -730,7 +730,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   /**
    * Check if the classes are in an inheritance relation. For this, the matched classes in
    * srcCD/tgtCD of the tgtClass/srcClass are compared with isSuper() to the srcClass.
@@ -744,7 +744,7 @@ public class Syn2SemDiffHelper {
         type2);
     Optional<ASTCDType> type1Matched = isSource ? findMatchedTypeTgt(type1) : findMatchedTypeSrc(
         type1);
-
+    
     return typeToMatch.filter(astcdType -> isSuperOf(astcdType.getSymbol()
         .getInternalQualifiedName(), type1.getSymbol().getInternalQualifiedName(),
         (ICD4CodeArtifactScope) (isSource ? srcCD.getEnclosingScope() : tgtCD.getEnclosingScope())))
@@ -753,7 +753,7 @@ public class Syn2SemDiffHelper {
                 type1Matched.get())) : (typeToMatch.isPresent() && srcSubMap.get(type1).contains(
                     typeToMatch.get())));
   }
-
+  
   /**
    * Check if the srcType has the given association from srcCD.
    *
@@ -769,7 +769,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Check if the srcType has the given association from tgtCD.
    *
@@ -785,7 +785,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   public boolean classHasAssociationTgtSrcRev(AssocStruct tgtStruct, ASTCDType srcType) {
     for (AssocStruct assocStruct1 : srcMap.get(srcType)) {
       if (sameAssociationTypeSrcTgtRev(assocStruct1, tgtStruct)) {
@@ -794,7 +794,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Check if the tgtType has the given association from srcCD.
    *
@@ -810,7 +810,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Check if the srcType is target of the given association from srcCD.
    *
@@ -826,7 +826,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Check if the tgtType is target of the given association from srcCD.
    *
@@ -842,7 +842,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Check if the srcType is target of the given association from tgtCD.
    *
@@ -858,7 +858,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   public boolean classIsTargetTgtSrcRev(AssocStruct association, ASTCDType srcType) {
     for (AssocStruct assocStruct : getAllOtherAssocs(srcType, true)) {
       if (sameAssociationTypeSrcTgtRev(assocStruct, association)) {
@@ -867,10 +867,10 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   public List<ASTCDType> getTypes(List<? extends ASTCDType> types, boolean isSource) {
     List<ASTCDType> resultTypes = new ArrayList<>();
-
+    
     for (ASTCDType astcdType : types) {
       if (astcdType instanceof ASTCDClass) {
         Optional<ASTCDType> matched = isSource ? findMatchedSrc((ASTCDClass) astcdType)
@@ -885,7 +885,7 @@ public class Syn2SemDiffHelper {
     }
     return resultTypes;
   }
-
+  
   /**
    * Check if two associations are exactly the same.
    *
@@ -908,7 +908,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Check if the target classes of the two associations are in an inheritance relation
    *
@@ -943,7 +943,7 @@ public class Syn2SemDiffHelper {
           (ICD4CodeArtifactScope) compilationUnit.getEnclosingScope());
     }
   }
-
+  
   public boolean inheritanceTgt(AssocStruct assocStruct, AssocStruct assocStruct1) {
     if (assocStruct.getSide().equals(ClassSide.Left) && assocStruct1.getSide().equals(
         ClassSide.Left)) {
@@ -965,7 +965,7 @@ public class Syn2SemDiffHelper {
           getConnectedTypes(assocStruct.getAssociation(), srcCD).a, false);
     }
   }
-
+  
   /**
    * Get all attributes that need to be added from inheritance structure to an object of a given
    * type
@@ -984,7 +984,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(astcdClass, attributes);
   }
-
+  
   public Pair<ASTCDType, List<ASTCDAttribute>> getAllAttrTgt(ASTCDType astcdClass) {
     List<ASTCDAttribute> attributes = new ArrayList<>();
     Set<ASTCDType> classes = getAllSuper(astcdClass, (ICD4CodeArtifactScope) tgtCD
@@ -996,7 +996,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(astcdClass, attributes);
   }
-
+  
   /**
    * Check if the srcAssoc has the same type as the srcAssoc1 - direction, role names and the
    * cardinalities of srcAssoc are sub-intervals of the cardinalities of srcAssoc1.
@@ -1015,7 +1015,7 @@ public class Syn2SemDiffHelper {
       return compareAssociations(srcAssocSuper, srcAssocSub, false);
     }
   }
-
+  
   private boolean compareAssociations(AssocStruct superAssoc, AssocStruct subAssoc,
       boolean sameSides) {
     // Compare role names, cardinality, and direction for both sides (left and right)
@@ -1045,7 +1045,7 @@ public class Syn2SemDiffHelper {
                                                                     .getAssociation().getLeft()
                                                                     .getCDCardinality()));
   }
-
+  
   /**
    * Check if the srcAssoc has the same type as the tgtAssoc - direction, role names and the
    * cardinalities of srcAssoc are sub-intervals of the cardinalities of tgtAssoc.
@@ -1063,7 +1063,7 @@ public class Syn2SemDiffHelper {
         .equals(ClassSide.Right);
     boolean isRightLeft = srcAssocSub.getSide().equals(ClassSide.Right) && tgtAssocSuper.getSide()
         .equals(ClassSide.Left);
-
+    
     if (isLeftLeft || isRightRight) {
       return matchRoleNames(srcAssocSub.getAssociation().getLeft(), tgtAssocSuper.getAssociation()
           .getLeft()) && matchRoleNames(srcAssocSub.getAssociation().getRight(), tgtAssocSuper
@@ -1098,10 +1098,10 @@ public class Syn2SemDiffHelper {
                                                       .getAssociation().getLeft()
                                                       .getCDCardinality()));
     }
-
+    
     return false;
   }
-
+  
   public boolean sameAssociationTypeSrcTgtRev(AssocStruct srcAssocSub, AssocStruct tgtAssocSuper) {
     boolean isLeftLeft = srcAssocSub.getSide().equals(ClassSide.Left) && tgtAssocSuper.getSide()
         .equals(ClassSide.Left);
@@ -1111,7 +1111,7 @@ public class Syn2SemDiffHelper {
         .equals(ClassSide.Right);
     boolean isRightLeft = srcAssocSub.getSide().equals(ClassSide.Right) && tgtAssocSuper.getSide()
         .equals(ClassSide.Left);
-
+    
     if (isLeftRight || isRightLeft) {
       return matchRoleNames(srcAssocSub.getAssociation().getLeft(), tgtAssocSuper.getAssociation()
           .getLeft()) && matchRoleNames(srcAssocSub.getAssociation().getRight(), tgtAssocSuper
@@ -1146,10 +1146,10 @@ public class Syn2SemDiffHelper {
                                                       .getAssociation().getLeft()
                                                       .getCDCardinality()));
     }
-
+    
     return false;
   }
-
+  
   /**
    * Given the following two cardinalities, find their intersection
    *
@@ -1203,7 +1203,7 @@ public class Syn2SemDiffHelper {
     }
     return null;
   }
-
+  
   /**
    * This is the same function from CDDefinition, but it compares the classes based on the qualified
    * name of the class.
@@ -1215,7 +1215,7 @@ public class Syn2SemDiffHelper {
     List<ASTCDAssociation> result = new ArrayList<>();
     List<ASTCDAssociation> associationsList = isSource ? srcCD.getCDDefinition()
         .getCDAssociationsList() : tgtCD.getCDDefinition().getCDAssociationsList();
-
+    
     for (ASTCDAssociation association : associationsList) {
       if (association.getLeftQualifiedName().getQName().equals(type.getSymbol()
           .getInternalQualifiedName()) && association.getCDAssocDir()
@@ -1229,7 +1229,7 @@ public class Syn2SemDiffHelper {
     }
     return result;
   }
-
+  
   /**
    * Compute what associations can be used from a class (associations that were from the class and
    * superAssociations). For each class and each possible association we save the direction and also
@@ -1245,28 +1245,28 @@ public class Syn2SemDiffHelper {
     findNonInstantiableClasses();
     checkRoleNameConflicts();
   }
-
+  
   private void processSourceTypes() {
     List<ASTCDType> srcTypes = getTypes(srcCD);
     for (ASTCDType astcdClass : srcTypes) {
       processAssociations(astcdClass, getCDAssociationsListForType(astcdClass, true), true);
     }
   }
-
+  
   private void processTargetTypes() {
     List<ASTCDType> tgtTypes = getTypes(tgtCD);
     for (ASTCDType astcdClass : tgtTypes) {
       processAssociations(astcdClass, getCDAssociationsListForType(astcdClass, false), false);
     }
   }
-
+  
   private List<ASTCDType> getTypes(ASTCDCompilationUnit compilationUnit) {
     List<ASTCDType> types = new ArrayList<>();
     types.addAll(compilationUnit.getCDDefinition().getCDClassesList());
     types.addAll(compilationUnit.getCDDefinition().getCDInterfacesList());
     return types;
   }
-
+  
   private void processAssociations(ASTCDType astcdClass, List<ASTCDAssociation> associations,
       boolean isSource) {
     for (ASTCDAssociation astcdAssociation : associations) {
@@ -1274,10 +1274,10 @@ public class Syn2SemDiffHelper {
           : tgtCD);
       if (pair.a == null)
         continue;
-
+      
       ASTCDAssociation copyAssoc = createVirtualAssociation(astcdAssociation);
       updateAssociationRoles(copyAssoc, astcdAssociation);
-
+      
       if (isSource) {
         handleAssociationMapping(astcdClass, astcdAssociation, pair, copyAssoc, srcMap);
       }
@@ -1286,14 +1286,14 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   private ASTCDAssociation createVirtualAssociation(ASTCDAssociation original) {
     ASTCDAssociation copyAssoc = original.deepClone();
     copyAssoc.setName(" ");
     ensureCardinalities(copyAssoc);
     return copyAssoc;
   }
-
+  
   private void ensureCardinalities(ASTCDAssociation assoc) {
     if (!assoc.getLeft().isPresentCDCardinality()) {
       assoc.getLeft().setCDCardinality(CD4CodeMill.cDCardMultBuilder().build());
@@ -1305,14 +1305,14 @@ public class Syn2SemDiffHelper {
       assoc.getLeft().setCDCardinality(CD4CodeMill.cDCardOneBuilder().build());
     }
   }
-
+  
   private void updateAssociationRoles(ASTCDAssociation copyAssoc, ASTCDAssociation original) {
     copyAssoc.getLeft().setCDRole(CD4CodeMill.cDRoleBuilder().setName(CDDiffUtil.inferRole(original
         .getLeft())).build());
     copyAssoc.getRight().setCDRole(CD4CodeMill.cDRoleBuilder().setName(CDDiffUtil.inferRole(original
         .getRight())).build());
   }
-
+  
   private void handleAssociationMapping(ASTCDType astcdClass, ASTCDAssociation original,
       Pair<ASTCDType, ASTCDType> pair, ASTCDAssociation copyAssoc,
       ArrayListMultimap<ASTCDType, AssocStruct> map) {
@@ -1327,7 +1327,7 @@ public class Syn2SemDiffHelper {
           false, null));
     }
   }
-
+  
   private AssocStruct createAssocStruct(ASTCDAssociation assoc, ASTCDAssociation original,
       ASTCDType astcdType, ASTCDType connectedType, ClassSide side, Boolean isSuperAssoc,
       ASTCDType superClass) {
@@ -1337,34 +1337,34 @@ public class Syn2SemDiffHelper {
     }
     return new AssocStruct(assoc, direction, side, true, superClass, connectedType, original);
   }
-
+  
   private AssocDirection determineAssocDirection(ASTCDAssociation assoc, ClassSide side) {
     if (assoc.getCDAssocDir().isBidirectional()) {
       return AssocDirection.BiDirectional;
     }
     return side == ClassSide.Left ? AssocDirection.LeftToRight : AssocDirection.RightToLeft;
   }
-
+  
   private void inheritAssociations(ASTCDCompilationUnit compilationUnit, boolean isSource) {
     List<ASTCDType> types = getTypes(compilationUnit);
     for (ASTCDType astcdClass : types) {
       Set<ASTCDType> superTypes = CDDiffUtil.getAllSuperTypes(astcdClass, compilationUnit
           .getCDDefinition());
       superTypes.remove(astcdClass);
-
+      
       for (ASTCDType superClass : superTypes) {
         List<ASTCDAssociation> associations = getCDAssociationsListForType(superClass, isSource);
         for (ASTCDAssociation assoc : associations) {
           Pair<ASTCDType, ASTCDType> pair = getConnectedTypes(assoc, compilationUnit);
           if (pair.a == null)
             continue;
-
+          
           processInheritedAssociation(astcdClass, assoc, superClass, pair, isSource);
         }
       }
     }
   }
-
+  
   private void processInheritedAssociation(ASTCDType subClass, ASTCDAssociation assoc,
       ASTCDType superClass, Pair<ASTCDType, ASTCDType> pair, boolean isSource) {
     ArrayListMultimap<ASTCDType, AssocStruct> map = isSource ? srcMap : tgtMap;
@@ -1381,14 +1381,14 @@ public class Syn2SemDiffHelper {
           superClass));
     }
   }
-
+  
   private ASTCDAssociation createInheritedAssoc(ASTCDAssociation original, ASTCDType subClass,
       ClassSide side) {
     ASTCDAssociation assoc = original.deepClone();
     assoc.setName(" ");
     updateAssociationRoles(assoc, original);
     ensureCardinalities(assoc);
-
+    
     if (side == ClassSide.Left) {
       assoc.getLeft().setMCQualifiedType(createQualifiedType(subClass));
     }
@@ -1397,17 +1397,17 @@ public class Syn2SemDiffHelper {
     }
     return assoc;
   }
-
+  
   private ASTMCQualifiedType createQualifiedType(ASTCDType type) {
     return CD4CodeMill.mCQualifiedTypeBuilder().setMCQualifiedName(MCQualifiedNameFacade
         .createQualifiedName(type.getSymbol().getInternalQualifiedName())).build();
   }
-
+  
   private void findNonInstantiableClasses() {
     findDuplicateAttributes(srcCD, notInstClassesSrc, true);
     findDuplicateAttributes(tgtCD, notInstClassesTgt, false);
   }
-
+  
   private void findDuplicateAttributes(ASTCDCompilationUnit compilationUnit,
       Set<ASTCDType> notInstClasses, boolean isSource) {
     for (ASTCDClass astcdClass : compilationUnit.getCDDefinition().getCDClassesList()) {
@@ -1425,12 +1425,12 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   private void checkRoleNameConflicts() {
     checkRoleNameConflicts(srcCD, notInstClassesSrc, true);
     checkRoleNameConflicts(tgtCD, notInstClassesTgt, false);
   }
-
+  
   private void checkRoleNameConflicts(ASTCDCompilationUnit compilationUnit,
       Set<ASTCDType> notInstClasses, boolean isSource) {
     for (ASTCDClass astcdClass : compilationUnit.getCDDefinition().getCDClassesList()) {
@@ -1444,7 +1444,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   /** Compute the subtypes for each type in the diagrams. */
   public void setSubMaps() {
     srcSubMap = ArrayListMultimap.create();
@@ -1454,13 +1454,13 @@ public class Syn2SemDiffHelper {
         srcSubMap.put(astcdClass, subClass);
       }
     }
-
+    
     for (ASTCDClass astcdClass : tgtCD.getCDDefinition().getCDClassesList()) {
       for (ASTCDClass subClass : getSpannedInheritance(tgtCD, astcdClass)) {
         tgtSubMap.put(astcdClass, subClass);
       }
     }
-
+    
     List<ASTCDInterface> interfaces = srcCD.getCDDefinition().getCDInterfacesList();
     for (ASTCDInterface astcdInterface : interfaces) {
       for (ASTCDClass astcdClass : srcCD.getCDDefinition().getCDClassesList()) {
@@ -1480,13 +1480,13 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   // Helper method to process interfaces and classes for superclass relationship
   private void processInterfacesAndClasses(ASTCDCompilationUnit cdUnit,
       ArrayListMultimap<ASTCDType, ASTCDClass> subMap) {
     List<ASTCDInterface> interfaces = cdUnit.getCDDefinition().getCDInterfacesList();
     List<ASTCDClass> classes = cdUnit.getCDDefinition().getCDClassesList();
-
+    
     for (ASTCDInterface astcdInterface : interfaces) {
       for (ASTCDClass astcdClass : classes) {
         if (CDInheritanceHelper.isSuperOf(astcdInterface.getSymbol().getInternalQualifiedName(),
@@ -1496,14 +1496,14 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   private boolean sameRoleNameAndClass(String roleName, ASTCDClass astcdClass, boolean isSource) {
     String roleName1 = roleName.substring(0, 1).toUpperCase() + roleName.substring(1);
-
+    
     // Determine which map and CD to use based on whether it's source or target
     ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
     ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-
+    
     for (AssocStruct assocStruct : mapToUse.get(astcdClass)) {
       if (assocStruct.getSide().equals(ClassSide.Left)) {
         if (CDDiffUtil.inferRole(assocStruct.getAssociation().getRight()).equals(roleName)
@@ -1522,7 +1522,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Get the classes that are connected with the association. The function returns null if the
    * associated objects aren't classes.
@@ -1543,7 +1543,7 @@ public class Syn2SemDiffHelper {
     Log.error("Could not resolve types of :" + CD4CodeMill.prettyPrint(association, false));
     return new Pair<>(null, null);
   }
-
+  
   /**
    * Compute the types that extend a given class.
    *
@@ -1564,7 +1564,7 @@ public class Syn2SemDiffHelper {
     subclasses.remove(astcdClass);
     return subclasses;
   }
-
+  
   /**
    * Check if the first cardinality is contained in the second cardinality.
    *
@@ -1589,7 +1589,7 @@ public class Syn2SemDiffHelper {
       return false;
     }
   }
-
+  
   public static AssocCardinality cardToEnum(ASTCDCardinality cardinality) {
     if (cardinality.isOne()) {
       return AssocCardinality.One;
@@ -1604,7 +1604,7 @@ public class Syn2SemDiffHelper {
       return AssocCardinality.Multiple;
     }
   }
-
+  
   /**
    * Get the minimal non-abstract subclass(strict subclass) of a given type. The minimal subclass is
    * the subclass with the least amount of attributes and associations(ingoing and outgoing).
@@ -1616,11 +1616,11 @@ public class Syn2SemDiffHelper {
   public Optional<ASTCDClass> minSubClass(ASTCDType baseClass, boolean isSource) {
     ArrayListMultimap<ASTCDType, ASTCDClass> subMap = isSource ? srcSubMap : tgtSubMap;
     Set<ASTCDType> notInstClasses = isSource ? notInstClassesSrc : notInstClassesTgt;
-
+    
     List<ASTCDClass> subClasses = subMap.get(baseClass);
     int lowestCount = Integer.MAX_VALUE;
     ASTCDClass subclassWithLowestCount = null;
-
+    
     for (ASTCDClass subclass : subClasses) {
       if (!subclass.getModifier().isAbstract() && !notInstClasses.contains(subclass)) {
         int attributeCount;
@@ -1633,23 +1633,23 @@ public class Syn2SemDiffHelper {
         int associationCount = getAssociationCount(subclass, isSource);
         int otherAssocsCount = getAllOtherAssocs(subclass, isSource).size();
         int totalCount = attributeCount + associationCount + otherAssocsCount;
-
+        
         if (totalCount < lowestCount) {
           lowestCount = totalCount;
           subclassWithLowestCount = subclass;
         }
       }
     }
-
+    
     return Optional.ofNullable(subclassWithLowestCount);
   }
-
+  
   public int getAssociationCount(ASTCDType astcdClass, boolean isSource) {
     int count = 0;
     // Determine which map and CD to use based on whether it's source or target
     ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
     ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-
+    
     for (AssocStruct assocStruct : mapToUse.get(astcdClass)) {
       if (assocStruct.getSide().equals(ClassSide.Left)) {
         if ((assocStruct.getAssociation().getRight().getCDCardinality().isAtLeastOne()
@@ -1672,7 +1672,7 @@ public class Syn2SemDiffHelper {
     }
     return count;
   }
-
+  
   /**
    * Check if the directions match in reverse.
    *
@@ -1698,7 +1698,7 @@ public class Syn2SemDiffHelper {
                           AssocDirection.RightToLeft) && tgtStruct.a.getDirection().equals(
                               AssocDirection.LeftToRight)));
   }
-
+  
   public static boolean matchDirection(AssocStruct srcStruct,
       Pair<AssocStruct, ClassSide> tgtStruct) {
     if (((srcStruct.getSide().equals(ClassSide.Left) && tgtStruct.b.equals(ClassSide.Left))
@@ -1716,7 +1716,7 @@ public class Syn2SemDiffHelper {
                           AssocDirection.RightToLeft) && tgtStruct.a.getDirection().equals(
                               AssocDirection.LeftToRight)));
   }
-
+  
   public boolean sameAssocStruct(AssocStruct srcStruct, AssocStruct tgtStruct) {
     return CDDiffUtil.inferRole(srcStruct.getAssociation().getLeft()).equals(CDDiffUtil.inferRole(
         tgtStruct.getAssociation().getLeft())) && CDDiffUtil.inferRole(srcStruct.getAssociation()
@@ -1726,7 +1726,7 @@ public class Syn2SemDiffHelper {
         && matchRoleNames(srcStruct.getAssociation().getRight(), tgtStruct.getAssociation()
             .getRight());
   }
-
+  
   public boolean sameAssocStructInReverse(AssocStruct struct, AssocStruct tgtStruct) {
     return CDDiffUtil.inferRole(struct.getAssociation().getLeft()).equals(CDDiffUtil.inferRole(
         tgtStruct.getAssociation().getRight())) && CDDiffUtil.inferRole(struct.getAssociation()
@@ -1735,7 +1735,7 @@ public class Syn2SemDiffHelper {
         && matchRoleNames(struct.getAssociation().getLeft(), tgtStruct.getAssociation().getRight())
         && matchRoleNames(struct.getAssociation().getRight(), tgtStruct.getAssociation().getLeft());
   }
-
+  
   /**
    * Compare associations. If for a pair of associations one of them is a subassociation and a loop
    * association, the other one is marked so that it won't be looked at for generation of object
@@ -1754,7 +1754,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   public boolean sameAssociationSpec(ASTCDAssociation association, ASTCDAssociation association2) {
     Pair<ASTCDCardinality, ASTCDCardinality> cardinalities = getCardinality(association2);
     Pair<ASTCDType, ASTCDType> conncected1 = getConnectedTypes(association, srcCD);
@@ -1770,12 +1770,12 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   public boolean isLoopStruct(AssocStruct assocStruct) {
     Pair<ASTCDType, ASTCDType> pair = getConnectedTypes(assocStruct.getAssociation(), srcCD);
     return pair.a.equals(pair.b);
   }
-
+  
   /**
    * Delete all associations that use the given type as target.
    *
@@ -1786,9 +1786,9 @@ public class Syn2SemDiffHelper {
     // Select the map and CD to use based on whether it's source or target
     ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
     ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-
+    
     List<Pair<ASTCDType, List<AssocStruct>>> toDelete = new ArrayList<>();
-
+    
     for (ASTCDType toCheck : mapToUse.keySet()) {
       if (toCheck != astcdType) {
         List<AssocStruct> toDeleteStructs = new ArrayList<>();
@@ -1807,7 +1807,7 @@ public class Syn2SemDiffHelper {
         toDelete.add(new Pair<>(toCheck, toDeleteStructs));
       }
     }
-
+    
     // Remove the structures from the map
     for (Pair<ASTCDType, List<AssocStruct>> pair : toDelete) {
       for (AssocStruct struct : pair.b) {
@@ -1815,7 +1815,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   /**
    * Delete the association from the other associated type.
    *
@@ -1827,7 +1827,7 @@ public class Syn2SemDiffHelper {
       // Select the appropriate map and CD based on the isSource flag
       ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
       ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-
+      
       if (assocStruct.getSide().equals(ClassSide.Left)) {
         // Get the associated types on the right side
         ASTCDType connectedTypeB = getConnectedTypes(assocStruct.getAssociation(), cdToUse).b;
@@ -1858,7 +1858,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   /**
    * This function is used when the object diagrams are derived under simple semantics. The function
    * changes the stereotype to contain only the base type of the object without the superclasses.
@@ -1882,7 +1882,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   /**
    * Get the cardinalities of an association.
    *
@@ -1898,7 +1898,7 @@ public class Syn2SemDiffHelper {
     else {
       left = association.getLeft().getCDCardinality();
     }
-
+    
     if (!association.getRight().isPresentCDCardinality()) {
       right = new ASTCDCardMult();
     }
@@ -1907,7 +1907,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(left, right);
   }
-
+  
   /**
    * Get the matching AssocStructs for a given pair. The id 'unmodifiedAssoc' is used to identify
    * the association in the map.
@@ -1929,7 +1929,7 @@ public class Syn2SemDiffHelper {
     else if (getAssocStructByUnmod(srcCLasses.b, srcAssoc, true).isPresent()) {
       srcStruct = getAssocStructByUnmod(srcCLasses.b, srcAssoc, true).get();
     }
-
+    
     if (!reversed && getAssocStructByUnmod(tgtCLasses.a, tgtAssoc, false).isPresent()) {
       tgtStruct = getAssocStructByUnmod(tgtCLasses.a, tgtAssoc, false).get();
     }
@@ -1938,7 +1938,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(srcStruct, tgtStruct);
   }
-
+  
   /**
    * Get the matching AssocStructs for a given association in srcCD/tgtCD.
    *
@@ -1952,7 +1952,7 @@ public class Syn2SemDiffHelper {
     // Select the appropriate map and CD based on the isSource flag
     ArrayListMultimap<ASTCDType, AssocStruct> mapToUse = isSource ? srcMap : tgtMap;
     ASTCDCompilationUnit cdToUse = isSource ? srcCD : tgtCD;
-
+    
     // Iterate through the AssocStructs for the given ASTCDType
     for (AssocStruct struct : mapToUse.get(astcdType)) {
       if (sameAssociation(struct.getUnmodifiedAssoc(), association, cdToUse)) {
@@ -1961,7 +1961,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   /**
    * Check if the superclasses of the given one are the same in the source and target diagram.
    *
@@ -2000,7 +2000,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Delete associations from srcMap with a specific role name
    *
@@ -2035,7 +2035,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   public boolean isOtherSideNeeded(AssocStruct assocStruct) {
     if (assocStruct.getSide().equals(ClassSide.Left) && (assocStruct.getAssociation().getRight()
         .getCDCardinality().isOne() || assocStruct.getAssociation().getRight().getCDCardinality()
@@ -2046,7 +2046,7 @@ public class Syn2SemDiffHelper {
         .getCDCardinality().isOne() || assocStruct.getAssociation().getLeft().getCDCardinality()
             .isAtLeastOne());
   }
-
+  
   /**
    * Check for all compositions if a subcomponent cannot be instantiated. If this is the case, the
    * composite class cannot be instantiated either.
@@ -2068,7 +2068,7 @@ public class Syn2SemDiffHelper {
         }
       }
     }
-
+    
     for (ASTCDType astcdType : tgtMap.keySet()) {
       for (ASTCDAssociation association : getCDAssociationsListForType(astcdType, false)) {
         Pair<ASTCDType, ASTCDType> pair = Syn2SemDiffHelper.getConnectedTypes(association, tgtCD);
@@ -2086,7 +2086,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   /**
    * Delete associations from trgMap with a specific role name
    *
@@ -2121,7 +2121,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   public List<AssocStruct> deletedAssocsForClass(ASTCDType astcdClass) {
     List<AssocStruct> list = new ArrayList<>();
     for (ASTCDAssociation association : deletedAssocs) {
@@ -2130,7 +2130,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-
+  
   /**
    * Search for an association in srcCD that can't be matched with an association in tgtCD.
    *
@@ -2193,12 +2193,12 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-
+  
   public boolean containedInList(AssocStruct srcStruct, AssocStruct tgtAssocStruct) {
     return diffs.stream().anyMatch(obj -> obj.getSrcElem() == srcStruct.getUnmodifiedAssoc() && obj
         .getTgtElem() == tgtAssocStruct.getUnmodifiedAssoc());
   }
-
+  
   /**
    * Search for an association in tgtCD that can't be matched with an association in srcCD.
    *
@@ -2249,7 +2249,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-
+  
   public List<AssocStruct> addedAssocsForClass(ASTCDType astcdClass) {
     List<AssocStruct> list = new ArrayList<>();
     for (ASTCDAssociation association : addedAssocs) {
@@ -2258,7 +2258,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-
+  
   /**
    * Get two non-abstract subclasses for a given pair.
    *
@@ -2320,7 +2320,7 @@ public class Syn2SemDiffHelper {
     }
     return null;
   }
-
+  
   public static ASTCDClass getCDClass(ASTCDCompilationUnit compilationUnit, String className) {
     for (ASTCDClass astcdClass : compilationUnit.getCDDefinition().getCDClassesList()) {
       if (astcdClass.getSymbol().getInternalQualifiedName().equals(className)) {
@@ -2329,7 +2329,7 @@ public class Syn2SemDiffHelper {
     }
     return null;
   }
-
+  
   /**
    * Check what the changes to the stereotype of a class are.
    *
@@ -2351,7 +2351,7 @@ public class Syn2SemDiffHelper {
     }
     return new Pair<>(abstractChange, singletonChange);
   }
-
+  
   /**
    * Sort the associations for a given type so that pairs aren't duplicated.
    *
@@ -2425,13 +2425,13 @@ public class Syn2SemDiffHelper {
     }
     return new OverlappingAssocsDirect(directOverlappingAssocs, directOverlappingNoRelation);
   }
-
+  
   public OverlappingAssocsDirect computeDirectForTypeNew(ASTCDType astcdType,
       ArrayListMultimap<ASTCDType, AssocStruct> map, ASTCDCompilationUnit compilationUnit) {
-
+    
     Set<Pair<AssocStruct, AssocStruct>> directOverlappingAssocs = new HashSet<>();
     Set<Pair<AssocStruct, AssocStruct>> directOverlappingNoRelation = new HashSet<>();
-
+    
     List<AssocStruct> assocStructs = map.get(astcdType);
     for (AssocStruct assoc1 : assocStructs) {
       for (AssocStruct assoc2 : assocStructs) {
@@ -2441,17 +2441,17 @@ public class Syn2SemDiffHelper {
                 compilationUnit);
             Pair<ASTCDType, ASTCDType> types2 = getConnectedTypes(assoc2.getAssociation(),
                 compilationUnit);
-
+            
             if (areTypesValid(types1, types2)) {
               AssocStruct sub = assoc1;
               AssocStruct sup = assoc2;
-
+              
               if (isSwappable(assoc1, assoc2, types1, types2)) {
                 sub = assoc2;
                 sup = assoc1;
               }
               updateAssocUsage(sub, sup, compilationUnit);
-
+              
               directOverlappingAssocs.add(new Pair<>(sub, sup));
             }
           }
@@ -2460,17 +2460,17 @@ public class Syn2SemDiffHelper {
     }
     return new OverlappingAssocsDirect(directOverlappingAssocs, directOverlappingNoRelation);
   }
-
+  
   private boolean pairExists(Set<Pair<AssocStruct, AssocStruct>> set, AssocStruct a,
       AssocStruct b) {
     return set.stream().anyMatch(pair -> (pair.a == b && pair.b == a));
   }
-
+  
   private boolean areTypesValid(Pair<ASTCDType, ASTCDType> pair1,
       Pair<ASTCDType, ASTCDType> pair2) {
     return pair1.a != null && pair1.b != null && pair2.a != null && pair2.b != null;
   }
-
+  
   private boolean isSwappable(AssocStruct assoc1, AssocStruct assoc2,
       Pair<ASTCDType, ASTCDType> pair1, Pair<ASTCDType, ASTCDType> pair2) {
     return assoc1.getSide().equals(ClassSide.Left) && assoc2.getSide().equals(ClassSide.Left)
@@ -2481,7 +2481,7 @@ public class Syn2SemDiffHelper {
                     pair2.a) || assoc1.getSide().equals(ClassSide.Right) && assoc2.getSide().equals(
                         ClassSide.Left) && pair1.a.equals(pair2.b) && pair1.b.equals(pair2.a);
   }
-
+  
   private void updateAssocUsage(AssocStruct sub, AssocStruct sup,
       ASTCDCompilationUnit compilationUnit) {
     setOtherSideUsage(sub, AssocType.SUB, compilationUnit);
@@ -2493,7 +2493,7 @@ public class Syn2SemDiffHelper {
       sup.setUsedAs(AssocType.SUPER);
     }
   }
-
+  
   /**
    * Get the pairs of duplicated associations for a given type
    *
@@ -2524,7 +2524,7 @@ public class Syn2SemDiffHelper {
     }
     return list;
   }
-
+  
   public void setOtherSideUsage(AssocStruct assocStruct, AssocType assocType,
       ASTCDCompilationUnit compilationUnit) {
     if (assocStruct.getDirection().equals(AssocDirection.BiDirectional)) {
@@ -2554,34 +2554,34 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   public void filterMatched() {
     matchedClasses.removeIf(pair -> !pair.a.getSymbol().getInternalQualifiedName().equals(pair.b
         .getSymbol().getInternalQualifiedName()));
-
+    
     matchedInterfaces.removeIf(pair -> !pair.a.getSymbol().getInternalQualifiedName().equals(pair.b
         .getSymbol().getInternalQualifiedName()));
   }
-
+  
   public void setMatcher() {
     matcher = new CachedMatches<>(matches.getAssocMatches());
   }
-
+  
   public List<Pair<ASTCDClass, List<AssocStruct>>> sortDiffs(
       List<Pair<ASTCDClass, AssocStruct>> input) {
     Map<ASTCDClass, List<AssocStruct>> resultMap = new HashMap<>();
-
+    
     for (Pair<ASTCDClass, AssocStruct> pair : input) {
       ASTCDClass cdClass = pair.a;
       AssocStruct assocStruct = pair.b;
-
+      
       resultMap.computeIfAbsent(cdClass, key -> new ArrayList<>()).add(assocStruct);
     }
-
+    
     return resultMap.entrySet().stream().map(entry -> new Pair<>(entry.getKey(), entry.getValue()))
         .collect(Collectors.toList());
   }
-
+  
   public Optional<Pair<ASTCDClass, List<AssocStruct>>> getPair(
       List<Pair<ASTCDClass, List<AssocStruct>>> list, ASTCDClass astcdClass) {
     for (Pair<ASTCDClass, List<AssocStruct>> pair : list) {
@@ -2591,7 +2591,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   /**
    * This function is used to treat duplicated associations BEFORE the overlapping associations.
    * This was needed as otherwise overlapping associations would be treated twice and eventually
@@ -2606,22 +2606,22 @@ public class Syn2SemDiffHelper {
     Set<ASTCDType> tgtToDelete = new HashSet<>();
     Set<Pair<ASTCDType, ASTCDRole>> tgtAssocsToDelete = new HashSet<>();
     Set<DeleteStruct> tgtAssocsToMergeWithDelete = new HashSet<>();
-
+    
     // Process source associations
     processAssociationMap(srcMap, srcCD, srcAssocsToMergeWithDelete, srcAssocsToDelete, srcToDelete,
         true);
-
+    
     // Process target associations
     processAssociationMap(tgtMap, tgtCD, tgtAssocsToMergeWithDelete, tgtAssocsToDelete, tgtToDelete,
         false);
-
+    
     // Handle deletions and merges for src
     handleDeletionsAndMerges(srcToDelete, srcAssocsToMergeWithDelete, srcAssocsToDelete, true);
-
+    
     // Handle deletions and merges for tgt
     handleDeletionsAndMerges(tgtToDelete, tgtAssocsToMergeWithDelete, tgtAssocsToDelete, false);
   }
-
+  
   // Helper method to process associations
   private void processAssociationMap(ArrayListMultimap<ASTCDType, AssocStruct> assocMap,
       ASTCDCompilationUnit cdType, Set<DeleteStruct> assocsToMergeWithDelete,
@@ -2646,7 +2646,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   // Determine if association is mergable
   private boolean isMergable(AssocStruct association, AssocStruct superAssoc, ASTCDType astcdClass,
       Set<DeleteStruct> assocsToMergeWithDelete, boolean isSrc) {
@@ -2655,14 +2655,14 @@ public class Syn2SemDiffHelper {
         || isInConflict(association, superAssoc) && inInheritanceRelation(association, superAssoc,
             isSrc ? srcCD : tgtCD);
   }
-
+  
   // Determine if association is deletable
   private boolean isDeletable(AssocStruct association, AssocStruct superAssoc, boolean isSrc) {
     return isInConflict(association, superAssoc) && !inInheritanceRelation(association, superAssoc,
         isSrc ? srcCD : tgtCD) && !getConnectedTypes(association.getAssociation(), isSrc ? srcCD
             : tgtCD).equals(getConnectedTypes(superAssoc.getAssociation(), isSrc ? srcCD : tgtCD));
   }
-
+  
   // Handle deletions and merges for src or tgt
   private void handleDeletionsAndMerges(Set<ASTCDType> toDelete,
       Set<DeleteStruct> assocsToMergeWithDelete, Set<Pair<ASTCDType, ASTCDRole>> assocsToDelete,
@@ -2687,7 +2687,7 @@ public class Syn2SemDiffHelper {
     removeAssociations(assocsToMergeWithDelete, isSrc);
     deleteAssociations(assocsToDelete, isSrc);
   }
-
+  
   // Delete a class and its subclasses
   private void deleteClassAndSubclasses(ASTCDType astcdClass, boolean isSrc) {
     if (isSrc) {
@@ -2707,7 +2707,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   // Remove associations
   private void removeAssociations(Set<DeleteStruct> assocsToMergeWithDelete, boolean isSrc) {
     for (DeleteStruct pair : assocsToMergeWithDelete) {
@@ -2719,7 +2719,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   // Delete associations
   private void deleteAssociations(Set<Pair<ASTCDType, ASTCDRole>> assocsToDelete, boolean isSrc) {
     for (Pair<ASTCDType, ASTCDRole> pair : assocsToDelete) {
@@ -2731,7 +2731,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   /**
    * Get a non-abstract class for changed type.
    *
@@ -2748,7 +2748,7 @@ public class Syn2SemDiffHelper {
     }
     return Optional.empty();
   }
-
+  
   /**
    * Check if an attribute is conatined in a class in tgtCD.
    *
@@ -2782,7 +2782,7 @@ public class Syn2SemDiffHelper {
     }
     return false;
   }
-
+  
   /**
    * Delete associations from subclasses in tgtCD.
    *
@@ -2804,7 +2804,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   /**
    * Delete associations from subclasses in srcCD.
    *
@@ -2824,7 +2824,7 @@ public class Syn2SemDiffHelper {
       }
     }
   }
-
+  
   public List<Pair<ASTCDClass, List<ASTCDAttribute>>> transform(
       List<Pair<ASTCDClass, ASTCDAttribute>> list) {
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> result = new ArrayList<>();
@@ -2833,7 +2833,7 @@ public class Syn2SemDiffHelper {
     }
     return result;
   }
-
+  
   /**
    * Sort the added and deleted attributes for a given type. This reduces the number of generated
    * diff-witnesses.
@@ -2843,7 +2843,7 @@ public class Syn2SemDiffHelper {
   public void sortTypeDiff(TypeDiffStruct typeDiffStruct) {
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> added = new ArrayList<>();
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> deleted = new ArrayList<>();
-
+    
     if (typeDiffStruct.getAddedAttributes() != null && !typeDiffStruct.getAddedAttributes()
         .isEmpty()) {
       added.addAll(typeDiffStruct.getAddedAttributes());
@@ -2852,33 +2852,33 @@ public class Syn2SemDiffHelper {
         .isEmpty()) {
       deleted.addAll(typeDiffStruct.getDeletedAttributes());
     }
-
+    
     Map<ASTCDClass, AddedDeletedAtt> classAttributeMap = new HashMap<>();
-
+    
     for (Pair<ASTCDClass, List<ASTCDAttribute>> pair : added) {
       ASTCDClass clazz = pair.a;
       List<ASTCDAttribute> attribute = pair.b;
-
+      
       if (!classAttributeMap.containsKey(clazz)) {
         classAttributeMap.put(clazz, new AddedDeletedAtt());
       }
       classAttributeMap.get(clazz).getAddedAttributes().addAll(attribute);
     }
-
+    
     for (Pair<ASTCDClass, List<ASTCDAttribute>> pair : deleted) {
       ASTCDClass clazz = pair.a;
       List<ASTCDAttribute> attribute = pair.b;
-
+      
       if (!classAttributeMap.containsKey(clazz)) {
         classAttributeMap.put(clazz, new AddedDeletedAtt());
       }
       classAttributeMap.get(clazz).getDeletedAttributes().addAll(attribute);
     }
-
+    
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> addedNew = new ArrayList<>();
     List<Pair<ASTCDClass, List<ASTCDAttribute>>> deletedNew = new ArrayList<>();
     List<Pair<ASTCDClass, AddedDeletedAtt>> addedDeleted = new ArrayList<>();
-
+    
     // Remove AddedDeletedAtt if no deleted attributes are present
     for (Map.Entry<ASTCDClass, AddedDeletedAtt> astcdClass : classAttributeMap.entrySet()) {
       if (astcdClass.getValue().getDeletedAttributes().isEmpty()) {
@@ -2896,5 +2896,5 @@ public class Syn2SemDiffHelper {
     typeDiffStruct.setAddedAttributes(addedNew);
     typeDiffStruct.setDeletedAttributes(deletedNew);
   }
-
+  
 }

--- a/cdmerge/src/main/java/de/monticore/cdmerge/CDMerge.java
+++ b/cdmerge/src/main/java/de/monticore/cdmerge/CDMerge.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 
 public class CDMerge {
-  
+
   /**
    * Set of Merge Parameters that are supported by the CD tool's CLI command `--mrg-config` as
    * defined in the README.
@@ -31,12 +31,12 @@ public class CDMerge {
       MergeParameter.MERGE_COMMENTS, MergeParameter.MERGE_ONLY_NAMED_ASSOCIATIONS,
       MergeParameter.MERGE_HETEROGENEOUS_TYPES, MergeParameter.PRIMITIVE_TYPE_CONVERSION,
       MergeParameter.STRICT, MergeParameter.WARNINGS_AS_ERRORS, MergeParameter.LOG_STDERR);
-  
+
   @Deprecated
   public static ASTCDCompilationUnit merge(List<ASTCDCompilationUnit> inputs) {
     return merge(inputs, "Merge", new HashSet<>());
   }
-  
+
   /**
    * merges inputCDs into composite CD according to specified mergeParameters
    *
@@ -44,9 +44,9 @@ public class CDMerge {
    */
   public static ASTCDCompilationUnit merge(List<ASTCDCompilationUnit> inputCDs,
       String compositeCDName, Set<MergeParameter> mergeParameters) {
-    
+
     Optional<ASTCDCompilationUnit> optAST;
-    
+
     if (inputCDs.size() < 2) {
       optAST = inputCDs.stream().findAny();
       if (optAST.isPresent()) {
@@ -55,15 +55,15 @@ public class CDMerge {
       Log.error("No Input-CD!");
       return null;
     }
-    
+
     try {
       optAST = new MergeTool(getConfig(inputCDs, compositeCDName, mergeParameters)).mergeCDs()
           .getMergedCD();
-      
+
       if (optAST.isPresent()) {
         return optAST.get();
       }
-      
+
     }
     catch (MergingException e) {
       Log.error(e.getMessage());
@@ -72,22 +72,22 @@ public class CDMerge {
     Log.error("Unknown Error");
     return null;
   }
-  
+
   /** helper-method that constructs the CDMergeConfig */
   private static CDMergeConfig getConfig(List<ASTCDCompilationUnit> inputModels, String name,
       Set<MergeParameter> mergeParameters) {
     CDMergeConfig.Builder builder = new CDMergeConfig.Builder(false).withParam(
         MergeParameter.AST_BASED).withParam(MergeParameter.OUTPUT_NAME, name);
-    
+
     mergeParameters.forEach(builder::withParam);
-    
+
     for (ASTCDCompilationUnit cd : inputModels) {
       Preconditions.checkNotNull(cd);
       builder.addInputAST(cd);
     }
     return builder.build();
   }
-  
+
   /**
    * Parses a json-object containing "Merge Parameters" as a json-array. Unsupported and unknown
    * parameters are filtered out.
@@ -112,5 +112,5 @@ public class CDMerge {
     }
     return mergeParameters;
   }
-  
+
 }

--- a/cdmerge/src/main/java/de/monticore/cdmerge/CDMerge.java
+++ b/cdmerge/src/main/java/de/monticore/cdmerge/CDMerge.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 
 public class CDMerge {
-
+  
   /**
    * Set of Merge Parameters that are supported by the CD tool's CLI command `--mrg-config` as
    * defined in the README.
@@ -31,12 +31,12 @@ public class CDMerge {
       MergeParameter.MERGE_COMMENTS, MergeParameter.MERGE_ONLY_NAMED_ASSOCIATIONS,
       MergeParameter.MERGE_HETEROGENEOUS_TYPES, MergeParameter.PRIMITIVE_TYPE_CONVERSION,
       MergeParameter.STRICT, MergeParameter.WARNINGS_AS_ERRORS, MergeParameter.LOG_STDERR);
-
+  
   @Deprecated
   public static ASTCDCompilationUnit merge(List<ASTCDCompilationUnit> inputs) {
     return merge(inputs, "Merge", new HashSet<>());
   }
-
+  
   /**
    * merges inputCDs into composite CD according to specified mergeParameters
    *
@@ -44,9 +44,9 @@ public class CDMerge {
    */
   public static ASTCDCompilationUnit merge(List<ASTCDCompilationUnit> inputCDs,
       String compositeCDName, Set<MergeParameter> mergeParameters) {
-
+    
     Optional<ASTCDCompilationUnit> optAST;
-
+    
     if (inputCDs.size() < 2) {
       optAST = inputCDs.stream().findAny();
       if (optAST.isPresent()) {
@@ -55,15 +55,15 @@ public class CDMerge {
       Log.error("No Input-CD!");
       return null;
     }
-
+    
     try {
       optAST = new MergeTool(getConfig(inputCDs, compositeCDName, mergeParameters)).mergeCDs()
           .getMergedCD();
-
+      
       if (optAST.isPresent()) {
         return optAST.get();
       }
-
+      
     }
     catch (MergingException e) {
       Log.error(e.getMessage());
@@ -72,22 +72,22 @@ public class CDMerge {
     Log.error("Unknown Error");
     return null;
   }
-
+  
   /** helper-method that constructs the CDMergeConfig */
   private static CDMergeConfig getConfig(List<ASTCDCompilationUnit> inputModels, String name,
       Set<MergeParameter> mergeParameters) {
     CDMergeConfig.Builder builder = new CDMergeConfig.Builder(false).withParam(
         MergeParameter.AST_BASED).withParam(MergeParameter.OUTPUT_NAME, name);
-
+    
     mergeParameters.forEach(builder::withParam);
-
+    
     for (ASTCDCompilationUnit cd : inputModels) {
       Preconditions.checkNotNull(cd);
       builder.addInputAST(cd);
     }
     return builder.build();
   }
-
+  
   /**
    * Parses a json-object containing "Merge Parameters" as a json-array. Unsupported and unknown
    * parameters are filtered out.
@@ -112,5 +112,5 @@ public class CDMerge {
     }
     return mergeParameters;
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AmbiguousMatchTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AmbiguousMatchTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -17,13 +18,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AmbiguousMatchTest extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/ambiguousMatch/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/ambiguousMatch/B.cd";
-  
+
   @Test
   public void testAssociationNonAssociative() throws IOException {
     List<String> inputModels = new ArrayList<>();
@@ -38,16 +39,16 @@ public class AmbiguousMatchTest extends BaseTest {
       assertTrue(e.getMessage().contains("Could not merge due to ambiguous match for"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.ASSERT_ASSOCIATIVITY).withParam(
             MergeParameter.FAIL_AMBIGUOUS).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AmbiguousMatchTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AmbiguousMatchTest.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -18,13 +17,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AmbiguousMatchTest extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/ambiguousMatch/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/ambiguousMatch/B.cd";
-
+  
   @Test
   public void testAssociationNonAssociative() throws IOException {
     List<String> inputModels = new ArrayList<>();
@@ -39,7 +38,7 @@ public class AmbiguousMatchTest extends BaseTest {
       assertTrue(e.getMessage().contains("Could not merge due to ambiguous match for"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.ASSERT_ASSOCIATIVITY).withParam(
@@ -50,5 +49,5 @@ public class AmbiguousMatchTest extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationAmbiguousRole.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationAmbiguousRole.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -17,13 +18,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationAmbiguousRole extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/ambiguousRole/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/ambiguousRole/B.cd";
-  
+
   @Test
   public void testAssociationAmbiguousRole() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,15 +43,15 @@ public class AssociationAmbiguousRole extends BaseTest {
       }
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY)
         .withParam(MergeParameter.FAIL_FAST);
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationAmbiguousRole.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationAmbiguousRole.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -18,13 +17,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationAmbiguousRole extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/ambiguousRole/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/ambiguousRole/B.cd";
-
+  
   @Test
   public void testAssociationAmbiguousRole() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -43,7 +42,7 @@ public class AssociationAmbiguousRole extends BaseTest {
       }
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY)
         .withParam(MergeParameter.FAIL_FAST);
@@ -53,5 +52,5 @@ public class AssociationAmbiguousRole extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCardinalities.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCardinalities.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -21,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationCardinalities extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/cardinalities/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/cardinalities/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/cardinalities/mergedCD.cd";
-
+  
   @Test
   public void testAssociationCardinalities() throws IOException {
     List<String> inputModels = new ArrayList<>();
@@ -48,7 +47,7 @@ public class AssociationCardinalities extends BaseTest {
       fail("Unexpected exception: " + e.getMessage());
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
@@ -59,5 +58,5 @@ public class AssociationCardinalities extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCardinalities.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCardinalities.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,15 +21,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationCardinalities extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/cardinalities/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/cardinalities/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/cardinalities/mergedCD.cd";
-  
+
   @Test
   public void testAssociationCardinalities() throws IOException {
     List<String> inputModels = new ArrayList<>();
@@ -47,16 +48,16 @@ public class AssociationCardinalities extends BaseTest {
       fail("Unexpected exception: " + e.getMessage());
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
             MergeParameter.FAIL_FAST);
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionAssociation.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionAssociation.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationCompositionAssociation extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/compositionAssociation/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/compositionAssociation/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/compositionAssociation/mergedCD.cd";
-
+  
   @Test
   public void testAssociationCompositionAssociation() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,7 +40,7 @@ public class AssociationCompositionAssociation extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -51,5 +50,5 @@ public class AssociationCompositionAssociation extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionAssociation.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionAssociation.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationCompositionAssociation extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/compositionAssociation/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/compositionAssociation/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/compositionAssociation/mergedCD.cd";
-  
+
   @Test
   public void testAssociationCompositionAssociation() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,15 +41,15 @@ public class AssociationCompositionAssociation extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionDesignissue.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionDesignissue.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -18,35 +19,35 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationCompositionDesignissue extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/compositionDesignissue/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/compositionDesignissue/B.cd";
-  
+
   @Test
   public void testAssociationCompositionDesignissue() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
     inputModels.add(INPUT_MODEL_1);
     inputModels.add(INPUT_MODEL_2);
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
-    
+
     MergeResult result = cdMerger.mergeCDs();
     processResult(result);
     if (result.getMaxErrorLevel() != ErrorLevel.DESIGN_ISSUE) {
       fail("Expected design issue because of ambiguous composition");
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY)
         .withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionDesignissue.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationCompositionDesignissue.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,27 +18,27 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationCompositionDesignissue extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/compositionDesignissue/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/compositionDesignissue/B.cd";
-
+  
   @Test
   public void testAssociationCompositionDesignissue() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
     inputModels.add(INPUT_MODEL_1);
     inputModels.add(INPUT_MODEL_2);
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
-
+    
     MergeResult result = cdMerger.mergeCDs();
     processResult(result);
     if (result.getMaxErrorLevel() != ErrorLevel.DESIGN_ISSUE) {
       fail("Expected design issue because of ambiguous composition");
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY)
         .withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -49,5 +48,5 @@ public class AssociationCompositionDesignissue extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationDerived.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationDerived.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -19,15 +18,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationDerived extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/testDerived/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/testDerived/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/testDerived/mergedCD.cd";
-
+  
   @Test
   public void testAssociationDerived() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -37,10 +36,10 @@ public class AssociationDerived extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-
+    
     assertTrue(results.getMergedCD().get().deepEquals(expectedCD, false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -50,5 +49,5 @@ public class AssociationDerived extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationDerived.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationDerived.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -18,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationDerived extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/testDerived/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/testDerived/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/testDerived/mergedCD.cd";
-  
+
   @Test
   public void testAssociationDerived() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -36,18 +37,18 @@ public class AssociationDerived extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    
+
     assertTrue(results.getMergedCD().get().deepEquals(expectedCD, false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNavigations.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNavigations.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationNavigations extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/navigations/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/navigations/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/navigations/mergedCD.cd";
-
+  
   @Test
   public void testAssociationNavigations() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,7 +40,7 @@ public class AssociationNavigations extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -51,5 +50,5 @@ public class AssociationNavigations extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNavigations.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNavigations.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationNavigations extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/navigations/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/navigations/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/navigations/mergedCD.cd";
-  
+
   @Test
   public void testAssociationNavigations() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,15 +41,15 @@ public class AssociationNavigations extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNoMatch.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNoMatch.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,15 +21,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationNoMatch extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/noMatch/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/noMatch/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/noMatch/mergedCD.cd";
-  
+
   @Test
   public void testAssociationNoMatch() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,7 +43,7 @@ public class AssociationNoMatch extends BaseTest {
       if (result.getMaxErrorLevel().ordinal() < ErrorLevel.WARNING.ordinal()) {
         fail("Warnings expected due to ambiguous association roles");
       }
-      
+
       if (!result.getLog(ErrorLevel.WARNING).hasLogWithMessageContaining(
           ".*Navigation over .* is ambiguous.*")) {
         fail("Warnings expected due to ambiguous association roles");
@@ -52,15 +53,15 @@ public class AssociationNoMatch extends BaseTest {
       fail("Unexpected Exception: " + unexpected.getMessage());
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNoMatch.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationNoMatch.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -21,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationNoMatch extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/noMatch/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/noMatch/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/noMatch/mergedCD.cd";
-
+  
   @Test
   public void testAssociationNoMatch() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -43,7 +42,7 @@ public class AssociationNoMatch extends BaseTest {
       if (result.getMaxErrorLevel().ordinal() < ErrorLevel.WARNING.ordinal()) {
         fail("Warnings expected due to ambiguous association roles");
       }
-
+      
       if (!result.getLog(ErrorLevel.WARNING).hasLogWithMessageContaining(
           ".*Navigation over .* is ambiguous.*")) {
         fail("Warnings expected due to ambiguous association roles");
@@ -53,7 +52,7 @@ public class AssociationNoMatch extends BaseTest {
       fail("Unexpected Exception: " + unexpected.getMessage());
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -63,5 +62,5 @@ public class AssociationNoMatch extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierConflict.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -19,13 +20,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationQualifierConflict extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/qualifierConflict/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/qualifierConflict/B.cd";
-  
+
   @Test
   public void testAssociationQualifierConflict() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -43,16 +44,16 @@ public class AssociationQualifierConflict extends BaseTest {
           "Association with same name but incompatible cardinalities"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierConflict.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,13 +19,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationQualifierConflict extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/qualifierConflict/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/qualifierConflict/B.cd";
-
+  
   @Test
   public void testAssociationQualifierConflict() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -44,7 +43,7 @@ public class AssociationQualifierConflict extends BaseTest {
           "Association with same name but incompatible cardinalities"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
@@ -55,5 +54,5 @@ public class AssociationQualifierConflict extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierOK.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierOK.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,16 +20,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationQualifierOK extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/qualifierOK/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/qualifierOK/B.cd";
-  
+
   private static final String EXPECTED = "src/test/resources/class_diagrams/Association"
       + "/qualifierOK/mergedCD.cd";
-  
+
   @Test
   public void testAssociationQualifierOK() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,15 +42,15 @@ public class AssociationQualifierOK extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierOK.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationQualifierOK.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,16 +19,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationQualifierOK extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/qualifierOK/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/qualifierOK/B.cd";
-
+  
   private static final String EXPECTED = "src/test/resources/class_diagrams/Association"
       + "/qualifierOK/mergedCD.cd";
-
+  
   @Test
   public void testAssociationQualifierOK() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,7 +41,7 @@ public class AssociationQualifierOK extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -52,5 +51,5 @@ public class AssociationQualifierOK extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesAttributeConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesAttributeConflict.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -19,13 +20,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationRolesAttributeConflict extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/rolesAttributeConflict/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/rolesAttributeConflict/B.cd";
-  
+
   @Test
   public void testAssociationRolesAttributeConflict() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,16 +42,16 @@ public class AssociationRolesAttributeConflict extends BaseTest {
       assertTrue(expected.toString().contains("Name of the field or role 'worker' is not unique"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesAttributeConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesAttributeConflict.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,13 +19,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationRolesAttributeConflict extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/rolesAttributeConflict/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/rolesAttributeConflict/B.cd";
-
+  
   @Test
   public void testAssociationRolesAttributeConflict() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,7 +41,7 @@ public class AssociationRolesAttributeConflict extends BaseTest {
       assertTrue(expected.toString().contains("Name of the field or role 'worker' is not unique"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
@@ -53,5 +52,5 @@ public class AssociationRolesAttributeConflict extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesConflict.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,13 +19,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationRolesConflict extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/rolesConflict/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/rolesConflict/B.cd";
-
+  
   @Test
   public void testAssociationRolesConflict() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -43,7 +42,7 @@ public class AssociationRolesConflict extends BaseTest {
           "Association with same name but conflicting roles"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
@@ -54,5 +53,5 @@ public class AssociationRolesConflict extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesConflict.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesConflict.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -19,13 +20,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationRolesConflict extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Association/rolesConflict/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Association/rolesConflict/B.cd";
-  
+
   @Test
   public void testAssociationRolesConflict() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,16 +43,16 @@ public class AssociationRolesConflict extends BaseTest {
           "Association with same name but conflicting roles"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesSimple.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesSimple.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationRolesSimple extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/rolesSimple/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/rolesSimple/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/rolesSimple/mergedCD.cd";
-
+  
   @Test
   public void testAssociationRolesSimple() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,7 +40,7 @@ public class AssociationRolesSimple extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -51,5 +50,5 @@ public class AssociationRolesSimple extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesSimple.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesSimple.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationRolesSimple extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/rolesSimple/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/rolesSimple/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/rolesSimple/mergedCD.cd";
-  
+
   @Test
   public void testAssociationRolesSimple() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,15 +41,15 @@ public class AssociationRolesSimple extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesWithAssocName.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesWithAssocName.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationRolesWithAssocName extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/rolesWithAssocName/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/rolesWithAssocName/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/rolesWithAssocName/mergedCD.cd";
-
+  
   @Test
   public void testAssociationRolesWithAssocName() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,16 +40,16 @@ public class AssociationRolesWithAssocName extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesWithAssocName.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociationRolesWithAssocName.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociationRolesWithAssocName extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Association";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/rolesWithAssocName/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/rolesWithAssocName/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/rolesWithAssocName/mergedCD.cd";
-  
+
   @Test
   public void testAssociationRolesWithAssocName() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,16 +41,16 @@ public class AssociationRolesWithAssocName extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociativityTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociativityTest.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -18,16 +17,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociativityTest extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/notAssociative/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/notAssociative/B.cd";
-
+  
   private static final String INPUT_MODEL_3 = "src/test/resources/class_diagrams"
       + "/notAssociative/C.cd";
-
+  
   @Test
   public void testAssociationNonAssociative() throws IOException {
     List<String> inputModels = new ArrayList<>();
@@ -43,7 +42,7 @@ public class AssociativityTest extends BaseTest {
       assertTrue(e.getMessage().contains("Input CDs are NOT associative"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.ASSERT_ASSOCIATIVITY).withParam(
@@ -54,5 +53,5 @@ public class AssociativityTest extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociativityTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AssociativityTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -17,16 +18,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AssociativityTest extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/notAssociative/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/notAssociative/B.cd";
-  
+
   private static final String INPUT_MODEL_3 = "src/test/resources/class_diagrams"
       + "/notAssociative/C.cd";
-  
+
   @Test
   public void testAssociationNonAssociative() throws IOException {
     List<String> inputModels = new ArrayList<>();
@@ -42,16 +43,16 @@ public class AssociativityTest extends BaseTest {
       assertTrue(e.getMessage().contains("Input CDs are NOT associative"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.ASSERT_ASSOCIATIVITY).withParam(
             MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeConflictDifferentTypes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeConflictDifferentTypes.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,13 +19,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AttributeConflictDifferentTypes extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams/Attribute"
       + "/conflictDifferentTypes/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams/Attribute"
       + "/conflictDifferentTypes/B.cd";
-
+  
   @Test
   public void testAttributeConflictDifferentTypes() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -43,17 +42,17 @@ public class AttributeConflictDifferentTypes extends BaseTest {
           "Name of the field or role 'birthday' is not unique for the class 'Person'"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeConflictDifferentTypes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeConflictDifferentTypes.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -19,13 +20,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AttributeConflictDifferentTypes extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams/Attribute"
       + "/conflictDifferentTypes/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams/Attribute"
       + "/conflictDifferentTypes/B.cd";
-  
+
   @Test
   public void testAttributeConflictDifferentTypes() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,17 +43,17 @@ public class AttributeConflictDifferentTypes extends BaseTest {
           "Name of the field or role 'birthday' is not unique for the class 'Person'"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDifferentAttributes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDifferentAttributes.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AttributeDifferentAttributes extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Attribute";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/differentAttributes/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/differentAttributes/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/differentAttributes/mergedCD.cd";
-
+  
   @Test
   public void testAttributeDifferentAttributes() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,7 +40,7 @@ public class AttributeDifferentAttributes extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -51,5 +50,5 @@ public class AttributeDifferentAttributes extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDifferentAttributes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDifferentAttributes.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AttributeDifferentAttributes extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Attribute";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/differentAttributes/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/differentAttributes/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/differentAttributes/mergedCD.cd";
-  
+
   @Test
   public void testAttributeDifferentAttributes() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,15 +41,15 @@ public class AttributeDifferentAttributes extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDuplicateAttributes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDuplicateAttributes.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AttributeDuplicateAttributes extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Attribute";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/duplicateAttributes/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/duplicateAttributes/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/duplicateAttributes/mergedCD.cd";
-
+  
   @Test
   public void testAttributeDuplicateAttributes() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,7 +40,7 @@ public class AttributeDuplicateAttributes extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -51,5 +50,5 @@ public class AttributeDuplicateAttributes extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDuplicateAttributes.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/AttributeDuplicateAttributes.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class AttributeDuplicateAttributes extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Attribute";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/duplicateAttributes/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/duplicateAttributes/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/duplicateAttributes/mergedCD.cd";
-  
+
   @Test
   public void testAttributeDuplicateAttributes() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,15 +41,15 @@ public class AttributeDuplicateAttributes extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralAllFlavours.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralAllFlavours.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class GeneralAllFlavours extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/allFlavours/CDA.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/allFlavours/CDB.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/allFlavours/mergedCD.cd";
-
+  
   @Test
   public void testAllFlavours() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,18 +40,18 @@ public class GeneralAllFlavours extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
             MergeParameter.MERGE_HETEROGENEOUS_TYPES).withParam(
                 MergeParameter.DISABLE_CONTEXT_CONDITIONS);
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralAllFlavours.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralAllFlavours.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class GeneralAllFlavours extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/allFlavours/CDA.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/allFlavours/CDB.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/allFlavours/mergedCD.cd";
-  
+
   @Test
   public void testAllFlavours() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,18 +41,18 @@ public class GeneralAllFlavours extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
             MergeParameter.MERGE_HETEROGENEOUS_TYPES).withParam(
                 MergeParameter.DISABLE_CONTEXT_CONDITIONS);
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralFourClassDiagrams.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralFourClassDiagrams.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -22,19 +21,19 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class GeneralFourClassDiagrams extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/four_classdiagrams/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/four_classdiagrams/B.cd";
-
+  
   private static final String INPUT_MODEL_3 = INPUT_MODEL_DIR + "/four_classdiagrams/C.cd";
-
+  
   private static final String INPUT_MODEL_4 = INPUT_MODEL_DIR + "/four_classdiagrams/D.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/four_classdiagrams/mergedCD.cd";
-
+  
   @Test
   public void testFourCDs() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -49,7 +48,7 @@ public class GeneralFourClassDiagrams extends BaseTest {
       processResult(results);
       assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(
           expectedCD, false));
-
+      
     }
     catch (MergingException e) {
       if (e.getLog().isPresent()) {
@@ -61,7 +60,7 @@ public class GeneralFourClassDiagrams extends BaseTest {
       }
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
@@ -74,5 +73,5 @@ public class GeneralFourClassDiagrams extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralFourClassDiagrams.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralFourClassDiagrams.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -21,19 +22,19 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class GeneralFourClassDiagrams extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/four_classdiagrams/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/four_classdiagrams/B.cd";
-  
+
   private static final String INPUT_MODEL_3 = INPUT_MODEL_DIR + "/four_classdiagrams/C.cd";
-  
+
   private static final String INPUT_MODEL_4 = INPUT_MODEL_DIR + "/four_classdiagrams/D.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/four_classdiagrams/mergedCD.cd";
-  
+
   @Test
   public void testFourCDs() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -48,7 +49,7 @@ public class GeneralFourClassDiagrams extends BaseTest {
       processResult(results);
       assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(
           expectedCD, false));
-      
+
     }
     catch (MergingException e) {
       if (e.getLog().isPresent()) {
@@ -60,7 +61,7 @@ public class GeneralFourClassDiagrams extends BaseTest {
       }
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
@@ -68,10 +69,10 @@ public class GeneralFourClassDiagrams extends BaseTest {
         // FIXME Tool works but CoCo Fails
         .withParam(MergeParameter.DISABLE_CONTEXT_CONDITIONS);
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralOffice.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralOffice.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class GeneralOffice extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/office/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/office/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/office/mergedCD.cd";
-  
+
   @Test
   public void testOffice() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,18 +41,18 @@ public class GeneralOffice extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(result.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
             MergeParameter.MERGE_HETEROGENEOUS_TYPES).withParam(
                 MergeParameter.DISABLE_CONTEXT_CONDITIONS);
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralOffice.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/GeneralOffice.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class GeneralOffice extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/General";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/office/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/office/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/office/mergedCD.cd";
-
+  
   @Test
   public void testOffice() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,18 +40,18 @@ public class GeneralOffice extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(result.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
             MergeParameter.MERGE_HETEROGENEOUS_TYPES).withParam(
                 MergeParameter.DISABLE_CONTEXT_CONDITIONS);
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictCyclicInheritance.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictCyclicInheritance.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,13 +19,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceConflictCyclicInheritance extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Inheritance/conflictCyclicInheritance/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Inheritance/conflictCyclicInheritance/B.cd";
-
+  
   @Test
   public void testInheritanceConflictCyclicInheritance() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,17 +41,17 @@ public class InheritanceConflictCyclicInheritance extends BaseTest {
       assertTrue(expected.getMessage().contains("introduces a cyclic dependence"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictCyclicInheritance.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictCyclicInheritance.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -19,13 +20,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceConflictCyclicInheritance extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Inheritance/conflictCyclicInheritance/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Inheritance/conflictCyclicInheritance/B.cd";
-  
+
   @Test
   public void testInheritanceConflictCyclicInheritance() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,17 +42,17 @@ public class InheritanceConflictCyclicInheritance extends BaseTest {
       assertTrue(expected.getMessage().contains("introduces a cyclic dependence"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictSuperclasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictSuperclasses.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,13 +19,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceConflictSuperclasses extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Inheritance/conflictSuperclasses/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Inheritance/conflictSuperclasses/B.cd";
-
+  
   @Test
   public void testInheritanceConflictSuperclasses() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -44,7 +43,7 @@ public class InheritanceConflictSuperclasses extends BaseTest {
           " Merged classes have incompatible superclasses 'Staff' and 'Person'"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
@@ -55,5 +54,5 @@ public class InheritanceConflictSuperclasses extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictSuperclasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceConflictSuperclasses.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -19,13 +20,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceConflictSuperclasses extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams"
       + "/Inheritance/conflictSuperclasses/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams"
       + "/Inheritance/conflictSuperclasses/B.cd";
-  
+
   @Test
   public void testInheritanceConflictSuperclasses() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -43,16 +44,16 @@ public class InheritanceConflictSuperclasses extends BaseTest {
           " Merged classes have incompatible superclasses 'Staff' and 'Person'"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDisjointInterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDisjointInterfaces.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceDisjointInterfaces extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/disjointInterfaces/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/disjointInterfaces/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/disjointInterfaces/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceDisjointInterfaces() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,15 +41,15 @@ public class InheritanceDisjointInterfaces extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDisjointInterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDisjointInterfaces.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceDisjointInterfaces extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/disjointInterfaces/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/disjointInterfaces/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/disjointInterfaces/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceDisjointInterfaces() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,7 +40,7 @@ public class InheritanceDisjointInterfaces extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -51,5 +50,5 @@ public class InheritanceDisjointInterfaces extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDuplicateSuperinterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDuplicateSuperinterfaces.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceDuplicateSuperinterfaces extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceDuplicateSuperinterfaces() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,15 +41,15 @@ public class InheritanceDuplicateSuperinterfaces extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDuplicateSuperinterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceDuplicateSuperinterfaces.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceDuplicateSuperinterfaces extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/duplicateSuperinterfaces/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceDuplicateSuperinterfaces() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,7 +40,7 @@ public class InheritanceDuplicateSuperinterfaces extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -51,5 +50,5 @@ public class InheritanceDuplicateSuperinterfaces extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup1.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup1.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,16 +19,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceInheritanceAttributePullup1 extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup1/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup1/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/inheritanceAttributePullup1/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceInheritanceAttributePullup1() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,7 +41,7 @@ public class InheritanceInheritanceAttributePullup1 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY)
         .withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -52,5 +51,5 @@ public class InheritanceInheritanceAttributePullup1 extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup1.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup1.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,16 +20,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceInheritanceAttributePullup1 extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup1/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup1/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/inheritanceAttributePullup1/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceInheritanceAttributePullup1() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,15 +42,15 @@ public class InheritanceInheritanceAttributePullup1 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY)
         .withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup2.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup2.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -21,16 +20,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceInheritanceAttributePullup2 extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup2/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup2/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/inheritanceAttributePullup2/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceInheritanceAttributePullup2() throws IOException {
     List<String> inputModels = new ArrayList<>();
@@ -38,7 +37,7 @@ public class InheritanceInheritanceAttributePullup2 extends BaseTest {
     inputModels.add(INPUT_MODEL_2);
     final ASTCDCompilationUnit expectedCD = loadModel(Paths.get(EXPECTED));
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
-
+    
     MergeResult results = null;
     try {
       results = cdMerger.mergeCDs();
@@ -51,7 +50,7 @@ public class InheritanceInheritanceAttributePullup2 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -61,5 +60,5 @@ public class InheritanceInheritanceAttributePullup2 extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup2.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup2.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,16 +21,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceInheritanceAttributePullup2 extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup2/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup2/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/inheritanceAttributePullup2/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceInheritanceAttributePullup2() throws IOException {
     List<String> inputModels = new ArrayList<>();
@@ -37,7 +38,7 @@ public class InheritanceInheritanceAttributePullup2 extends BaseTest {
     inputModels.add(INPUT_MODEL_2);
     final ASTCDCompilationUnit expectedCD = loadModel(Paths.get(EXPECTED));
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
-    
+
     MergeResult results = null;
     try {
       results = cdMerger.mergeCDs();
@@ -50,15 +51,15 @@ public class InheritanceInheritanceAttributePullup2 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup3.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup3.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,16 +19,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceInheritanceAttributePullup3 extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup3/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup3/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/inheritanceAttributePullup3/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceInheritanceAttributePullup3() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,7 +41,7 @@ public class InheritanceInheritanceAttributePullup3 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
@@ -52,5 +51,5 @@ public class InheritanceInheritanceAttributePullup3 extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup3.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceInheritanceAttributePullup3.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,16 +20,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceInheritanceAttributePullup3 extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/inheritanceAttributePullup3/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/inheritanceAttributePullup3/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/inheritanceAttributePullup3/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceInheritanceAttributePullup3() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,15 +42,15 @@ public class InheritanceInheritanceAttributePullup3 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces1.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces1.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceRedundantSuperinterfaces1 extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceRedundantSuperinterfaces1() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,16 +41,16 @@ public class InheritanceRedundantSuperinterfaces1 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces1.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces1.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceRedundantSuperinterfaces1 extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/redundantSuperinterfaces1/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceRedundantSuperinterfaces1() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,16 +40,16 @@ public class InheritanceRedundantSuperinterfaces1 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces2.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces2.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceRedundantSuperinterfaces2 extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceRedundantSuperinterfaces2() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,16 +40,16 @@ public class InheritanceRedundantSuperinterfaces2 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces2.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceRedundantSuperinterfaces2.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceRedundantSuperinterfaces2 extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/redundantSuperinterfaces2/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceRedundantSuperinterfaces2() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,16 +41,16 @@ public class InheritanceRedundantSuperinterfaces2 extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceClasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceClasses.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,18 +20,18 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceTransitiveInheritanceClasses extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR
       + "/transitiveInheritanceClasses/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR
       + "/transitiveInheritanceClasses/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/transitiveInheritanceClasses/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceTransitiveInheritanceClasses() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -43,18 +44,18 @@ public class InheritanceTransitiveInheritanceClasses extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = new CDMergeConfig.Builder(false).withParam(
         MergeParameter.CHECK_ONLY, MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD").withParam(MergeParameter.LOG_DEBUG).withParam(
                 MergeParameter.LOG_TO_CONSOLE);
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceClasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceClasses.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,18 +19,18 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceTransitiveInheritanceClasses extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR
       + "/transitiveInheritanceClasses/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR
       + "/transitiveInheritanceClasses/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/transitiveInheritanceClasses/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceTransitiveInheritanceClasses() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -44,18 +43,18 @@ public class InheritanceTransitiveInheritanceClasses extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = new CDMergeConfig.Builder(false).withParam(
         MergeParameter.CHECK_ONLY, MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD").withParam(MergeParameter.LOG_DEBUG).withParam(
                 MergeParameter.LOG_TO_CONSOLE);
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceInterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceInterfaces.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,18 +20,18 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceTransitiveInheritanceInterfaces extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR
       + "/transitiveInheritanceInterfaces/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR
       + "/transitiveInheritanceInterfaces/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/transitiveInheritanceInterfaces/mergedCD.cd";
-  
+
   @Test
   public void testInheritanceTransitiveInheritanceInterfaces() throws IOException,
       MergingException {
@@ -44,16 +45,16 @@ public class InheritanceTransitiveInheritanceInterfaces extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceInterfaces.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/InheritanceTransitiveInheritanceInterfaces.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,18 +19,18 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class InheritanceTransitiveInheritanceInterfaces extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Inheritance";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR
       + "/transitiveInheritanceInterfaces/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR
       + "/transitiveInheritanceInterfaces/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/transitiveInheritanceInterfaces/mergedCD.cd";
-
+  
   @Test
   public void testInheritanceTransitiveInheritanceInterfaces() throws IOException,
       MergingException {
@@ -45,16 +44,16 @@ public class InheritanceTransitiveInheritanceInterfaces extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/StereotypeMergeTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/StereotypeMergeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDClass;
 import de.monticore.cdbasis._ast.ASTCDDefinition;
@@ -21,21 +22,21 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class StereotypeMergeTest extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams";
-  
+
   // A stereo
   private static final String INPUT_MODEL_A = INPUT_MODEL_DIR + "/Stereotypes/CD1.cd";
-  
+
   // B stereo
   private static final String INPUT_MODEL_B = INPUT_MODEL_DIR + "/Stereotypes/CD2.cd";
-  
+
   // No stereos
   private static final String INPUT_MODEL_NO = INPUT_MODEL_DIR + "/Stereotypes/CD3.cd";
-  
+
   // multiple stereos
   private static final String INPUT_MODEL_MULT = INPUT_MODEL_DIR + "/Stereotypes/CD4.cd";
-  
+
   @Test
   public void testMergeWithOneSide() throws IOException, MergingException {
     // Test merge (A, No_stereos): If all stereos of A are present in the result
@@ -45,10 +46,10 @@ public class StereotypeMergeTest extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    
+
     assertTrue(results.mergeSuccess());
     assertTrue(results.getMergedCD().isPresent());
-    
+
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
     assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
     assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
@@ -63,7 +64,7 @@ public class StereotypeMergeTest extends BaseTest {
     assertTrue(attr_a.getModifier().getStereotype().contains("A3"), "Attribute stereo incorrect");
     assertFalse(attr_no.getModifier().isPresentStereotype(), "Attribute stereo not missing");
   }
-  
+
   @Test
   public void testMergeWithOtherSide() throws IOException, MergingException {
     // Test merge (No_stereos, A): If all stereos of A are present in the result
@@ -73,10 +74,10 @@ public class StereotypeMergeTest extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    
+
     assertTrue(results.mergeSuccess());
     assertTrue(results.getMergedCD().isPresent());
-    
+
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
     assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
     assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
@@ -91,7 +92,7 @@ public class StereotypeMergeTest extends BaseTest {
     assertTrue(attr_a.getModifier().getStereotype().contains("A3"), "Attribute stereo incorrect");
     assertFalse(attr_no.getModifier().isPresentStereotype(), "Attribute stereo not missing");
   }
-  
+
   @Test
   public void testMergeWithBothSides() throws IOException, MergingException {
     // Test merge (A, B): If all stereos of A and B are present in the merged result
@@ -101,10 +102,10 @@ public class StereotypeMergeTest extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    
+
     assertTrue(results.mergeSuccess());
     assertTrue(results.getMergedCD().isPresent());
-    
+
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
     assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
     assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
@@ -124,7 +125,7 @@ public class StereotypeMergeTest extends BaseTest {
     assertTrue(attr_b.getModifier().isPresentStereotype(), "Attribute stereo missing");
     assertTrue(attr_b.getModifier().getStereotype().contains("B3"), "Attribute stereo incorrect");
   }
-  
+
   @Test
   public void testMergeWithBothSidesMult() throws IOException, MergingException {
     // Same as above, just that merge(A, MULT) where mult has multiple stereos
@@ -134,10 +135,10 @@ public class StereotypeMergeTest extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-    
+
     assertTrue(results.mergeSuccess());
     assertTrue(results.getMergedCD().isPresent());
-    
+
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
     assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
     assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
@@ -160,16 +161,16 @@ public class StereotypeMergeTest extends BaseTest {
     assertTrue(attr_mult.getModifier().getStereotype().contains("DD3"),
         "Attribute stereo incorrect");
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/StereotypeMergeTest.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/StereotypeMergeTest.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDAttribute;
 import de.monticore.cdbasis._ast.ASTCDClass;
@@ -22,21 +21,21 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class StereotypeMergeTest extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams";
-
+  
   // A stereo
   private static final String INPUT_MODEL_A = INPUT_MODEL_DIR + "/Stereotypes/CD1.cd";
-
+  
   // B stereo
   private static final String INPUT_MODEL_B = INPUT_MODEL_DIR + "/Stereotypes/CD2.cd";
-
+  
   // No stereos
   private static final String INPUT_MODEL_NO = INPUT_MODEL_DIR + "/Stereotypes/CD3.cd";
-
+  
   // multiple stereos
   private static final String INPUT_MODEL_MULT = INPUT_MODEL_DIR + "/Stereotypes/CD4.cd";
-
+  
   @Test
   public void testMergeWithOneSide() throws IOException, MergingException {
     // Test merge (A, No_stereos): If all stereos of A are present in the result
@@ -46,10 +45,10 @@ public class StereotypeMergeTest extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-
+    
     assertTrue(results.mergeSuccess());
     assertTrue(results.getMergedCD().isPresent());
-
+    
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
     assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
     assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
@@ -64,7 +63,7 @@ public class StereotypeMergeTest extends BaseTest {
     assertTrue(attr_a.getModifier().getStereotype().contains("A3"), "Attribute stereo incorrect");
     assertFalse(attr_no.getModifier().isPresentStereotype(), "Attribute stereo not missing");
   }
-
+  
   @Test
   public void testMergeWithOtherSide() throws IOException, MergingException {
     // Test merge (No_stereos, A): If all stereos of A are present in the result
@@ -74,10 +73,10 @@ public class StereotypeMergeTest extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-
+    
     assertTrue(results.mergeSuccess());
     assertTrue(results.getMergedCD().isPresent());
-
+    
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
     assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
     assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
@@ -92,7 +91,7 @@ public class StereotypeMergeTest extends BaseTest {
     assertTrue(attr_a.getModifier().getStereotype().contains("A3"), "Attribute stereo incorrect");
     assertFalse(attr_no.getModifier().isPresentStereotype(), "Attribute stereo not missing");
   }
-
+  
   @Test
   public void testMergeWithBothSides() throws IOException, MergingException {
     // Test merge (A, B): If all stereos of A and B are present in the merged result
@@ -102,10 +101,10 @@ public class StereotypeMergeTest extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-
+    
     assertTrue(results.mergeSuccess());
     assertTrue(results.getMergedCD().isPresent());
-
+    
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
     assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
     assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
@@ -125,7 +124,7 @@ public class StereotypeMergeTest extends BaseTest {
     assertTrue(attr_b.getModifier().isPresentStereotype(), "Attribute stereo missing");
     assertTrue(attr_b.getModifier().getStereotype().contains("B3"), "Attribute stereo incorrect");
   }
-
+  
   @Test
   public void testMergeWithBothSidesMult() throws IOException, MergingException {
     // Same as above, just that merge(A, MULT) where mult has multiple stereos
@@ -135,10 +134,10 @@ public class StereotypeMergeTest extends BaseTest {
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
-
+    
     assertTrue(results.mergeSuccess());
     assertTrue(results.getMergedCD().isPresent());
-
+    
     ASTCDDefinition def = results.getMergedCD().get().getCDDefinition();
     assertTrue(def.getModifier().isPresentStereotype(), "CDDefinition stereo missing");
     assertTrue(def.getModifier().getStereotype().contains("A1"), "CDDefinition stereo incorrect");
@@ -161,7 +160,7 @@ public class StereotypeMergeTest extends BaseTest {
     assertTrue(attr_mult.getModifier().getStereotype().contains("DD3"),
         "Attribute stereo incorrect");
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
@@ -172,5 +171,5 @@ public class StereotypeMergeTest extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesAbstractClasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesAbstractClasses.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,38 +20,38 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesAbstractClasses extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/abstractClasses/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/abstractClasses/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/abstractClasses/mergedCD.cd";
-  
+
   @Test
   public void testTypesAbstractClasses() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
     inputModels.add(INPUT_MODEL_1);
     inputModels.add(INPUT_MODEL_2);
     final ASTCDCompilationUnit expectedCD = loadModel(Paths.get(EXPECTED));
-    
+
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesAbstractClasses.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesAbstractClasses.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,38 +19,38 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesAbstractClasses extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/abstractClasses/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/abstractClasses/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/abstractClasses/mergedCD.cd";
-
+  
   @Test
   public void testTypesAbstractClasses() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
     inputModels.add(INPUT_MODEL_1);
     inputModels.add(INPUT_MODEL_2);
     final ASTCDCompilationUnit expectedCD = loadModel(Paths.get(EXPECTED));
-
+    
     final MergeTool cdMerger = new MergeTool(getConfig(inputModels));
     MergeResult results = cdMerger.mergeCDs();
     processResult(results);
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassEnum.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesHeterogeneousClassEnum extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousClassEnum/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousClassEnum/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/heterogeneousClassEnum/mergedCD.cd";
-  
+
   @Test
   public void testTypesHeterogeneousClassEnum() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,16 +41,16 @@ public class TypesHeterogeneousClassEnum extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
             MergeParameter.MERGE_HETEROGENEOUS_TYPES, MergeParameter.ON);
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassEnum.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesHeterogeneousClassEnum extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousClassEnum/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousClassEnum/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/heterogeneousClassEnum/mergedCD.cd";
-
+  
   @Test
   public void testTypesHeterogeneousClassEnum() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,7 +40,7 @@ public class TypesHeterogeneousClassEnum extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
@@ -52,5 +51,5 @@ public class TypesHeterogeneousClassEnum extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassInterface.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassInterface.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,16 +19,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesHeterogeneousClassInterface extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousClassInterface/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousClassInterface/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/heterogeneousClassInterface/mergedCD.cd";
-
+  
   @Test
   public void testTypesHeterogeneousClassInterface() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,7 +41,7 @@ public class TypesHeterogeneousClassInterface extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
@@ -53,5 +52,5 @@ public class TypesHeterogeneousClassInterface extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassInterface.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousClassInterface.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,16 +20,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesHeterogeneousClassInterface extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousClassInterface/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousClassInterface/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/heterogeneousClassInterface/mergedCD.cd";
-  
+
   @Test
   public void testTypesHeterogeneousClassInterface() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,16 +42,16 @@ public class TypesHeterogeneousClassInterface extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
             MergeParameter.MERGE_HETEROGENEOUS_TYPES, MergeParameter.ON);
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousInterfaceEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousInterfaceEnum.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,16 +19,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesHeterogeneousInterfaceEnum extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousInterfaceEnum/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousInterfaceEnum/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/heterogeneousInterfaceEnum/mergedCD.cd";
-
+  
   @Test
   public void testTypesHeterogeneousInterfaceEnum() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,7 +41,7 @@ public class TypesHeterogeneousInterfaceEnum extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
@@ -53,5 +52,5 @@ public class TypesHeterogeneousInterfaceEnum extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousInterfaceEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesHeterogeneousInterfaceEnum.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,16 +20,16 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesHeterogeneousInterfaceEnum extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/heterogeneousInterfaceEnum/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/heterogeneousInterfaceEnum/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR
       + "/heterogeneousInterfaceEnum/mergedCD.cd";
-  
+
   @Test
   public void testTypesHeterogeneousInterfaceEnum() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,16 +42,16 @@ public class TypesHeterogeneousInterfaceEnum extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD").withParam(
             MergeParameter.MERGE_HETEROGENEOUS_TYPES, MergeParameter.ON);
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesMergeEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesMergeEnum.java
@@ -3,7 +3,6 @@ package de.monticore.cdmerge.integrationtest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
@@ -20,15 +19,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesMergeEnum extends BaseTest {
-
+  
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-
+  
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/mergeEnum/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/mergeEnum/B.cd";
-
+  
   private static final String EXPECTED = INPUT_MODEL_DIR + "/mergeEnum/mergedCD.cd";
-
+  
   @Test
   public void testTypesMergeEnum() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,16 +40,16 @@ public class TypesMergeEnum extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-
+    
     for (String m : inputModels) {
       Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-
+  
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesMergeEnum.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesMergeEnum.java
@@ -4,6 +4,7 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -19,15 +20,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesMergeEnum extends BaseTest {
-  
+
   private static final String INPUT_MODEL_DIR = "src/test/resources/class_diagrams/Types";
-  
+
   private static final String INPUT_MODEL_1 = INPUT_MODEL_DIR + "/mergeEnum/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = INPUT_MODEL_DIR + "/mergeEnum/B.cd";
-  
+
   private static final String EXPECTED = INPUT_MODEL_DIR + "/mergeEnum/mergedCD.cd";
-  
+
   @Test
   public void testTypesMergeEnum() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -40,16 +41,16 @@ public class TypesMergeEnum extends BaseTest {
     assertTrue(parseCD(CDMergeUtils.prettyPrint(results.getMergedCD().get())).deepEquals(expectedCD,
         false));
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.OUTPUT_NAME, "mergedCD");
-    
+
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesNameConflictNonHeteorogenous.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesNameConflictNonHeteorogenous.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
 import de.monticore.cdmerge.config.CDMergeConfig;
@@ -19,13 +20,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesNameConflictNonHeteorogenous extends BaseTest {
-  
+
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams/Types"
       + "/NameConflictNonHeteorogenous/A.cd";
-  
+
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams/Types"
       + "/NameConflictNonHeteorogenous/B.cd";
-  
+
   @Test
   public void testTypesTypeNameConflictNonHeteorogenous() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -41,16 +42,16 @@ public class TypesNameConflictNonHeteorogenous extends BaseTest {
       assertTrue(expected.getMessage().contains("The name Color is used several times"));
     }
   }
-  
+
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
             "mergedCD");
     for (String m : inputModels) {
-      Preconditions.checkNotNull(loadModel(Paths.get(m)));
+      Verify.verifyNotNull(loadModel(Paths.get(m)));
       builder.addInputFile(m);
     }
     return builder.build();
   }
-  
+
 }

--- a/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesNameConflictNonHeteorogenous.java
+++ b/cdmerge/src/test/java/de/monticore/cdmerge/integrationtest/TypesNameConflictNonHeteorogenous.java
@@ -4,7 +4,6 @@ package de.monticore.cdmerge.integrationtest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import de.monticore.cdmerge.BaseTest;
 import de.monticore.cdmerge.MergeTool;
@@ -20,13 +19,13 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TypesNameConflictNonHeteorogenous extends BaseTest {
-
+  
   private static final String INPUT_MODEL_1 = "src/test/resources/class_diagrams/Types"
       + "/NameConflictNonHeteorogenous/A.cd";
-
+  
   private static final String INPUT_MODEL_2 = "src/test/resources/class_diagrams/Types"
       + "/NameConflictNonHeteorogenous/B.cd";
-
+  
   @Test
   public void testTypesTypeNameConflictNonHeteorogenous() throws IOException, MergingException {
     List<String> inputModels = new ArrayList<>();
@@ -42,7 +41,7 @@ public class TypesNameConflictNonHeteorogenous extends BaseTest {
       assertTrue(expected.getMessage().contains("The name Color is used several times"));
     }
   }
-
+  
   private CDMergeConfig getConfig(List<String> inputModels) throws IOException {
     CDMergeConfig.Builder builder = getConfigBuilder().withParam(MergeParameter.CHECK_ONLY,
         MergeParameter.ON).withParam(MergeParameter.FAIL_FAST).withParam(MergeParameter.OUTPUT_NAME,
@@ -53,5 +52,5 @@ public class TypesNameConflictNonHeteorogenous extends BaseTest {
     }
     return builder.build();
   }
-
+  
 }

--- a/cdtool/src/test/java/de/monticore/CDDiffCLIToolTest.java
+++ b/cdtool/src/test/java/de/monticore/CDDiffCLIToolTest.java
@@ -3,6 +3,7 @@ package de.monticore;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.common.base.Verify;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cddiff.CDDiffUtil;
 import de.monticore.cddiff.alloycddiff.CDSemantics;
@@ -20,17 +21,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class CDDiffCLIToolTest {
-  
+
   private static final String TOOL_PATH = "src/test/resources/de/monticore/";
   final String[] owDiffOptions = { "alloy-based", "reduction-based" };
-  
+
   final String[] cwDiffOptions = { "", "--rule-based" };
-  
+
   @BeforeEach
   public void init() {
     LogStub.init();
   }
-  
+
   @Test
   public void testChain() {
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
@@ -39,54 +40,54 @@ public class CDDiffCLIToolTest {
     String[] args = { "-i", cd1, "--merge", cd2, "--semdiff", cd2, "-o", output, "-pp",
         "Employees12.cd" };
     CD4CodeTool.main(args);
-    
+
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
     assertEquals(Log.getErrorCount(), 0);
   }
-  
+
   @Test
   public void testSyntaxDiff() {
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees1.cd";
     CD4CodeTool.main(new String[] { "-i", cd1, "--syntaxdiff", cd2, "--show", "all" });
-    
+
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
     assertEquals(Log.getErrorCount(), 0);
   }
-  
+
   @Test
   public void testConformance() {
     final String con = TOOL_PATH + "cdconformance/adapter/GraphAdapter.cd";
     final String ref = TOOL_PATH + "cdconformance/adapter/Adapter.cd";
     CD4CodeTool.main(new String[] { "-i", con, "--reference", ref, "--map", "m1", "m2" });
-    
+
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
     assertEquals(Log.getErrorCount(), 0);
   }
-  
+
   @Test
   public void testSemDiff() {
     // given 2 CDs that are not semantically equivalent
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees1.cd";
     final String output = "./target/generated/cddiff-test/CLITestWithDiff";
-    
+
     for (String cwDiffOption : cwDiffOptions) {
       // when CD4CodeTool is used to compute the semantic difference
       String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
           "--difflimit", "20", cwDiffOption };
       CD4CodeTool.main(args);
-      
+
       try {
-        ASTCDCompilationUnit ast1 = Objects.requireNonNull(CDDiffUtil.loadCD(cd1)).deepClone();
-        ASTCDCompilationUnit ast2 = Objects.requireNonNull(CDDiffUtil.loadCD(cd2)).deepClone();
-        
+        ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
+        ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
+
         // then corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         assertNotNull(odFiles);
-        
+
         // now check for each OD if it is a diff-witness, i.e., in sem(cd1)\sem(cd2)
-        
+
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
             assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.SIMPLE_CLOSED_WORLD, ast1,
@@ -97,7 +98,7 @@ public class CDDiffCLIToolTest {
       catch (NullPointerException | IOException e) {
         fail(e.getMessage());
       }
-      
+
       // clean-up
       try {
         PathUtils.delete(Paths.get(output));
@@ -107,20 +108,20 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-  
+
   @Test
   public void testNoSemDiff() {
     // given 2 CDs that are semantically equivalent
     final String cd1 = TOOL_PATH + "cddiff/SimilarManagers/CDSimilarManagerv1" + ".cd";
     final String cd2 = TOOL_PATH + "cddiff/SimilarManagers/CDSimilarManagerv2" + ".cd";
     final String output = "./target/generated/cddiff-test/CLITestWithoutDiff";
-    
+
     for (String cwDiffOption : cwDiffOptions) {
       // when CD4CodeTool is used to compute the semantic difference
       String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
           "--difflimit", "20", cwDiffOption };
       CD4CodeTool.main(args);
-      
+
       // no corresponding .od files are generated
       File[] odFiles = Paths.get(output).toFile().listFiles();
       if (odFiles == null) {
@@ -134,7 +135,7 @@ public class CDDiffCLIToolTest {
         }
       }
       assertTrue(odFilePaths.isEmpty());
-      
+
       // clean-up
       try {
         PathUtils.delete(Paths.get(output));
@@ -144,28 +145,28 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-  
+
   @Test
   public void testDefaultSemDiff() {
     // given 2 CDs that are not semantically equivalent
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees1.cd";
     final String output = "./target/generated/cddiff-test/CLITestWithDefaultDiff";
-    
+
     // when CD4CodeTool is used to compute the semantic difference
     String[] args = { "-i", cd1, "--semdiff", cd2, "-o", output };
     CD4CodeTool.main(args);
-    
+
     try {
-      ASTCDCompilationUnit ast1 = Objects.requireNonNull(CDDiffUtil.loadCD(cd1)).deepClone();
-      ASTCDCompilationUnit ast2 = Objects.requireNonNull(CDDiffUtil.loadCD(cd2)).deepClone();
-      
+      ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
+      ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
+
       // then corresponding .od files are generated
       File[] odFiles = Paths.get(output).toFile().listFiles();
       assertNotNull(odFiles);
-      
+
       // now check for each OD if it is a diff-witness, i.e., in sem(cd1)\sem(cd2)
-      
+
       for (File odFile : odFiles) {
         if (odFile.getName().endsWith(".od")) {
           assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.SIMPLE_CLOSED_WORLD, ast1,
@@ -176,7 +177,7 @@ public class CDDiffCLIToolTest {
     catch (NullPointerException | IOException e) {
       fail(e.getMessage());
     }
-    
+
     // clean-up
     try {
       PathUtils.delete(Paths.get(output));
@@ -185,7 +186,7 @@ public class CDDiffCLIToolTest {
       Log.warn(String.format("Could not delete %s due to %s", output, e.getMessage()));
     }
   }
-  
+
   @Test
   public void testOpenWorldDiff() {
     // given 2 CDs such that the first is simply missing an association defined in the second
@@ -198,7 +199,7 @@ public class CDDiffCLIToolTest {
         String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
             "--difflimit", "20", "--open-world", owDiffOption, cwDiffOption };
         CD4CodeTool.main(args);
-        
+
         // some corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         assertNotNull(odFiles);
@@ -209,7 +210,7 @@ public class CDDiffCLIToolTest {
           }
         }
         assertFalse(odFilePaths.isEmpty());
-        
+
         // clean-up
         try {
           PathUtils.delete(Paths.get(output));
@@ -220,22 +221,22 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-  
+
   @Test
   public void testNoOpenWorldDiff() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees1.cd";
     final String output = "./target/generated/cddiff-test/CLITestWithoutOWDiff";
-    
+
     for (String cwDiffOption : cwDiffOptions) {
       for (String owDiffOption : owDiffOptions) {
-        
+
         // when CD4CodeTool is used to compute the semantic difference
         String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
             "--difflimit", "20", "--open-world", owDiffOption, cwDiffOption };
         CD4CodeTool.main(args);
-        
+
         // no corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         if (odFiles == null) {
@@ -249,7 +250,7 @@ public class CDDiffCLIToolTest {
           }
         }
         assertTrue(odFilePaths.isEmpty());
-        
+
         // clean-up
         try {
           PathUtils.delete(Paths.get(output));
@@ -260,21 +261,21 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-  
+
   @Test
   public void testNoOpenWorldDiff4Abstract2Interface() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = TOOL_PATH + "cddiff/Abstract2Interface" + "/AbstractPerson.cd";
     final String cd2 = TOOL_PATH + "cddiff/Abstract2Interface" + "/InterfacePerson.cd";
     final String output = "./target/generated/cddiff-test/CLITestAbstract2InterfaceNoOWDiff";
-    
+
     for (String cwDiffOption : cwDiffOptions) {
       for (String owDiffOption : owDiffOptions) {
         // when CD4CodeTool is used to compute the semantic difference
         String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
             "--difflimit", "20", "--open-world", owDiffOption, cwDiffOption };
         CD4CodeTool.main(args);
-        
+
         // no corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         if (odFiles == null) {
@@ -288,7 +289,7 @@ public class CDDiffCLIToolTest {
           }
         }
         assertTrue(odFilePaths.isEmpty());
-        
+
         // clean-up
         try {
           PathUtils.delete(Paths.get(output));
@@ -299,22 +300,22 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-  
+
   @Test
   public void testNoOpenWorldDiffWithPackages() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees8.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees7.cd";
     final String output = "./target/generated/cddiff-test/CLITestWithPackagesAndNoOWDiff";
-    
+
     for (String cwDiffOption : cwDiffOptions) {
       for (String owDiffOption : owDiffOptions) {
-        
+
         // when CD4CodeTool is used to compute the semantic difference
         String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
             "--difflimit", "20", "--open-world", owDiffOption, cwDiffOption };
         CD4CodeTool.main(args);
-        
+
         // no corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         if (odFiles == null) {
@@ -328,7 +329,7 @@ public class CDDiffCLIToolTest {
           }
         }
         assertTrue(odFilePaths.isEmpty());
-        
+
         // clean-up
         try {
           PathUtils.delete(Paths.get(output));
@@ -339,31 +340,31 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-  
+
   @Test
   public void testValidityOfSemDiffWithPackages() {
-    
+
     // given 2 CDs that are not semantically equivalent
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees4.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees3.cd";
     final String output = "target/generated/cddiff-test/ValidityOfCDDiffWithPackages";
-    
+
     for (String cwDiffOption : cwDiffOptions) {
       // when CD4CodeTool is used to compute the semantic difference
       String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
           "--difflimit", "20", cwDiffOption };
       CD4CodeTool.main(args);
-      
+
       try {
-        ASTCDCompilationUnit ast1 = Objects.requireNonNull(CDDiffUtil.loadCD(cd1)).deepClone();
-        ASTCDCompilationUnit ast2 = Objects.requireNonNull(CDDiffUtil.loadCD(cd2)).deepClone();
-        
+        ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
+        ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
+
         // then corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         assertNotNull(odFiles);
-        
+
         // now check for each OD if it is a diff-witness, i.e., in sem(cd1)\sem(cd2)
-        
+
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
             assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.SIMPLE_CLOSED_WORLD, ast1,
@@ -376,24 +377,24 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-  
+
   @Test
   public void testValidityOfOW2CWReduction() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees7.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees8.cd";
     final String output = "target/generated/cddiff-test/ValidityOfOW2CWReduction";
-    
+
     for (String cwDiffOption : cwDiffOptions) {
       // when CD4CodeTool is used to compute the semantic difference
       String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
           "--difflimit", "20", "--open-world", "reduction-based", cwDiffOption };
       CD4CodeTool.main(args);
-      
+
       // no corresponding .od files are generated
       File[] odFiles = Paths.get(output).toFile().listFiles();
       assertNotNull(odFiles);
-      
+
       try {
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
@@ -402,7 +403,7 @@ public class CDDiffCLIToolTest {
                     .toFile(), odFile));
           }
         }
-        
+
       }
       catch (Exception e) {
         e.printStackTrace();
@@ -411,26 +412,26 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-  
+
   @Test
   public void testValidityOfOW2CWReduction2() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = "src/test/resources/doc/DigitalTwin3.cd";
     final String cd2 = "src/test/resources/doc/DigitalTwin2.cd";
     final String output = "target/generated/cddiff-test/ValidityOfOW2CWReduction2";
-    
+
     // when CD4CodeTool is used to compute the semantic difference
     String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output, "--difflimit",
         "20", "--open-world", "reduction-based" };
     CD4CodeTool.main(args);
-    
+
     // no corresponding .od files are generated
     File[] odFiles = Paths.get(output).toFile().listFiles();
     assertNotNull(odFiles);
-    
+
     try {
-      ASTCDCompilationUnit ast1 = Objects.requireNonNull(CDDiffUtil.loadCD(cd1)).deepClone();
-      ASTCDCompilationUnit ast2 = Objects.requireNonNull(CDDiffUtil.loadCD(cd2)).deepClone();
+      ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
+      ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
       for (File odFile : odFiles) {
         if (odFile.getName().endsWith(".od")) {
           assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.STA_OPEN_WORLD, ast1, ast2,
@@ -440,7 +441,7 @@ public class CDDiffCLIToolTest {
                   .toFile(), odFile));
         }
       }
-      
+
     }
     catch (Exception e) {
       e.printStackTrace();
@@ -448,5 +449,5 @@ public class CDDiffCLIToolTest {
       fail();
     }
   }
-  
+
 }

--- a/cdtool/src/test/java/de/monticore/CDDiffCLIToolTest.java
+++ b/cdtool/src/test/java/de/monticore/CDDiffCLIToolTest.java
@@ -15,23 +15,22 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import org.apache.commons.io.file.PathUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class CDDiffCLIToolTest {
-
+  
   private static final String TOOL_PATH = "src/test/resources/de/monticore/";
   final String[] owDiffOptions = { "alloy-based", "reduction-based" };
-
+  
   final String[] cwDiffOptions = { "", "--rule-based" };
-
+  
   @BeforeEach
   public void init() {
     LogStub.init();
   }
-
+  
   @Test
   public void testChain() {
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
@@ -40,54 +39,54 @@ public class CDDiffCLIToolTest {
     String[] args = { "-i", cd1, "--merge", cd2, "--semdiff", cd2, "-o", output, "-pp",
         "Employees12.cd" };
     CD4CodeTool.main(args);
-
+    
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
     assertEquals(Log.getErrorCount(), 0);
   }
-
+  
   @Test
   public void testSyntaxDiff() {
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees1.cd";
     CD4CodeTool.main(new String[] { "-i", cd1, "--syntaxdiff", cd2, "--show", "all" });
-
+    
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
     assertEquals(Log.getErrorCount(), 0);
   }
-
+  
   @Test
   public void testConformance() {
     final String con = TOOL_PATH + "cdconformance/adapter/GraphAdapter.cd";
     final String ref = TOOL_PATH + "cdconformance/adapter/Adapter.cd";
     CD4CodeTool.main(new String[] { "-i", con, "--reference", ref, "--map", "m1", "m2" });
-
+    
     // assertEquals("Parsing and CoCo check successful!\r\n", getOut());
     assertEquals(Log.getErrorCount(), 0);
   }
-
+  
   @Test
   public void testSemDiff() {
     // given 2 CDs that are not semantically equivalent
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees1.cd";
     final String output = "./target/generated/cddiff-test/CLITestWithDiff";
-
+    
     for (String cwDiffOption : cwDiffOptions) {
       // when CD4CodeTool is used to compute the semantic difference
       String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
           "--difflimit", "20", cwDiffOption };
       CD4CodeTool.main(args);
-
+      
       try {
         ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
         ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
-
+        
         // then corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         assertNotNull(odFiles);
-
+        
         // now check for each OD if it is a diff-witness, i.e., in sem(cd1)\sem(cd2)
-
+        
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
             assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.SIMPLE_CLOSED_WORLD, ast1,
@@ -98,7 +97,7 @@ public class CDDiffCLIToolTest {
       catch (NullPointerException | IOException e) {
         fail(e.getMessage());
       }
-
+      
       // clean-up
       try {
         PathUtils.delete(Paths.get(output));
@@ -108,20 +107,20 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-
+  
   @Test
   public void testNoSemDiff() {
     // given 2 CDs that are semantically equivalent
     final String cd1 = TOOL_PATH + "cddiff/SimilarManagers/CDSimilarManagerv1" + ".cd";
     final String cd2 = TOOL_PATH + "cddiff/SimilarManagers/CDSimilarManagerv2" + ".cd";
     final String output = "./target/generated/cddiff-test/CLITestWithoutDiff";
-
+    
     for (String cwDiffOption : cwDiffOptions) {
       // when CD4CodeTool is used to compute the semantic difference
       String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
           "--difflimit", "20", cwDiffOption };
       CD4CodeTool.main(args);
-
+      
       // no corresponding .od files are generated
       File[] odFiles = Paths.get(output).toFile().listFiles();
       if (odFiles == null) {
@@ -135,7 +134,7 @@ public class CDDiffCLIToolTest {
         }
       }
       assertTrue(odFilePaths.isEmpty());
-
+      
       // clean-up
       try {
         PathUtils.delete(Paths.get(output));
@@ -145,28 +144,28 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-
+  
   @Test
   public void testDefaultSemDiff() {
     // given 2 CDs that are not semantically equivalent
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees1.cd";
     final String output = "./target/generated/cddiff-test/CLITestWithDefaultDiff";
-
+    
     // when CD4CodeTool is used to compute the semantic difference
     String[] args = { "-i", cd1, "--semdiff", cd2, "-o", output };
     CD4CodeTool.main(args);
-
+    
     try {
       ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
       ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
-
+      
       // then corresponding .od files are generated
       File[] odFiles = Paths.get(output).toFile().listFiles();
       assertNotNull(odFiles);
-
+      
       // now check for each OD if it is a diff-witness, i.e., in sem(cd1)\sem(cd2)
-
+      
       for (File odFile : odFiles) {
         if (odFile.getName().endsWith(".od")) {
           assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.SIMPLE_CLOSED_WORLD, ast1,
@@ -177,7 +176,7 @@ public class CDDiffCLIToolTest {
     catch (NullPointerException | IOException e) {
       fail(e.getMessage());
     }
-
+    
     // clean-up
     try {
       PathUtils.delete(Paths.get(output));
@@ -186,7 +185,7 @@ public class CDDiffCLIToolTest {
       Log.warn(String.format("Could not delete %s due to %s", output, e.getMessage()));
     }
   }
-
+  
   @Test
   public void testOpenWorldDiff() {
     // given 2 CDs such that the first is simply missing an association defined in the second
@@ -199,7 +198,7 @@ public class CDDiffCLIToolTest {
         String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
             "--difflimit", "20", "--open-world", owDiffOption, cwDiffOption };
         CD4CodeTool.main(args);
-
+        
         // some corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         assertNotNull(odFiles);
@@ -210,7 +209,7 @@ public class CDDiffCLIToolTest {
           }
         }
         assertFalse(odFilePaths.isEmpty());
-
+        
         // clean-up
         try {
           PathUtils.delete(Paths.get(output));
@@ -221,22 +220,22 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-
+  
   @Test
   public void testNoOpenWorldDiff() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees2.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees1.cd";
     final String output = "./target/generated/cddiff-test/CLITestWithoutOWDiff";
-
+    
     for (String cwDiffOption : cwDiffOptions) {
       for (String owDiffOption : owDiffOptions) {
-
+        
         // when CD4CodeTool is used to compute the semantic difference
         String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
             "--difflimit", "20", "--open-world", owDiffOption, cwDiffOption };
         CD4CodeTool.main(args);
-
+        
         // no corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         if (odFiles == null) {
@@ -250,7 +249,7 @@ public class CDDiffCLIToolTest {
           }
         }
         assertTrue(odFilePaths.isEmpty());
-
+        
         // clean-up
         try {
           PathUtils.delete(Paths.get(output));
@@ -261,21 +260,21 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-
+  
   @Test
   public void testNoOpenWorldDiff4Abstract2Interface() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = TOOL_PATH + "cddiff/Abstract2Interface" + "/AbstractPerson.cd";
     final String cd2 = TOOL_PATH + "cddiff/Abstract2Interface" + "/InterfacePerson.cd";
     final String output = "./target/generated/cddiff-test/CLITestAbstract2InterfaceNoOWDiff";
-
+    
     for (String cwDiffOption : cwDiffOptions) {
       for (String owDiffOption : owDiffOptions) {
         // when CD4CodeTool is used to compute the semantic difference
         String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
             "--difflimit", "20", "--open-world", owDiffOption, cwDiffOption };
         CD4CodeTool.main(args);
-
+        
         // no corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         if (odFiles == null) {
@@ -289,7 +288,7 @@ public class CDDiffCLIToolTest {
           }
         }
         assertTrue(odFilePaths.isEmpty());
-
+        
         // clean-up
         try {
           PathUtils.delete(Paths.get(output));
@@ -300,22 +299,22 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-
+  
   @Test
   public void testNoOpenWorldDiffWithPackages() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees8.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees7.cd";
     final String output = "./target/generated/cddiff-test/CLITestWithPackagesAndNoOWDiff";
-
+    
     for (String cwDiffOption : cwDiffOptions) {
       for (String owDiffOption : owDiffOptions) {
-
+        
         // when CD4CodeTool is used to compute the semantic difference
         String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
             "--difflimit", "20", "--open-world", owDiffOption, cwDiffOption };
         CD4CodeTool.main(args);
-
+        
         // no corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         if (odFiles == null) {
@@ -329,7 +328,7 @@ public class CDDiffCLIToolTest {
           }
         }
         assertTrue(odFilePaths.isEmpty());
-
+        
         // clean-up
         try {
           PathUtils.delete(Paths.get(output));
@@ -340,31 +339,31 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-
+  
   @Test
   public void testValidityOfSemDiffWithPackages() {
-
+    
     // given 2 CDs that are not semantically equivalent
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees4.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees3.cd";
     final String output = "target/generated/cddiff-test/ValidityOfCDDiffWithPackages";
-
+    
     for (String cwDiffOption : cwDiffOptions) {
       // when CD4CodeTool is used to compute the semantic difference
       String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
           "--difflimit", "20", cwDiffOption };
       CD4CodeTool.main(args);
-
+      
       try {
         ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
         ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
-
+        
         // then corresponding .od files are generated
         File[] odFiles = Paths.get(output).toFile().listFiles();
         assertNotNull(odFiles);
-
+        
         // now check for each OD if it is a diff-witness, i.e., in sem(cd1)\sem(cd2)
-
+        
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
             assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.SIMPLE_CLOSED_WORLD, ast1,
@@ -377,24 +376,24 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-
+  
   @Test
   public void testValidityOfOW2CWReduction() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = TOOL_PATH + "cddiff/Employees/Employees7.cd";
     final String cd2 = TOOL_PATH + "cddiff/Employees/Employees8.cd";
     final String output = "target/generated/cddiff-test/ValidityOfOW2CWReduction";
-
+    
     for (String cwDiffOption : cwDiffOptions) {
       // when CD4CodeTool is used to compute the semantic difference
       String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output,
           "--difflimit", "20", "--open-world", "reduction-based", cwDiffOption };
       CD4CodeTool.main(args);
-
+      
       // no corresponding .od files are generated
       File[] odFiles = Paths.get(output).toFile().listFiles();
       assertNotNull(odFiles);
-
+      
       try {
         for (File odFile : odFiles) {
           if (odFile.getName().endsWith(".od")) {
@@ -403,7 +402,7 @@ public class CDDiffCLIToolTest {
                     .toFile(), odFile));
           }
         }
-
+        
       }
       catch (Exception e) {
         e.printStackTrace();
@@ -412,23 +411,23 @@ public class CDDiffCLIToolTest {
       }
     }
   }
-
+  
   @Test
   public void testValidityOfOW2CWReduction2() {
     // given 2 CDs such that the first is a refinement of the second under an open-world assumption
     final String cd1 = "src/test/resources/doc/DigitalTwin3.cd";
     final String cd2 = "src/test/resources/doc/DigitalTwin2.cd";
     final String output = "target/generated/cddiff-test/ValidityOfOW2CWReduction2";
-
+    
     // when CD4CodeTool is used to compute the semantic difference
     String[] args = { "-i", cd1, "--semdiff", cd2, "--diffsize", "21", "-o", output, "--difflimit",
         "20", "--open-world", "reduction-based" };
     CD4CodeTool.main(args);
-
+    
     // no corresponding .od files are generated
     File[] odFiles = Paths.get(output).toFile().listFiles();
     assertNotNull(odFiles);
-
+    
     try {
       ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
       ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
@@ -441,7 +440,7 @@ public class CDDiffCLIToolTest {
                   .toFile(), odFile));
         }
       }
-
+      
     }
     catch (Exception e) {
       e.printStackTrace();
@@ -449,5 +448,5 @@ public class CDDiffCLIToolTest {
       fail();
     }
   }
-
+  
 }

--- a/cdtool/src/test/java/de/monticore/ExampleCommandTest.java
+++ b/cdtool/src/test/java/de/monticore/ExampleCommandTest.java
@@ -24,21 +24,20 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Objects;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class ExampleCommandTest extends OutTestBasis {
-
+  
   static final String outputPath = "target/generated/example-commands/";
-
+  
   @BeforeEach
   public void resetMill() {
     CD4CodeMill.reset();
   }
-
+  
   /**
    * Tests commands: java -jar MCCD.jar -i src/MyAddress.cd -s symbols/MyAddress.cdsym java -jar
    * MCCD.jar -i src/MyLife --path symbols -pp
@@ -52,7 +51,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeTool.main(new String[] { "-i", fileName, "--path", outputPath + "symbols", "-o",
         outputPath + "out", "--gen" });
   }
-
+  
   /**
    * Tests commands: java -jar MCCD.jar -i src/MyAddress.cd -s symbols/MyAddress.cdsym java -jar
    * MCCd.jar -i src/MyLife --path symbols -o out --gen
@@ -66,7 +65,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeTool.main(new String[] { "-i", fileName, "--path", outputPath + "symbols", "-pp" });
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /** Step1: Getting started for command: java -jar MCCD.jar -i src/MyExample.cd */
   @Test
   public void testGettingStartedExample() {
@@ -74,7 +73,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeTool.main(new String[] { "-i", fileName });
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /** Step2: Pretty printing for command: java -jar MCCD.jar -i src/MyExample.cd -pp */
   @Test
   public void testPrettyPrintingExample1() {
@@ -82,7 +81,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeTool.main(new String[] { "-i", fileName, "-pp" });
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step2: Pretty printing for command: java -jar MCCD.jar -i src/MyExample.cd -pp
    * target/PPExample.cd
@@ -96,24 +95,24 @@ public class ExampleCommandTest extends OutTestBasis {
         outputPath + "MyExample.cd"), false));
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /** Step3: storing symbols for command: java -jar MCCD.jar -i src/MyExample.cd -s */
   @Test
   public void testStoringSymbolsExample1() {
     String fileName = "src/test/resources/doc/MyExample.cd";
-
+    
     // copy the CD into test-directory
     CD4CodeTool.main(new String[] { "-i", fileName, "-pp", outputPath + "MyExample.cd" });
     fileName = outputPath + "MyExample.cd";
-
+    
     // execute the command at test
     CD4CodeTool.main(new String[] { "-i", fileName, "-s" });
-
+    
     // test if the result exists and no errors occur
     assertTrue(Files.exists(Paths.get(outputPath + "MyExample.cdsym")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step3: storing symbols for command: java -jar MCCD.jar -i src/MyExample.cd -s
    * symbols/MyExample.cdsym
@@ -121,15 +120,15 @@ public class ExampleCommandTest extends OutTestBasis {
   @Test
   public void testStoringSymbolsExample2() {
     String fileName = "src/test/resources/doc/MyExample.cd";
-
+    
     // execute the command at test
     CD4CodeTool.main(new String[] { "-i", fileName, "-s", outputPath + "symbols/MyExample.cdsym" });
-
+    
     // test if the result exists and no errors occur
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step 4: Adding FieldSymbols corresponding to association roles for command: java -jar MCCD.jar
    * -i src/MyExample.cd -s symbols/MyExample.cdsym --fieldfromrole all
@@ -142,7 +141,7 @@ public class ExampleCommandTest extends OutTestBasis {
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step 4: Adding FieldSymbols corresponding to association roles for command: java -jar MCCD.jar
    * -i src/MyExample.cd -s symbols/MyExample.cdsym --fieldfromrole navigable
@@ -155,7 +154,7 @@ public class ExampleCommandTest extends OutTestBasis {
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step 5: Importing Symbol Files Using a Path for command: java -jar MCCD.jar -i
    * src/monticore/MyLife.cd
@@ -171,16 +170,16 @@ public class ExampleCommandTest extends OutTestBasis {
       CD4CodeMill.init();
       return null;
     }).when(tool).init();
-
+    
     // When
     tool.run(new String[] { "-i", fileName });
-
+    
     // Then
     assertEquals(3, Log.getFindingsCount(), "Actual findings: " + Log.getFindings().toString());
     assertEquals("0xA0324 Cannot find symbol Address", Log.getFindings().get(0).getMsg());
     Log.clearFindings();
   }
-
+  
   /**
    * Step 5: Importing Symbol Files Using a Path for commands: java -jar MCCD.jar -i
    * src/MyAddress.cd -s symbols/MyAddress.cdsym java -jar MCCD.jar -i src/monticore/MyLife.cd
@@ -197,7 +196,7 @@ public class ExampleCommandTest extends OutTestBasis {
         + "symbols" });
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step 7: Generating .java-Files for command: java -jar MCCD.jar -i src/MyExample.cd --gen -o out
    */
@@ -210,7 +209,7 @@ public class ExampleCommandTest extends OutTestBasis {
         outputPath + "out/" + retrieveRelativeGenPath(c, cd) + ".java"))));
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step 7: Generating .java-Files for command: java -jar MCCD.jar -i src/MyCompany.cd -o out --gen
    * --fieldfromrole navigable
@@ -226,7 +225,7 @@ public class ExampleCommandTest extends OutTestBasis {
         outputPath + "out/" + retrieveRelativeGenPath(c, cd) + ".java"))));
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step 8: The Semantic Difference of Two Class Diagrams for command: java -jar MCCD.jar -i
    * src/MyEmployees1.cd --semdiff scr/MyEmployees2.cd
@@ -238,7 +237,7 @@ public class ExampleCommandTest extends OutTestBasis {
         "src/test/resources/doc/MyEmployees2.cd" });
     assertEquals(0, Log.getErrorCount());
   }
-
+  
   /**
    * Step 8: The Semantic Difference of Two Class Diagrams for command: java -jar MCCD.jar -i
    * src/MyEmployees1.cd --semdiff src/MyEmployees2.cd --difflimit 20 -o out
@@ -249,17 +248,17 @@ public class ExampleCommandTest extends OutTestBasis {
     final String cd2 = "src/test/resources/doc/MyEmployees2.cd";
     CD4CodeTool.main(new String[] { "-i", cd1, "--semdiff", cd2, "--difflimit", "20", "-o",
         outputPath + "out" });
-
+    
     try {
       ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
       ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
-
+      
       // then corresponding .od files are generated
       File[] odFiles = Paths.get(outputPath + "out").toFile().listFiles();
       assertNotNull(odFiles);
-
+      
       // now check for each OD if it is a diff-witness, i.e., in sem(cd1)\sem(cd2)
-
+      
       for (File odFile : odFiles) {
         if (odFile.getName().endsWith(".od")) {
           assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.SIMPLE_CLOSED_WORLD, ast1,
@@ -272,7 +271,7 @@ public class ExampleCommandTest extends OutTestBasis {
     }
     assertEquals(0, Log.getErrorCount());
   }
-
+  
   /**
    * Step 9: Merging Two Class Diagram for command: java -jar MCCD.jar -i src/MyEmployees2.cd
    * --merge src/MyWorkplace.cd -o out -pp
@@ -284,7 +283,7 @@ public class ExampleCommandTest extends OutTestBasis {
         "src/test/resources/doc/Management.cd", "-pp" });
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   /**
    * Step 9: Merging Two Class Diagram for command: java -jar MCCD.jar -i src/MyEmployees2.cd
    * --merge src/MyWorkplace.cd -o out -pp MyJob.cd
@@ -298,13 +297,13 @@ public class ExampleCommandTest extends OutTestBasis {
     assertTrue(Files.exists(Paths.get(outputPath + "out/UniversitySystem.cd")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-
+  
   protected void resetGlobalScope() {
     CD4CodeMill.globalScope().clear();
     CD4CodeMill.globalScope().init();
     BuiltInTypes.addBuiltInTypes(CD4CodeMill.globalScope());
   }
-
+  
   protected ASTCDCompilationUnit loadAndCheckCD(String filePath) {
     try {
       Optional<ASTCDCompilationUnit> optCD = CD4CodeMill.parser().parse(filePath);
@@ -317,14 +316,14 @@ public class ExampleCommandTest extends OutTestBasis {
       optCD.get().accept(c.getTraverser());
       new CD4CodeCoCosDelegator().getCheckerForAllCoCos().checkAll(optCD.get());
       return optCD.get();
-
+      
     }
     catch (IOException e) {
       fail(e.getMessage());
     }
     return null;
   }
-
+  
   protected String retrieveRelativeGenPath(ASTCDClass c, ASTCDCompilationUnit cd) {
     String res = "";
     if (cd.isPresentMCPackageDeclaration()) {
@@ -335,5 +334,5 @@ public class ExampleCommandTest extends OutTestBasis {
     res = res.replaceAll("\\.", "/");
     return res;
   }
-
+  
 }

--- a/cdtool/src/test/java/de/monticore/ExampleCommandTest.java
+++ b/cdtool/src/test/java/de/monticore/ExampleCommandTest.java
@@ -3,6 +3,7 @@ package de.monticore;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.common.base.Verify;
 import de.monticore.cd.OutTestBasis;
 import de.monticore.cd._symboltable.BuiltInTypes;
 import de.monticore.cd4code.CD4CodeMill;
@@ -30,14 +31,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class ExampleCommandTest extends OutTestBasis {
-  
+
   static final String outputPath = "target/generated/example-commands/";
-  
+
   @BeforeEach
   public void resetMill() {
     CD4CodeMill.reset();
   }
-  
+
   /**
    * Tests commands: java -jar MCCD.jar -i src/MyAddress.cd -s symbols/MyAddress.cdsym java -jar
    * MCCD.jar -i src/MyLife --path symbols -pp
@@ -51,7 +52,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeTool.main(new String[] { "-i", fileName, "--path", outputPath + "symbols", "-o",
         outputPath + "out", "--gen" });
   }
-  
+
   /**
    * Tests commands: java -jar MCCD.jar -i src/MyAddress.cd -s symbols/MyAddress.cdsym java -jar
    * MCCd.jar -i src/MyLife --path symbols -o out --gen
@@ -65,7 +66,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeTool.main(new String[] { "-i", fileName, "--path", outputPath + "symbols", "-pp" });
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /** Step1: Getting started for command: java -jar MCCD.jar -i src/MyExample.cd */
   @Test
   public void testGettingStartedExample() {
@@ -73,7 +74,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeTool.main(new String[] { "-i", fileName });
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /** Step2: Pretty printing for command: java -jar MCCD.jar -i src/MyExample.cd -pp */
   @Test
   public void testPrettyPrintingExample1() {
@@ -81,7 +82,7 @@ public class ExampleCommandTest extends OutTestBasis {
     CD4CodeTool.main(new String[] { "-i", fileName, "-pp" });
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step2: Pretty printing for command: java -jar MCCD.jar -i src/MyExample.cd -pp
    * target/PPExample.cd
@@ -95,24 +96,24 @@ public class ExampleCommandTest extends OutTestBasis {
         outputPath + "MyExample.cd"), false));
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /** Step3: storing symbols for command: java -jar MCCD.jar -i src/MyExample.cd -s */
   @Test
   public void testStoringSymbolsExample1() {
     String fileName = "src/test/resources/doc/MyExample.cd";
-    
+
     // copy the CD into test-directory
     CD4CodeTool.main(new String[] { "-i", fileName, "-pp", outputPath + "MyExample.cd" });
     fileName = outputPath + "MyExample.cd";
-    
+
     // execute the command at test
     CD4CodeTool.main(new String[] { "-i", fileName, "-s" });
-    
+
     // test if the result exists and no errors occur
     assertTrue(Files.exists(Paths.get(outputPath + "MyExample.cdsym")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step3: storing symbols for command: java -jar MCCD.jar -i src/MyExample.cd -s
    * symbols/MyExample.cdsym
@@ -120,15 +121,15 @@ public class ExampleCommandTest extends OutTestBasis {
   @Test
   public void testStoringSymbolsExample2() {
     String fileName = "src/test/resources/doc/MyExample.cd";
-    
+
     // execute the command at test
     CD4CodeTool.main(new String[] { "-i", fileName, "-s", outputPath + "symbols/MyExample.cdsym" });
-    
+
     // test if the result exists and no errors occur
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step 4: Adding FieldSymbols corresponding to association roles for command: java -jar MCCD.jar
    * -i src/MyExample.cd -s symbols/MyExample.cdsym --fieldfromrole all
@@ -141,7 +142,7 @@ public class ExampleCommandTest extends OutTestBasis {
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step 4: Adding FieldSymbols corresponding to association roles for command: java -jar MCCD.jar
    * -i src/MyExample.cd -s symbols/MyExample.cdsym --fieldfromrole navigable
@@ -154,7 +155,7 @@ public class ExampleCommandTest extends OutTestBasis {
     assertTrue(Files.exists(Paths.get(outputPath + "symbols/MyExample.cdsym")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step 5: Importing Symbol Files Using a Path for command: java -jar MCCD.jar -i
    * src/monticore/MyLife.cd
@@ -170,16 +171,16 @@ public class ExampleCommandTest extends OutTestBasis {
       CD4CodeMill.init();
       return null;
     }).when(tool).init();
-    
+
     // When
     tool.run(new String[] { "-i", fileName });
-    
+
     // Then
     assertEquals(3, Log.getFindingsCount(), "Actual findings: " + Log.getFindings().toString());
     assertEquals("0xA0324 Cannot find symbol Address", Log.getFindings().get(0).getMsg());
     Log.clearFindings();
   }
-  
+
   /**
    * Step 5: Importing Symbol Files Using a Path for commands: java -jar MCCD.jar -i
    * src/MyAddress.cd -s symbols/MyAddress.cdsym java -jar MCCD.jar -i src/monticore/MyLife.cd
@@ -196,7 +197,7 @@ public class ExampleCommandTest extends OutTestBasis {
         + "symbols" });
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step 7: Generating .java-Files for command: java -jar MCCD.jar -i src/MyExample.cd --gen -o out
    */
@@ -209,7 +210,7 @@ public class ExampleCommandTest extends OutTestBasis {
         outputPath + "out/" + retrieveRelativeGenPath(c, cd) + ".java"))));
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step 7: Generating .java-Files for command: java -jar MCCD.jar -i src/MyCompany.cd -o out --gen
    * --fieldfromrole navigable
@@ -225,7 +226,7 @@ public class ExampleCommandTest extends OutTestBasis {
         outputPath + "out/" + retrieveRelativeGenPath(c, cd) + ".java"))));
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step 8: The Semantic Difference of Two Class Diagrams for command: java -jar MCCD.jar -i
    * src/MyEmployees1.cd --semdiff scr/MyEmployees2.cd
@@ -237,7 +238,7 @@ public class ExampleCommandTest extends OutTestBasis {
         "src/test/resources/doc/MyEmployees2.cd" });
     assertEquals(0, Log.getErrorCount());
   }
-  
+
   /**
    * Step 8: The Semantic Difference of Two Class Diagrams for command: java -jar MCCD.jar -i
    * src/MyEmployees1.cd --semdiff src/MyEmployees2.cd --difflimit 20 -o out
@@ -248,17 +249,17 @@ public class ExampleCommandTest extends OutTestBasis {
     final String cd2 = "src/test/resources/doc/MyEmployees2.cd";
     CD4CodeTool.main(new String[] { "-i", cd1, "--semdiff", cd2, "--difflimit", "20", "-o",
         outputPath + "out" });
-    
+
     try {
-      ASTCDCompilationUnit ast1 = Objects.requireNonNull(CDDiffUtil.loadCD(cd1)).deepClone();
-      ASTCDCompilationUnit ast2 = Objects.requireNonNull(CDDiffUtil.loadCD(cd2)).deepClone();
-      
+      ASTCDCompilationUnit ast1 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd1)).deepClone();
+      ASTCDCompilationUnit ast2 = Verify.verifyNotNull(CDDiffUtil.loadCD(cd2)).deepClone();
+
       // then corresponding .od files are generated
       File[] odFiles = Paths.get(outputPath + "out").toFile().listFiles();
       assertNotNull(odFiles);
-      
+
       // now check for each OD if it is a diff-witness, i.e., in sem(cd1)\sem(cd2)
-      
+
       for (File odFile : odFiles) {
         if (odFile.getName().endsWith(".od")) {
           assertTrue(new OD2CDMatcher().checkIfDiffWitness(CDSemantics.SIMPLE_CLOSED_WORLD, ast1,
@@ -271,7 +272,7 @@ public class ExampleCommandTest extends OutTestBasis {
     }
     assertEquals(0, Log.getErrorCount());
   }
-  
+
   /**
    * Step 9: Merging Two Class Diagram for command: java -jar MCCD.jar -i src/MyEmployees2.cd
    * --merge src/MyWorkplace.cd -o out -pp
@@ -283,7 +284,7 @@ public class ExampleCommandTest extends OutTestBasis {
         "src/test/resources/doc/Management.cd", "-pp" });
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   /**
    * Step 9: Merging Two Class Diagram for command: java -jar MCCD.jar -i src/MyEmployees2.cd
    * --merge src/MyWorkplace.cd -o out -pp MyJob.cd
@@ -297,13 +298,13 @@ public class ExampleCommandTest extends OutTestBasis {
     assertTrue(Files.exists(Paths.get(outputPath + "out/UniversitySystem.cd")));
     assertTrue(getErr().isEmpty(), getErr());
   }
-  
+
   protected void resetGlobalScope() {
     CD4CodeMill.globalScope().clear();
     CD4CodeMill.globalScope().init();
     BuiltInTypes.addBuiltInTypes(CD4CodeMill.globalScope());
   }
-  
+
   protected ASTCDCompilationUnit loadAndCheckCD(String filePath) {
     try {
       Optional<ASTCDCompilationUnit> optCD = CD4CodeMill.parser().parse(filePath);
@@ -316,14 +317,14 @@ public class ExampleCommandTest extends OutTestBasis {
       optCD.get().accept(c.getTraverser());
       new CD4CodeCoCosDelegator().getCheckerForAllCoCos().checkAll(optCD.get());
       return optCD.get();
-      
+
     }
     catch (IOException e) {
       fail(e.getMessage());
     }
     return null;
   }
-  
+
   protected String retrieveRelativeGenPath(ASTCDClass c, ASTCDCompilationUnit cd) {
     String res = "";
     if (cd.isPresentMCPackageDeclaration()) {
@@ -334,5 +335,5 @@ public class ExampleCommandTest extends OutTestBasis {
     res = res.replaceAll("\\.", "/");
     return res;
   }
-  
+
 }


### PR DESCRIPTION
Completed subtasks:
 -  Log::errorIfNull should be deprecated and replaced
 -  Objects::requireNonNull should be replaced as well (technically not part of the Logging issue, but related)

There are still open subtasks in in issue #4835