### PR TITLE
CD2JavaGenCoCos for the CDGenTool

### DIFF
--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -16,7 +16,6 @@ import de.monticore.cd4code.CD4CodeMill;
 import de.monticore.cd4code._cocos.CD4CodeCoCoChecker;
 import de.monticore.cd4code._symboltable.ICD4CodeArtifactScope;
 import de.monticore.cd4code._visitor.CD4CodeTraverser;
-import de.monticore.cd4code.cocos.CD4CodeCoCosDelegator;
 import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDClass;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;

--- a/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/CDGenTool.java
@@ -13,12 +13,15 @@ import de.monticore.cd4analysis._util.CD4AnalysisTypeDispatcher;
 import de.monticore.cd4analysis.trafo.CDAssociationCreateFieldsFromAllRoles;
 import de.monticore.cd4analysis.trafo.CDAssociationCreateFieldsFromNavigableRoles;
 import de.monticore.cd4code.CD4CodeMill;
+import de.monticore.cd4code._cocos.CD4CodeCoCoChecker;
 import de.monticore.cd4code._symboltable.ICD4CodeArtifactScope;
 import de.monticore.cd4code._visitor.CD4CodeTraverser;
+import de.monticore.cd4code.cocos.CD4CodeCoCosDelegator;
 import de.monticore.cdbasis.CDBasisMill;
 import de.monticore.cdbasis._ast.ASTCDClass;
 import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis.trafo.CDBasisDefaultPackageTrafo;
+import de.monticore.cdgen.cocos.CD2JavaGenCoCos;
 import de.monticore.cdinterfaceandenum._ast.ASTCDEnum;
 import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
 import de.monticore.generating.GeneratorSetup;
@@ -388,7 +391,8 @@ public class CDGenTool extends CDGeneratorTool {
    * @param ast the original ast
    */
   public void runCoCos(ASTCDCompilationUnit ast) {
-    super.runCoCos(ast);
+    CD4CodeCoCoChecker checker = new CD2JavaGenCoCos().getCheckerForAllCoCos();
+    checker.checkAll(ast);
   }
   
   @Override

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CD2JavaGenCoCos.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CD2JavaGenCoCos.java
@@ -10,8 +10,6 @@ public class CD2JavaGenCoCos extends CD4CodeCoCosDelegator {
   protected void addCheckerForAllCoCos(CD4CodeCoCoChecker checker) {
     super.addCheckerForAllCoCos(checker);
     checker.addCoCo(new CDAssociationUniqueInHierarchy());
-    checker.addCoCo(new CDNoAttributesInInterfaces());
-    checker.addCoCo(new CDNoOutgoingAssocs4Interfaces());
     checker.addCoCo(new CDSingleClassInheritance());
   }
   

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
@@ -36,7 +36,8 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
           // if they share a left role-name, the referenced types on the right should not be the
           // same
           if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2, AssocSide.LEFT))
-              && isNavigable(assoc1, AssocSide.LEFT) && isNavigable(assoc2, AssocSide.LEFT)) {
+              && assoc1.getCDAssocDir().isDefinitiveNavigableLeft() && assoc2.getCDAssocDir()
+                  .isDefinitiveNavigableLeft()) {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getRightQualifiedName()
                     .getQName()));
@@ -45,21 +46,23 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
           // if they share a right role-name, the referenced types on the left should not be the
           // same
           if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2,
-              AssocSide.RIGHT)) && isNavigable(assoc1, AssocSide.RIGHT) && isNavigable(assoc2,
-                  AssocSide.RIGHT)) {
+              AssocSide.RIGHT)) && assoc1.getCDAssocDir().isDefinitiveNavigableRight() && assoc2
+                  .getCDAssocDir().isDefinitiveNavigableRight()) {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
           
           // We also consider a left-to-right role name match ...
           if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2, AssocSide.RIGHT))
-              && isNavigable(assoc1, AssocSide.LEFT) && isNavigable(assoc2, AssocSide.RIGHT)) {
+              && assoc1.getCDAssocDir().isDefinitiveNavigableLeft() && assoc2.getCDAssocDir()
+                  .isDefinitiveNavigableRight()) {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
           // ... as well as a right-to-left match
           if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2, AssocSide.LEFT))
