### PR TITLE
Propagate CDAssociation modifiers to the respective role symbols

### DIFF
--- a/cdlang/src/main/java/de/monticore/cdassociation/_symboltable/CDAssociationSymbolTableCompleter.java
+++ b/cdlang/src/main/java/de/monticore/cdassociation/_symboltable/CDAssociationSymbolTableCompleter.java
@@ -55,7 +55,7 @@ public class CDAssociationSymbolTableCompleter implements CDAssociationVisitor2,
     }
     symbol.setType(typeResult.get());
     
-    setupModifiers(side.getModifier(), symbol);
+    setupModifiers(side.getModifier(), ast.getModifier(), symbol);
     
     symbol.setIsDefinitiveNavigable(isLeft ? ast.getCDAssocDir().isDefinitiveNavigableLeft() : ast
         .getCDAssocDir().isDefinitiveNavigableRight());
@@ -144,13 +144,13 @@ public class CDAssociationSymbolTableCompleter implements CDAssociationVisitor2,
     }
   }
   
-  public void setupModifiers(ASTModifier modifier, CDRoleSymbol roleSymbol) {
-    roleSymbol.setIsPublic(modifier.isPublic());
-    roleSymbol.setIsPrivate(modifier.isPrivate());
-    roleSymbol.setIsProtected(modifier.isProtected());
-    roleSymbol.setIsStatic(modifier.isStatic());
-    roleSymbol.setIsFinal(modifier.isFinal());
-    roleSymbol.setIsDerived(modifier.isDerived());
+  public void setupModifiers(ASTModifier assocSideModifier, ASTModifier assocModifier, CDRoleSymbol roleSymbol) {
+    roleSymbol.setIsPublic(assocSideModifier.isPublic());
+    roleSymbol.setIsPrivate(assocSideModifier.isPrivate());
+    roleSymbol.setIsProtected(assocSideModifier.isProtected());
+    roleSymbol.setIsStatic(assocSideModifier.isStatic());
+    roleSymbol.setIsFinal(assocSideModifier.isFinal());
+    roleSymbol.setIsDerived(assocSideModifier.isDerived() || assocModifier.isDerived());
   }
   
   public static void addRoleToTheirType(CDRoleSymbol symbol, TypeSymbol otherType) {

--- a/cdlang/src/main/java/de/monticore/cdassociation/_symboltable/CDAssociationSymbolTableCompleter.java
+++ b/cdlang/src/main/java/de/monticore/cdassociation/_symboltable/CDAssociationSymbolTableCompleter.java
@@ -146,11 +146,11 @@ public class CDAssociationSymbolTableCompleter implements CDAssociationVisitor2,
   
   public void setupModifiers(ASTModifier assocSideModifier, ASTModifier assocModifier,
       CDRoleSymbol roleSymbol) {
-    roleSymbol.setIsPublic(assocSideModifier.isPublic());
-    roleSymbol.setIsPrivate(assocSideModifier.isPrivate());
-    roleSymbol.setIsProtected(assocSideModifier.isProtected());
-    roleSymbol.setIsStatic(assocSideModifier.isStatic());
-    roleSymbol.setIsFinal(assocSideModifier.isFinal());
+    roleSymbol.setIsPublic(assocSideModifier.isPublic() || assocModifier.isPublic());
+    roleSymbol.setIsPrivate(assocSideModifier.isPrivate() || assocModifier.isPrivate());
+    roleSymbol.setIsProtected(assocSideModifier.isProtected() || assocModifier.isProtected());
+    roleSymbol.setIsStatic(assocSideModifier.isStatic() || assocModifier.isStatic());
+    roleSymbol.setIsFinal(assocSideModifier.isFinal() || assocModifier.isFinal());
     roleSymbol.setIsDerived(assocSideModifier.isDerived() || assocModifier.isDerived());
   }
   

--- a/cdlang/src/main/java/de/monticore/cdassociation/_symboltable/CDAssociationSymbolTableCompleter.java
+++ b/cdlang/src/main/java/de/monticore/cdassociation/_symboltable/CDAssociationSymbolTableCompleter.java
@@ -144,7 +144,8 @@ public class CDAssociationSymbolTableCompleter implements CDAssociationVisitor2,
     }
   }
   
-  public void setupModifiers(ASTModifier assocSideModifier, ASTModifier assocModifier, CDRoleSymbol roleSymbol) {
+  public void setupModifiers(ASTModifier assocSideModifier, ASTModifier assocModifier,
+      CDRoleSymbol roleSymbol) {
     roleSymbol.setIsPublic(assocSideModifier.isPublic());
     roleSymbol.setIsPrivate(assocSideModifier.isPrivate());
     roleSymbol.setIsProtected(assocSideModifier.isProtected());


### PR DESCRIPTION
There are three possible locations to define modifiers in CDAssociations.
However, the Association symbol does not store them.
In fact, the first association modifier seems to be redundant and might even introduce inconsistencies.
With this Pull Request, we propagate the association modifiers to the role symbols.
As a result, the first modifiers becomes a short notation for setting the same modifiers for both roles.
In a second step, we will introduce CoCos to prevent using the first modifier and any of the other two in parallel.