### PR TITLE
Fix AddAttributeTest

### DIFF
--- a/cdlang/src/test/javatrafo/de/monticore/trafo/AddAttributeTest.java
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/AddAttributeTest.java
@@ -1,43 +1,1 @@
-/* (c) https://github.com/MontiCore/monticore */
-package de.monticore.trafo;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import de.monticore.cd4code.CD4CodeMill;
-import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
-import de.monticore.literals.mccommonliterals.MCCommonLiteralsMill;
-import de.monticore.tf.AddAttribute;
-import java.io.IOException;
-import java.util.Optional;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-public class AddAttributeTest {
-  
-  @BeforeAll
-  public static void init() {
-    CD4CodeMill.reset();
-    CD4CodeMill.init();
-  }
-  
-  @Test
-  public void testAddAttr() throws IOException {
-    String input = "src/test/resources/de/monticore/trafo/MoveAttrAB.cd";
-    Optional<ASTCDCompilationUnit> ast = CD4CodeMill.parser().parse(input);
-    
-    assertTrue(ast.isPresent());
-    
-    AddAttribute addAttribute = new AddAttribute(ast.get());
-    assertTrue(addAttribute.doPatternMatching());
-    
-    addAttribute.doReplacement();
-    
-    assertEquals("boolean", ast.get().getCDDefinition().getCDClassesList().get(0)
-        .getCDAttributeList().get(1).getMCType().printType());
-    String pp = MCCommonLiteralsMill.prettyPrint(ast.get().getCDDefinition().getCDClassesList().get(
-        0).getCDAttributeList().get(1).getInitial(), true);
-    assertEquals("true", pp);
-  }
-  
-}
+/* (c) https://github.com/MontiCore/monticore */package de.monticore.trafo;import static org.junit.jupiter.api.Assertions.assertEquals;import static org.junit.jupiter.api.Assertions.assertTrue;import de.monticore.cd4code.CD4CodeMill;import de.monticore.cdbasis._ast.ASTCDCompilationUnit;import de.monticore.literals.mccommonliterals.MCCommonLiteralsMill;import de.monticore.tf.AddAttribute;import java.io.IOException;import java.util.Optional;import org.junit.jupiter.api.BeforeAll;import org.junit.jupiter.api.Test;public class AddAttributeTest {    @BeforeAll  public static void init() {    CD4CodeMill.reset();    CD4CodeMill.init();  }    @Test  public void testAddAttr() throws IOException {    String input = "src/test/resources/de/monticore/trafo/MoveAttrAB.cd";    Optional<ASTCDCompilationUnit> ast = CD4CodeMill.parser().parse(input);        assertTrue(ast.isPresent());        AddAttribute addAttribute = new AddAttribute(ast.get());    assertTrue(addAttribute.doPatternMatching());        addAttribute.doReplacement();        assertEquals("boolean", ast.get().getCDDefinition().getCDClassesList().get(0)        .getCDAttributeList().get(1).getMCType().printType());    String pp = MCCommonLiteralsMill.prettyPrint(ast.get().getCDDefinition().getCDClassesList().get(        0).getCDAttributeList().get(1).getInitial(), true);    assertEquals("true", pp.strip());  }  }

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/AddAttributeTest.java
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/AddAttributeTest.java
@@ -1,1 +1,45 @@
-/* (c) https://github.com/MontiCore/monticore */package de.monticore.trafo;import static org.junit.jupiter.api.Assertions.assertEquals;import static org.junit.jupiter.api.Assertions.assertTrue;import de.monticore.cd4code.CD4CodeMill;import de.monticore.cdbasis._ast.ASTCDCompilationUnit;import de.monticore.literals.mccommonliterals.MCCommonLiteralsMill;import de.monticore.tf.AddAttribute;import java.io.IOException;import java.util.Optional;import org.junit.jupiter.api.BeforeAll;import org.junit.jupiter.api.Test;public class AddAttributeTest {    @BeforeAll  public static void init() {    CD4CodeMill.reset();    CD4CodeMill.init();  }    @Test  public void testAddAttr() throws IOException {    String input = "src/test/resources/de/monticore/trafo/MoveAttrAB.cd";    Optional<ASTCDCompilationUnit> ast = CD4CodeMill.parser().parse(input);        assertTrue(ast.isPresent());        AddAttribute addAttribute = new AddAttribute(ast.get());    assertTrue(addAttribute.doPatternMatching());        addAttribute.doReplacement();        assertEquals("boolean", ast.get().getCDDefinition().getCDClassesList().get(0)        .getCDAttributeList().get(1).getMCType().printType());    String pp = MCCommonLiteralsMill.prettyPrint(ast.get().getCDDefinition().getCDClassesList().get(        0).getCDAttributeList().get(1).getInitial(), true);    assertEquals("true", pp.strip());  }  }
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.trafo;
+
+import de.monticore.cd4code.CD4CodeMill;
+import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
+import de.monticore.literals.mccommonliterals.MCCommonLiteralsMill;
+import de.monticore.tf.AddAttribute;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AddAttributeTest {
+  
+  @BeforeAll
+  public static void init() {
+    CD4CodeMill.reset();
+    CD4CodeMill.init();
+  }
+  
+  @Test
+  public void testAddAttr() throws IOException {
+    String input = "src/test/resources/de/monticore/trafo/MoveAttrAB.cd";
+    Optional<ASTCDCompilationUnit> ast = CD4CodeMill.parser().parse(input);
+    
+    assertTrue(ast.isPresent());
+    
+    AddAttribute addAttribute = new AddAttribute(ast.get());
+    assertTrue(addAttribute.doPatternMatching());
+    
+    addAttribute.doReplacement();
+    
+    assertEquals("boolean",
+        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().get(1)
+            .getMCType().printType());
+    String pp = MCCommonLiteralsMill.prettyPrint(
+        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().get(1)
+            .getInitial(), true);
+    assertEquals("true", pp.strip());
+  }
+}

--- a/cdlang/src/test/javatrafo/de/monticore/trafo/AddAttributeTest.java
+++ b/cdlang/src/test/javatrafo/de/monticore/trafo/AddAttributeTest.java
@@ -34,12 +34,11 @@ public class AddAttributeTest {
     
     addAttribute.doReplacement();
     
-    assertEquals("boolean",
-        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().get(1)
-            .getMCType().printType());
-    String pp = MCCommonLiteralsMill.prettyPrint(
-        ast.get().getCDDefinition().getCDClassesList().get(0).getCDAttributeList().get(1)
-            .getInitial(), true);
+    assertEquals("boolean", ast.get().getCDDefinition().getCDClassesList().get(0)
+        .getCDAttributeList().get(1).getMCType().printType());
+    String pp = MCCommonLiteralsMill.prettyPrint(ast.get().getCDDefinition().getCDClassesList().get(
+        0).getCDAttributeList().get(1).getInitial(), true);
     assertEquals("true", pp.strip());
   }
+  
 }


### PR DESCRIPTION
Switching to the ModelAccessor and incremental indices adds the parent comments instantly instead of appending them after potential pattern matching.
Consequently, the pretty printer adds extra newlines, causing the previous assertion to fail.