-              && isNavigable(assoc1, AssocSide.RIGHT) && isNavigable(assoc2, AssocSide.LEFT)) {
+              && assoc1.getCDAssocDir().isDefinitiveNavigableRight() && assoc2.getCDAssocDir()
+                  .isDefinitiveNavigableLeft()) {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getRightQualifiedName()
                     .getQName()));

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
@@ -17,9 +17,7 @@ import java.util.*;
  */
 public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
   
-  /**
-   * @param node class to check.
-   */
+  /** @param node class to check. */
   @Override
   public void check(ASTCDDefinition node) {
     
@@ -38,39 +36,60 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
           // if they share a left role-name, the referenced types on the right should not be the
           // same
           if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2,
-              AssocSide.LEFT))) {
-            checkRef(node, findTypeByFullName(assoc1, assoc1.getRightQualifiedName().getQName()),
-                findTypeByFullName(assoc2, assoc2.getRightQualifiedName().getQName()), assoc1);
+              AssocSide.LEFT)) && sharedNavigability(assoc1,assoc2,false)) {
+            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName().getQName()),
+                findTypeByFullName(assoc2, assoc2.getRightQualifiedName().getQName()));
           }
           
           // if they share a right role-name, the referenced types on the left should not be the
           // same
           if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2,
-              AssocSide.RIGHT))) {
-            checkRef(node, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName().getQName()),
-                findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()), assoc1);
+              AssocSide.RIGHT)) && sharedNavigability(assoc1,assoc2,false)) {
+            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName().getQName()),
+                findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
           
           // We also consider a left-to-right role name match ...
           if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2,
-              AssocSide.RIGHT))) {
-            checkRef(node, findTypeByFullName(assoc1, assoc1.getRightQualifiedName().getQName()),
-                findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()), assoc1);
+              AssocSide.RIGHT)) && sharedNavigability(assoc1,assoc2,true)) {
+            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName().getQName()),
+                findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
           // ... as well as a right-to-left match
           if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2,
-              AssocSide.LEFT))) {
-            checkRef(node, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName().getQName()),
-                findTypeByFullName(assoc2, assoc2.getRightQualifiedName().getQName()), assoc1);
+              AssocSide.LEFT)) && sharedNavigability(assoc1,assoc2,true)) {
+            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName().getQName()),
+                findTypeByFullName(assoc2, assoc2.getRightQualifiedName().getQName()));
           }
         }
       }
     }
   }
-  
-  /**
-   * helper-method to find types by full-name
-   */
+
+  private boolean sharedNavigability(ASTCDAssociation assoc1, ASTCDAssociation assoc2,
+      boolean reverse) {
+    if (reverse) {
+      return (assoc1.getCDAssocDir().isDefinitiveNavigableRight()
+          && assoc2.getCDAssocDir().isDefinitiveNavigableLeft())
+          || (assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+          && assoc2.getCDAssocDir().isDefinitiveNavigableRight())
+          || (!assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+          && !assoc1.getCDAssocDir().isDefinitiveNavigableRight())
+          || (!assoc2.getCDAssocDir().isDefinitiveNavigableLeft()
+          && !assoc2.getCDAssocDir().isDefinitiveNavigableRight());
+    } else {
+      return (assoc1.getCDAssocDir().isDefinitiveNavigableRight()
+            && assoc2.getCDAssocDir().isDefinitiveNavigableRight())
+          || (assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+            && assoc2.getCDAssocDir().isDefinitiveNavigableLeft())
+          || (!assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+            && !assoc1.getCDAssocDir().isDefinitiveNavigableRight())
+          || (!assoc2.getCDAssocDir().isDefinitiveNavigableLeft()
+          && !assoc2.getCDAssocDir().isDefinitiveNavigableRight());
+    }
+  }
+
+  /** helper-method to find types by full-name */
   protected ASTCDType findTypeByFullName(ASTCDAssociation node, String fullName) {
     
     Optional<CDTypeSymbol> optSymbol = node.getEnclosingScope().resolveCDType(fullName);
@@ -78,18 +97,16 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
       return optSymbol.get().getAstNode();
     }
     
-    Log.error("0xCDCE2: Could not find: " + fullName + ".");
+    Log.error("0xCDCE2: Could not find: " + fullName + ".", node.get_SourcePositionStart());
     return null;
   }
   
   /** Check if type2 is the same as type1. */
