### PR TITLE
Revert "integrate CD2JavaGenCoCos into the CDGenTool"

### DIFF
--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -13,14 +13,12 @@ import de.monticore.cd4analysis._util.CD4AnalysisTypeDispatcher;
 import de.monticore.cd4analysis.trafo.CDAssociationCreateFieldsFromAllRoles;
 import de.monticore.cd4analysis.trafo.CDAssociationCreateFieldsFromNavigableRoles;
 import de.monticore.cd4code.CD4CodeMill;
-import de.monticore.cd4code._cocos.CD4CodeCoCoChecker;
 import de.monticore.cd4code._symboltable.ICD4CodeArtifactScope;
 import de.monticore.cd4code._visitor.CD4CodeTraverser;
 import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDClass;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.trafo.CDBasisDefaultPackageTrafo;
-import de.monticore.cdgen.cocos.CD2JavaGenCoCos;
 import de.monticore.cdinterfaceandenum._ast.ASTCDEnum;
 import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
 import de.monticore.generating.GeneratorSetup;
@@ -390,8 +388,7 @@ public class CDGenTool extends CDGeneratorTool {
    * @param ast the original ast
    */
   public void runCoCos(ASTCDCompilationUnit ast) {
-    CD4CodeCoCoChecker checker = new CD2JavaGenCoCos().getCheckerForAllCoCos();
-    checker.checkAll(ast);
+    super.runCoCos(ast);
   }
   
   @Override


### PR DESCRIPTION
This reverts commit 9f9da7d10dec1e1f4ab5818362bc596f099bde39. The commit broke apps downstream. The `CDAssociationUnique` coco is too restrictive. It is also missing source position information. Furthermore, the included cocos seem to cause a NullPointerException in another app.