-  protected void checkRef(ASTCDDefinition node, ASTCDType type1, ASTCDType type2,
-      ASTCDAssociation assoc1) {
+  protected void checkRef(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1, ASTCDType type2) {
     if (type1.equals(type2)) {
-      Log.error(String.format("0xCDCE1: %s has a duplicate association to %s", type1.getName(),
-          type2.getName()), assoc1.isPresent_SourcePositionStart() ? assoc1
-              .get_SourcePositionStart() : null, assoc1.isPresent_SourcePositionEnd() ? assoc1
-                  .get_SourcePositionEnd() : null);
+      Log.error(String.format("0xCDCE1: %s has duplicate associations at %s and %s.",
+          type1.getName(), assoc1.get_SourcePositionStart(), assoc2.get_SourcePositionStart()),
+          assoc2.get_SourcePositionStart());
     }
   }
   
@@ -114,7 +131,7 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
     }
   }
   
-  private enum AssocSide {
+  protected enum AssocSide {
     LEFT, RIGHT;
   }
   

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
@@ -36,7 +36,7 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
           // if they share a left role-name, the referenced types on the right should not be the
           // same
           if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2, AssocSide.LEFT))
-              && sharedNavigability(assoc1, assoc2, false)) {
+              && isNavigable(assoc1, AssocSide.LEFT) && isNavigable(assoc2, AssocSide.LEFT)) {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getRightQualifiedName()
                     .getQName()));
@@ -45,20 +45,21 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
           // if they share a right role-name, the referenced types on the left should not be the
           // same
           if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2,
-              AssocSide.RIGHT)) && sharedNavigability(assoc1, assoc2, false)) {
+              AssocSide.RIGHT)) && isNavigable(assoc1, AssocSide.RIGHT) && isNavigable(assoc2,
+              AssocSide.RIGHT))  {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
           
           // We also consider a left-to-right role name match ...
           if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2, AssocSide.RIGHT))
-              && sharedNavigability(assoc1, assoc2, true)) {
+              && isNavigable(assoc1, AssocSide.LEFT) && isNavigable(assoc2, AssocSide.RIGHT)) {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
           // ... as well as a right-to-left match
           if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2, AssocSide.LEFT))
-              && sharedNavigability(assoc1, assoc2, true)) {
+              && isNavigable(assoc1, AssocSide.RIGHT) && isNavigable(assoc2, AssocSide.LEFT)) {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getRightQualifiedName()
                     .getQName()));
@@ -67,29 +68,19 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
       }
     }
   }
-  
-  private boolean sharedNavigability(ASTCDAssociation assoc1, ASTCDAssociation assoc2,
-      boolean reverse) {
-    if (reverse) {
-      return (assoc1.getCDAssocDir().isDefinitiveNavigableRight() && assoc2.getCDAssocDir()
-          .isDefinitiveNavigableLeft()) || (assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-              && assoc2.getCDAssocDir().isDefinitiveNavigableRight()) || (!assoc1.getCDAssocDir()
-                  .isDefinitiveNavigableLeft() && !assoc1.getCDAssocDir()
-                      .isDefinitiveNavigableRight()) || (!assoc2.getCDAssocDir()
-                          .isDefinitiveNavigableLeft() && !assoc2.getCDAssocDir()
-                              .isDefinitiveNavigableRight());
-    }
-    else {
-      return (assoc1.getCDAssocDir().isDefinitiveNavigableRight() && assoc2.getCDAssocDir()
-          .isDefinitiveNavigableRight()) || (assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-              && assoc2.getCDAssocDir().isDefinitiveNavigableLeft()) || (!assoc1.getCDAssocDir()
-                  .isDefinitiveNavigableLeft() && !assoc1.getCDAssocDir()
-                      .isDefinitiveNavigableRight()) || (!assoc2.getCDAssocDir()
-                          .isDefinitiveNavigableLeft() && !assoc2.getCDAssocDir()
-                              .isDefinitiveNavigableRight());
+
+  private static boolean isNavigable(ASTCDAssociation assoc1, AssocSide side1) {
+    if (side1.equals(AssocSide.LEFT) ) {
+      return assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+              || (!assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+              && !assoc1.getCDAssocDir().isDefinitiveNavigableRight());
+    } else {
+      return  assoc1.getCDAssocDir().isDefinitiveNavigableRight()
+              || (!assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+              && !assoc1.getCDAssocDir().isDefinitiveNavigableRight());
     }
   }
-  
+
   /** helper-method to find types by full-name */
   protected ASTCDType findTypeByFullName(ASTCDAssociation node, String fullName) {
     

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
@@ -46,7 +46,7 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
           // same
           if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2,
               AssocSide.RIGHT)) && isNavigable(assoc1, AssocSide.RIGHT) && isNavigable(assoc2,
-              AssocSide.RIGHT))  {
+                  AssocSide.RIGHT)) {
             checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName()
                 .getQName()), findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
@@ -68,19 +68,18 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
       }
     }
   }
-
+  
   private static boolean isNavigable(ASTCDAssociation assoc1, AssocSide side1) {
-    if (side1.equals(AssocSide.LEFT) ) {
-      return assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-              || (!assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-              && !assoc1.getCDAssocDir().isDefinitiveNavigableRight());
-    } else {
-      return  assoc1.getCDAssocDir().isDefinitiveNavigableRight()
-              || (!assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-              && !assoc1.getCDAssocDir().isDefinitiveNavigableRight());
+    if (side1.equals(AssocSide.LEFT)) {
+      return assoc1.getCDAssocDir().isDefinitiveNavigableLeft() || (!assoc1.getCDAssocDir()
+          .isDefinitiveNavigableLeft() && !assoc1.getCDAssocDir().isDefinitiveNavigableRight());
+    }
+    else {
+      return assoc1.getCDAssocDir().isDefinitiveNavigableRight() || (!assoc1.getCDAssocDir()
+          .isDefinitiveNavigableLeft() && !assoc1.getCDAssocDir().isDefinitiveNavigableRight());
     }
   }
-
+  
   /** helper-method to find types by full-name */
   protected ASTCDType findTypeByFullName(ASTCDAssociation node, String fullName) {
     

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
@@ -16,8 +16,7 @@ import java.util.*;
  * Checks that there are not multiple occurrences of the same association between types
  */
 public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
-  
-  /** @param node class to check. */
+
   @Override
   public void check(ASTCDDefinition node) {
     
@@ -71,18 +70,7 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
       }
     }
   }
-  
-  private static boolean isNavigable(ASTCDAssociation assoc1, AssocSide side1) {
-    if (side1.equals(AssocSide.LEFT)) {
-      return assoc1.getCDAssocDir().isDefinitiveNavigableLeft() || (!assoc1.getCDAssocDir()
-          .isDefinitiveNavigableLeft() && !assoc1.getCDAssocDir().isDefinitiveNavigableRight());
-    }
-    else {
-      return assoc1.getCDAssocDir().isDefinitiveNavigableRight() || (!assoc1.getCDAssocDir()
-          .isDefinitiveNavigableLeft() && !assoc1.getCDAssocDir().isDefinitiveNavigableRight());
-    }
-  }
-  
+
   /** helper-method to find types by full-name */
   protected ASTCDType findTypeByFullName(ASTCDAssociation node, String fullName) {
     
@@ -99,8 +87,14 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
   protected void checkRef(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1,
       ASTCDType type2) {
     if (type1.equals(type2)) {
-      Log.error(String.format("0xCDCE1: %s has duplicate associations at %s and %s.", type1
-          .getName(), assoc1.get_SourcePositionStart(), assoc2.get_SourcePositionStart()), assoc2
+      Log.error(String.format("0xCDCE1: %s has duplicate associations %s at %s and %s, "
+          + "i.e. 2 different associations with the same target role-name for a given source-type."
+              + "This may lead to conflicts in the generated code and is therefore not permitted "
+              + "for code generation purposes.",
+          type1
+          .getName(), assoc1.getPrintableName(), assoc1.get_SourcePositionStart(),
+              assoc2.get_SourcePositionStart()),
+          assoc2
               .get_SourcePositionStart());
     }
   }

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
@@ -35,60 +35,61 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
           
           // if they share a left role-name, the referenced types on the right should not be the
           // same
-          if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2,
-              AssocSide.LEFT)) && sharedNavigability(assoc1,assoc2,false)) {
-            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName().getQName()),
-                findTypeByFullName(assoc2, assoc2.getRightQualifiedName().getQName()));
+          if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2, AssocSide.LEFT))
+              && sharedNavigability(assoc1, assoc2, false)) {
+            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName()
+                .getQName()), findTypeByFullName(assoc2, assoc2.getRightQualifiedName()
+                    .getQName()));
           }
           
           // if they share a right role-name, the referenced types on the left should not be the
           // same
           if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2,
-              AssocSide.RIGHT)) && sharedNavigability(assoc1,assoc2,false)) {
-            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName().getQName()),
-                findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
+              AssocSide.RIGHT)) && sharedNavigability(assoc1, assoc2, false)) {
+            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName()
+                .getQName()), findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
           
           // We also consider a left-to-right role name match ...
-          if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2,
-              AssocSide.RIGHT)) && sharedNavigability(assoc1,assoc2,true)) {
-            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName().getQName()),
-                findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
+          if (deriveRoleName(assoc1, AssocSide.LEFT).equals(deriveRoleName(assoc2, AssocSide.RIGHT))
+              && sharedNavigability(assoc1, assoc2, true)) {
+            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getRightQualifiedName()
+                .getQName()), findTypeByFullName(assoc2, assoc2.getLeftQualifiedName().getQName()));
           }
           // ... as well as a right-to-left match
-          if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2,
-              AssocSide.LEFT)) && sharedNavigability(assoc1,assoc2,true)) {
-            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName().getQName()),
-                findTypeByFullName(assoc2, assoc2.getRightQualifiedName().getQName()));
+          if (deriveRoleName(assoc1, AssocSide.RIGHT).equals(deriveRoleName(assoc2, AssocSide.LEFT))
+              && sharedNavigability(assoc1, assoc2, true)) {
+            checkRef(assoc1, assoc2, findTypeByFullName(assoc1, assoc1.getLeftQualifiedName()
+                .getQName()), findTypeByFullName(assoc2, assoc2.getRightQualifiedName()
+                    .getQName()));
           }
         }
       }
     }
   }
-
+  
   private boolean sharedNavigability(ASTCDAssociation assoc1, ASTCDAssociation assoc2,
       boolean reverse) {
     if (reverse) {
-      return (assoc1.getCDAssocDir().isDefinitiveNavigableRight()
-          && assoc2.getCDAssocDir().isDefinitiveNavigableLeft())
-          || (assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-          && assoc2.getCDAssocDir().isDefinitiveNavigableRight())
-          || (!assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-          && !assoc1.getCDAssocDir().isDefinitiveNavigableRight())
-          || (!assoc2.getCDAssocDir().isDefinitiveNavigableLeft()
-          && !assoc2.getCDAssocDir().isDefinitiveNavigableRight());
-    } else {
-      return (assoc1.getCDAssocDir().isDefinitiveNavigableRight()
-            && assoc2.getCDAssocDir().isDefinitiveNavigableRight())
-          || (assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-            && assoc2.getCDAssocDir().isDefinitiveNavigableLeft())
-          || (!assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
-            && !assoc1.getCDAssocDir().isDefinitiveNavigableRight())
-          || (!assoc2.getCDAssocDir().isDefinitiveNavigableLeft()
-          && !assoc2.getCDAssocDir().isDefinitiveNavigableRight());
+      return (assoc1.getCDAssocDir().isDefinitiveNavigableRight() && assoc2.getCDAssocDir()
+          .isDefinitiveNavigableLeft()) || (assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+              && assoc2.getCDAssocDir().isDefinitiveNavigableRight()) || (!assoc1.getCDAssocDir()
+                  .isDefinitiveNavigableLeft() && !assoc1.getCDAssocDir()
+                      .isDefinitiveNavigableRight()) || (!assoc2.getCDAssocDir()
+                          .isDefinitiveNavigableLeft() && !assoc2.getCDAssocDir()
+                              .isDefinitiveNavigableRight());
+    }
+    else {
+      return (assoc1.getCDAssocDir().isDefinitiveNavigableRight() && assoc2.getCDAssocDir()
+          .isDefinitiveNavigableRight()) || (assoc1.getCDAssocDir().isDefinitiveNavigableLeft()
+              && assoc2.getCDAssocDir().isDefinitiveNavigableLeft()) || (!assoc1.getCDAssocDir()
+                  .isDefinitiveNavigableLeft() && !assoc1.getCDAssocDir()
+                      .isDefinitiveNavigableRight()) || (!assoc2.getCDAssocDir()
+                          .isDefinitiveNavigableLeft() && !assoc2.getCDAssocDir()
+                              .isDefinitiveNavigableRight());
     }
   }
-
+  
   /** helper-method to find types by full-name */
   protected ASTCDType findTypeByFullName(ASTCDAssociation node, String fullName) {
     
@@ -102,11 +103,12 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
   }
   
   /** Check if type2 is the same as type1. */
-  protected void checkRef(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1, ASTCDType type2) {
+  protected void checkRef(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1,
+      ASTCDType type2) {
     if (type1.equals(type2)) {
-      Log.error(String.format("0xCDCE1: %s has duplicate associations at %s and %s.",
-          type1.getName(), assoc1.get_SourcePositionStart(), assoc2.get_SourcePositionStart()),
-          assoc2.get_SourcePositionStart());
+      Log.error(String.format("0xCDCE1: %s has duplicate associations at %s and %s.", type1
+          .getName(), assoc1.get_SourcePositionStart(), assoc2.get_SourcePositionStart()), assoc2
+              .get_SourcePositionStart());
     }
   }
   

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUnique.java
@@ -16,7 +16,7 @@ import java.util.*;
  * Checks that there are not multiple occurrences of the same association between types
  */
 public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
-
+  
   @Override
   public void check(ASTCDDefinition node) {
     
@@ -70,7 +70,7 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
       }
     }
   }
-
+  
   /** helper-method to find types by full-name */
   protected ASTCDType findTypeByFullName(ASTCDAssociation node, String fullName) {
     
@@ -89,13 +89,10 @@ public class CDAssociationUnique implements CDBasisASTCDDefinitionCoCo {
     if (type1.equals(type2)) {
       Log.error(String.format("0xCDCE1: %s has duplicate associations %s at %s and %s, "
           + "i.e. 2 different associations with the same target role-name for a given source-type."
-              + "This may lead to conflicts in the generated code and is therefore not permitted "
-              + "for code generation purposes.",
-          type1
-          .getName(), assoc1.getPrintableName(), assoc1.get_SourcePositionStart(),
-              assoc2.get_SourcePositionStart()),
-          assoc2
-              .get_SourcePositionStart());
+          + "This may lead to conflicts in the generated code and is therefore not permitted "
+          + "for code generation purposes.", type1.getName(), assoc1.getPrintableName(), assoc1
+              .get_SourcePositionStart(), assoc2.get_SourcePositionStart()), assoc2
+                  .get_SourcePositionStart());
     }
   }
   

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUniqueInHierarchy.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUniqueInHierarchy.java
@@ -39,9 +39,9 @@ public class CDAssociationUniqueInHierarchy extends CDAssociationUnique {
       final TypeSymbol nextType = typesToVisit.pop();
       if (nextType.getFullName().equals(type2.getSymbol().getFullName())) {
         Log.error(String.format("0xCDCE6: %s redefines an association of %s from %s at %s."
-            + "Redefining associations are not supported by code generators.", type1
-            .getName(), type2.getName(), assoc2.get_SourcePositionStart(), assoc1
-                .get_SourcePositionStart()), assoc1.get_SourcePositionStart());
+            + "Redefining associations are not supported by code generators.", type1.getName(),
+            type2.getName(), assoc2.get_SourcePositionStart(), assoc1.get_SourcePositionStart()),
+            assoc1.get_SourcePositionStart());
         return;
       }
       

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUniqueInHierarchy.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUniqueInHierarchy.java
@@ -38,7 +38,8 @@ public class CDAssociationUniqueInHierarchy extends CDAssociationUnique {
     while (!typesToVisit.isEmpty()) {
       final TypeSymbol nextType = typesToVisit.pop();
       if (nextType.getFullName().equals(type2.getSymbol().getFullName())) {
-        Log.error(String.format("0xCDCE6: %s redefines an association of %s from %s at %s", type1
+        Log.error(String.format("0xCDCE6: %s redefines an association of %s from %s at %s."
+            + "Redefining associations are not supported by code generators.", type1
             .getName(), type2.getName(), assoc2.get_SourcePositionStart(), assoc1
                 .get_SourcePositionStart()), assoc1.get_SourcePositionStart());
         return;

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUniqueInHierarchy.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUniqueInHierarchy.java
@@ -2,7 +2,6 @@
 package de.monticore.cdgen.cocos;
 
 import de.monticore.cdassociation._ast.ASTCDAssociation;
-import de.monticore.cdbasis._ast.ASTCDDefinition;
 import de.monticore.cdbasis._ast.ASTCDType;
 import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
 import de.se_rwth.commons.logging.Log;
@@ -16,7 +15,8 @@ import java.util.*;
 public class CDAssociationUniqueInHierarchy extends CDAssociationUnique {
   
   @Override
-  protected void checkRef(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1, ASTCDType type2) {
+  protected void checkRef(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1,
+      ASTCDType type2) {
     super.checkRef(assoc1, assoc2, type1, type2);
     // We now also check if the types are in a sub/super-type relation
     checkSuper(assoc1, assoc2, type1, type2);
@@ -24,7 +24,8 @@ public class CDAssociationUniqueInHierarchy extends CDAssociationUnique {
   }
   
   /** Check if type2 is a super-type of type1. */
-  protected void checkSuper(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1, ASTCDType type2) {
+  protected void checkSuper(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1,
+      ASTCDType type2) {
     
     Stack<TypeSymbol> typesToVisit = new Stack<>();
     
@@ -37,10 +38,9 @@ public class CDAssociationUniqueInHierarchy extends CDAssociationUnique {
     while (!typesToVisit.isEmpty()) {
       final TypeSymbol nextType = typesToVisit.pop();
       if (nextType.getFullName().equals(type2.getSymbol().getFullName())) {
-        Log.error(String.format("0xCDCE6: %s redefines an association of %s from %s at %s",
-            type1.getName(), type2.getName(), assoc2.get_SourcePositionStart(),
-                assoc1.get_SourcePositionStart()),
-            assoc1.get_SourcePositionStart());
+        Log.error(String.format("0xCDCE6: %s redefines an association of %s from %s at %s", type1
+            .getName(), type2.getName(), assoc2.get_SourcePositionStart(), assoc1
+                .get_SourcePositionStart()), assoc1.get_SourcePositionStart());
         return;
       }
       

--- a/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUniqueInHierarchy.java
+++ b/cdlang/src/main/java/de/monticore/cdgen/cocos/CDAssociationUniqueInHierarchy.java
@@ -16,16 +16,15 @@ import java.util.*;
 public class CDAssociationUniqueInHierarchy extends CDAssociationUnique {
   
   @Override
-  protected void checkRef(ASTCDDefinition node, ASTCDType type1, ASTCDType type2,
-      ASTCDAssociation assoc1) {
-    super.checkRef(node, type1, type2, assoc1);
+  protected void checkRef(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1, ASTCDType type2) {
+    super.checkRef(assoc1, assoc2, type1, type2);
     // We now also check if the types are in a sub/super-type relation
-    checkSuper(type1, type2);
-    checkSuper(type2, type1);
+    checkSuper(assoc1, assoc2, type1, type2);
+    checkSuper(assoc2, assoc1, type2, type1);
   }
   
   /** Check if type2 is a super-type of type1. */
-  protected void checkSuper(ASTCDType type1, ASTCDType type2) {
+  protected void checkSuper(ASTCDAssociation assoc1, ASTCDAssociation assoc2, ASTCDType type1, ASTCDType type2) {
     
     Stack<TypeSymbol> typesToVisit = new Stack<>();
     
@@ -38,8 +37,10 @@ public class CDAssociationUniqueInHierarchy extends CDAssociationUnique {
     while (!typesToVisit.isEmpty()) {
       final TypeSymbol nextType = typesToVisit.pop();
       if (nextType.getFullName().equals(type2.getSymbol().getFullName())) {
-        Log.error(String.format("0xCDCE6: %s redefines an association of %s.", type1.getName(),
-            type2.getName()));
+        Log.error(String.format("0xCDCE6: %s redefines an association of %s from %s at %s",
+            type1.getName(), type2.getName(), assoc2.get_SourcePositionStart(),
+                assoc1.get_SourcePositionStart()),
+            assoc1.get_SourcePositionStart());
         return;
       }
       

--- a/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
@@ -55,6 +55,20 @@ public class CDAssociationUniqueTest extends AbstractJavaGenCoCoTest {
         + "  association assoc1 A -> B;" + "  association assoc2 A -> B;" + "}";
     runTest(model, false);
   }
+
+  @Test
+  public void testOnlyNavigable() throws IOException {
+    String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
+        + "  association A -> B;" + "  association A -> (r) B;" + "}";
+    runTest(model, false);
+  }
+
+  @Test
+  public void testOnlyNavigableReverse() throws IOException {
+    String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
+        + "  association A -> B;" + "  association B (r) <- A;" + "}";
+    runTest(model, false);
+  }
   
   @Test
   public void testOpposedAssocs() throws IOException {

--- a/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
@@ -55,35 +55,35 @@ public class CDAssociationUniqueTest extends AbstractJavaGenCoCoTest {
         + "  association assoc1 A -> B;" + "  association assoc2 A -> B;" + "}";
     runTest(model, false);
   }
-
+  
   @Test
   public void testOpposedAssocs() throws IOException {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
         + "  association A -> B;" + "  association A <- B;" + "}";
     runTest(model, false);
   }
-
+  
   @Test
   public void testOpposedAssocs2() throws IOException {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
         + "  association A -> B;" + "  association B -> A;" + "}";
     runTest(model, false);
   }
-
+  
   @Test
   public void testNonOpposedAssocs() throws IOException {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
         + "  association A -> B;" + "  association A <-> B;" + "}";
     runTestForErrorCode(model, ERROR_CODE);
   }
-
+  
   @Test
   public void testNonOpposedAssocs2() throws IOException {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
         + "  association A -> B;" + "  association A -- B;" + "}";
     runTestForErrorCode(model, ERROR_CODE);
   }
-
+  
   @Test
   public void testNonOpposedAssocs3() throws IOException {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"

--- a/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
@@ -94,7 +94,7 @@ public class CDAssociationUniqueTest extends AbstractJavaGenCoCoTest {
   @Test
   public void testNonOpposedAssocs2() throws IOException {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
-        + "  association A -> B;" + "  association A -- B;" + "}";
+        + "  association A -> B;" + "  association A <-> B;" + "}";
     runTestForErrorCode(model, ERROR_CODE);
   }
   
@@ -103,6 +103,13 @@ public class CDAssociationUniqueTest extends AbstractJavaGenCoCoTest {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
         + "  association A -> B;" + "  association B <- A;" + "}";
     runTestForErrorCode(model, ERROR_CODE);
+  }
+  
+  @Test
+  public void testNonOpposedAssocsUnspecified() throws IOException {
+    String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
+        + "  association A -> B;" + "  association A -- B;" + "}";
+    runTest(model, false);
   }
   
 }

--- a/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
@@ -55,14 +55,14 @@ public class CDAssociationUniqueTest extends AbstractJavaGenCoCoTest {
         + "  association assoc1 A -> B;" + "  association assoc2 A -> B;" + "}";
     runTest(model, false);
   }
-
+  
   @Test
   public void testOnlyNavigable() throws IOException {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
         + "  association A -> B;" + "  association A -> (r) B;" + "}";
     runTest(model, false);
   }
-
+  
   @Test
   public void testOnlyNavigableReverse() throws IOException {
     String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"

--- a/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
+++ b/cdlang/src/test/java/de/monticore/cdgen/cocos/CDAssociationUniqueTest.java
@@ -55,5 +55,40 @@ public class CDAssociationUniqueTest extends AbstractJavaGenCoCoTest {
         + "  association assoc1 A -> B;" + "  association assoc2 A -> B;" + "}";
     runTest(model, false);
   }
+
+  @Test
+  public void testOpposedAssocs() throws IOException {
+    String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
+        + "  association A -> B;" + "  association A <- B;" + "}";
+    runTest(model, false);
+  }
+
+  @Test
+  public void testOpposedAssocs2() throws IOException {
+    String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
+        + "  association A -> B;" + "  association B -> A;" + "}";
+    runTest(model, false);
+  }
+
+  @Test
+  public void testNonOpposedAssocs() throws IOException {
+    String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
+        + "  association A -> B;" + "  association A <-> B;" + "}";
+    runTestForErrorCode(model, ERROR_CODE);
+  }
+
+  @Test
+  public void testNonOpposedAssocs2() throws IOException {
+    String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
+        + "  association A -> B;" + "  association A -- B;" + "}";
+    runTestForErrorCode(model, ERROR_CODE);
+  }
+
+  @Test
+  public void testNonOpposedAssocs3() throws IOException {
+    String model = "classdiagram DuplicateAssocs {" + "  class A; class B;"
+        + "  association A -> B;" + "  association B <- A;" + "}";
+    runTestForErrorCode(model, ERROR_CODE);
+  }
   
 }


### PR DESCRIPTION
- `CDUniqueAssociation` now allows "duplicate" associations with explicitly opposing navigation directions: e.g., A -> B, A <- B.
- `CDUniqueAssociation`  and `CDUniqueAssociationInHierarchy` output SourcePosition of the associations 